### PR TITLE
[codex] Add self-hosted runner fallback to workflows

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -30,60 +30,8 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
-  select-runner:
-    name: Select runner
-    runs-on: ubuntu-latest
-    outputs:
-      runner_labels: ${{ steps.select.outputs.runner_labels }}
-    steps:
-      - name: Prefer idle self-hosted runner
-        id: select
-        uses: actions/github-script@v9
-        with:
-          github-token: ${{ secrets.RUNNER_SELECTOR_TOKEN || github.token }}
-          script: |
-            const selfHostedLabels = JSON.parse(process.env.SELF_HOSTED_RUNNER_LABELS)
-            const fallbackRunner = process.env.FALLBACK_RUNNER_LABEL
-            let selectedRunnerJson = JSON.stringify(fallbackRunner)
-
-            try {
-              const runners = await github.paginate(
-                github.rest.actions.listSelfHostedRunnersForRepo,
-                {
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  per_page: 100,
-                }
-              )
-
-              const hasMatchingIdleRunner = runners.some((runner) => {
-                const labels = new Set((runner.labels || []).map((label) => label.name))
-                return (
-                  runner.status === "online" &&
-                  runner.busy === false &&
-                  selfHostedLabels.every((label) => labels.has(label))
-                )
-              })
-
-              if (hasMatchingIdleRunner) {
-                selectedRunnerJson = JSON.stringify(selfHostedLabels)
-                core.info(`Selected self-hosted runner labels ${selfHostedLabels.join(", ")}.`)
-              } else {
-                core.info(
-                  `No idle self-hosted runner with labels ${selfHostedLabels.join(", ")} was found; falling back to ${fallbackRunner}.`
-                )
-              }
-            } catch (error) {
-              core.warning(
-                `Could not inspect self-hosted runners; falling back to ${fallbackRunner}. ${error.message}`
-              )
-            }
-
-            core.setOutput("runner_labels", selectedRunnerJson)
-
   publish:
-    needs: select-runner
-    runs-on: ${{ fromJSON(needs.select-runner.outputs.runner_labels) }}
+    runs-on: ubuntu-latest
     environment: production
     steps:
       - name: Checkout

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -19,16 +19,71 @@ on:
         type: string
 
 permissions:
+  actions: read
   contents: write
   id-token: write # for npm provenance (requires Node 18+ and npm >=9)
   attestations: write
 
 env:
+  FALLBACK_RUNNER_LABEL: ubuntu-latest
+  SELF_HOSTED_RUNNER_LABELS: '["self-hosted","Linux","X64"]'
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
-  publish:
+  select-runner:
+    name: Select runner
     runs-on: ubuntu-latest
+    outputs:
+      runner_labels: ${{ steps.select.outputs.runner_labels }}
+    steps:
+      - name: Prefer idle self-hosted runner
+        id: select
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.RUNNER_SELECTOR_TOKEN || github.token }}
+          script: |
+            const selfHostedLabels = JSON.parse(process.env.SELF_HOSTED_RUNNER_LABELS)
+            const fallbackRunner = process.env.FALLBACK_RUNNER_LABEL
+            let selectedRunnerJson = JSON.stringify(fallbackRunner)
+
+            try {
+              const runners = await github.paginate(
+                github.rest.actions.listSelfHostedRunnersForRepo,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  per_page: 100,
+                }
+              )
+
+              const hasMatchingIdleRunner = runners.some((runner) => {
+                const labels = new Set((runner.labels || []).map((label) => label.name))
+                return (
+                  runner.status === "online" &&
+                  runner.busy === false &&
+                  selfHostedLabels.every((label) => labels.has(label))
+                )
+              })
+
+              if (hasMatchingIdleRunner) {
+                selectedRunnerJson = JSON.stringify(selfHostedLabels)
+                core.info(`Selected self-hosted runner labels ${selfHostedLabels.join(", ")}.`)
+              } else {
+                core.info(
+                  `No idle self-hosted runner with labels ${selfHostedLabels.join(", ")} was found; falling back to ${fallbackRunner}.`
+                )
+              }
+            } catch (error) {
+              core.warning(
+                `Could not inspect self-hosted runners; falling back to ${fallbackRunner}. ${error.message}`
+              )
+            }
+
+            core.setOutput("runner_labels", selectedRunnerJson)
+
+  publish:
+    needs: select-runner
+    runs-on: ${{ fromJSON(needs.select-runner.outputs.runner_labels) }}
     environment: production
     steps:
       - name: Checkout
@@ -86,7 +141,7 @@ jobs:
 
           echo "New version: $NEW_VER"
           git push --follow-tags
-          
+
           # Expose tag (vX.Y.Z) and version (X.Y.Z) for later steps
           VER_NO_V=${NEW_VER#v}
           echo "tag=$NEW_VER" >> "$GITHUB_OUTPUT"
@@ -99,13 +154,13 @@ jobs:
           else
             echo "flags=--access public" >> "$GITHUB_OUTPUT"
           fi
-          
+
       - name: Install deps (CI)
         run: npm ci
 
       - name: Test (coverage)
         run: npm run test:coverage
-        
+
       - name: Install Codecov CLI
         run: python3 -m pip install --upgrade codecov-cli
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
       - name: Prefer idle self-hosted runner
         id: select
         uses: actions/github-script@v9
+        env:
+          RUNNER_SELECTOR_TOKEN_AVAILABLE: ${{ secrets.RUNNER_SELECTOR_TOKEN != '' }}
         with:
           github-token: ${{ secrets.RUNNER_SELECTOR_TOKEN || github.token }}
           script: |
@@ -34,6 +36,12 @@ jobs:
 
             if (context.eventName === "pull_request") {
               core.info(`Pull request CI always uses ${fallbackRunner}.`)
+              core.setOutput("runner_labels", selectedRunnerJson)
+              return
+            }
+
+            if (process.env.RUNNER_SELECTOR_TOKEN_AVAILABLE !== "true") {
+              core.info("RUNNER_SELECTOR_TOKEN is not configured; using the hosted fallback runner.")
               core.setOutput("runner_labels", selectedRunnerJson)
               return
             }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,70 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  actions: read
+  contents: read
+
 env:
+  FALLBACK_RUNNER_LABEL: ubuntu-latest
+  SELF_HOSTED_RUNNER_LABELS: '["self-hosted","Linux","X64"]'
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
-  build-test:
+  select-runner:
+    name: Select runner
     runs-on: ubuntu-latest
+    outputs:
+      runner_labels: ${{ steps.select.outputs.runner_labels }}
+    steps:
+      - name: Prefer idle self-hosted runner
+        id: select
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.RUNNER_SELECTOR_TOKEN || github.token }}
+          script: |
+            const selfHostedLabels = JSON.parse(process.env.SELF_HOSTED_RUNNER_LABELS)
+            const fallbackRunner = process.env.FALLBACK_RUNNER_LABEL
+            let selectedRunnerJson = JSON.stringify(fallbackRunner)
+
+            try {
+              const runners = await github.paginate(
+                github.rest.actions.listSelfHostedRunnersForRepo,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  per_page: 100,
+                }
+              )
+
+              const hasMatchingIdleRunner = runners.some((runner) => {
+                const labels = new Set((runner.labels || []).map((label) => label.name))
+                return (
+                  runner.status === "online" &&
+                  runner.busy === false &&
+                  selfHostedLabels.every((label) => labels.has(label))
+                )
+              })
+
+              if (hasMatchingIdleRunner) {
+                selectedRunnerJson = JSON.stringify(selfHostedLabels)
+                core.info(`Selected self-hosted runner labels ${selfHostedLabels.join(", ")}.`)
+              } else {
+                core.info(
+                  `No idle self-hosted runner with labels ${selfHostedLabels.join(", ")} was found; falling back to ${fallbackRunner}.`
+                )
+              }
+            } catch (error) {
+              core.warning(
+                `Could not inspect self-hosted runners; falling back to ${fallbackRunner}. ${error.message}`
+              )
+            }
+
+            core.setOutput("runner_labels", selectedRunnerJson)
+
+  build-test:
+    needs: select-runner
+    runs-on: ${{ fromJSON(needs.select-runner.outputs.runner_labels) }}
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,12 @@ jobs:
             const fallbackRunner = process.env.FALLBACK_RUNNER_LABEL
             let selectedRunnerJson = JSON.stringify(fallbackRunner)
 
+            if (context.eventName === "pull_request") {
+              core.info(`Pull request CI always uses ${fallbackRunner}.`)
+              core.setOutput("runner_labels", selectedRunnerJson)
+              return
+            }
+
             try {
               const runners = await github.paginate(
                 github.rest.actions.listSelfHostedRunnersForRepo,


### PR DESCRIPTION
## Summary

- Add a runner selector job to CI/CD workflows.
- Prefer an idle self-hosted runner with labels `self-hosted`, `Linux`, and `X64`.
- Fall back to `ubuntu-latest` when a matching runner is unavailable or runner inspection fails.

## Validation

- `github-actionlint` on the changed workflows.
- `git diff --check` for workflow whitespace/conflict checks.
