### PR TITLE
[codex] add WebGPU wavefront mesh renderer

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -82,6 +82,9 @@ jobs:
           if [ "${BUMP}" = "none" ]; then
             CURRENT_VER=$(node -p "require('./package.json').version")
             NEW_VER="v${CURRENT_VER}"
+            if ! git rev-parse -q --verify "refs/tags/${NEW_VER}" >/dev/null; then
+              git tag -a "${NEW_VER}" -m "chore: release ${NEW_VER} [skip ci]"
+            fi
           else
             # shellcheck disable=SC2086
             NEW_VER=$(sh -lc "$BUMP_CMD")

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ dist
 coverage
 playwright-report
 test-results
+.npm-cache-packcheck
 
 # Private key material in cert directories (never commit)
 **/certs/**/*-key.pem

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,64 @@ All notable changes to this project will be documented in this file.
 - **Added**
   - Added wavefront path-tracing queue/buffer contracts and bounce-schedule
     metadata beneath `createRayTracingRenderPlan(...)`.
+  - Added a tiled WebGPU wavefront compute renderer with scene-object buffers,
+    GPU ray queues, hit records, material continuation, emissive/environment
+    termination, ambient residual expiry, denoise resolve, and presentation.
+  - Added triangle mesh normalization, GPU-source mesh packing, triangle/BVH
+    buffer contracts, and display-quality guards requiring mesh BVH input.
+  - Added GPU mesh-source buffer packing and GPU build-pass entry points for
+    triangle assembly, GPU Morton leaf sorting, sorted leaf materialization,
+    and deterministic, level-concurrent BVH node construction.
+  - Added public BVH sort-stage and build-level scheduling metadata for worker/queue
+    integration.
+  - Expanded GPU hit records with primitive id, material reference, medium
+    reference, barycentric coordinates, and UV coordinates.
+  - Added mesh BVH tests for flat normals, smooth normals, stable triangle
+    identity, leaf splitting, and GPU record layout stability.
+  - Added public scene-object packing/config helpers for Product Studio and
+    other package consumers.
+  - Updated the browser demo to mount the wavefront compute renderer directly
+    and consume a `@plasius/gpu-lighting` environment preset.
+  - Added `samplesPerPixel` support for GPU wavefront renders so quality
+    presets can accumulate multiple primary-ray samples without increasing
+    tile-queue buffer size.
+  - Added a two-stage full-frame GPU denoise pass that filters linear
+    `rgba16float` radiance through a scratch texture after all tiles complete,
+    then tone-maps into the final `rgba8unorm` output while avoiding tile-local
+    denoise artifacts.
+  - Added GPU emissive-triangle continuation guidance stored in the BVH buffer
+    tail so active diffuse rays sample finite mesh light geometry more often
+    without adding a ninth trace storage buffer or separate direct-light/shadow
+    accumulation path.
 
 - **Changed**
-  - (placeholder)
+  - Wavefront environment misses now evaluate a direction-aware sky/key-light
+    environment payload instead of only using a flat environment colour.
+  - Display-quality wavefront configuration now uses GPU-built mesh
+    acceleration; CPU-built mesh acceleration is treated as debug-only.
+  - Replaced the one-thread BVH internal-node build kernel with bottom-up
+    level dispatches so parent nodes at the same depth build concurrently on
+    the GPU.
+  - Reordered mesh BVH leaves on the GPU by Morton-style centroid keys before
+    internal node construction, avoiding author/index-order BVH layout as the
+    display-quality baseline.
+  - Removed the direct `@plasius/gpu-shared` dependency from the renderer to
+    keep shared demo adapters dependent on the renderer rather than the reverse.
+  - Wavefront surface resolution now removes the separate direct key-light
+    accumulation term, clamps high-energy path samples in linear radiance, and
+    applies a bounded estimator weight to guided emissive hits while relying on
+    active emissive/environment path hits plus ambient residual expiry for
+    preview output.
+  - Wavefront primary-ray jitter and bounce sampling now use mixed
+    pixel/sample/bounce/frame seeds to reduce row-correlated low-sample noise.
 
 - **Fixed**
-  - (placeholder)
+  - Fixed primary-ray jitter seeding to use absolute screen pixel ids instead
+    of tile-local pixel ids, preventing repeated sampling patterns across
+    tiles.
+  - Fixed the WebGPU hit-buffer stride to match the WGSL `HitRecord` layout
+    and added a continuation-queue capacity guard, preventing tile-row
+    corruption in mesh BVH wavefront renders.
 
 - **Security**
   - (placeholder)

--- a/README.md
+++ b/README.md
@@ -106,6 +106,104 @@ performance packages. It now also exposes the renderer-owned wavefront queue
 model, versioned ray/hit/surface/material/medium/accumulation contracts, and
 the termination policy for emissive/environment path completion.
 
+## WebGPU Wavefront Compute Renderer
+
+The package also exposes an executable WebGPU wavefront renderer for active-ray
+debug validation scenes. It is compute-driven, tiled, and breadth-first by
+bounce depth, so queue buffers are bounded by tile size instead of presentation
+resolution. Renderer-owned GPU record sizes are part of the public compute
+limits so ray, hit, triangle, BVH, and accumulation buffers stay aligned with
+their WGSL layouts.
+
+```js
+import {
+  createWavefrontPathTracingComputeRenderer,
+} from "@plasius/gpu-renderer";
+
+const renderer = await createWavefrontPathTracingComputeRenderer({
+  canvas: document.querySelector("#product-render"),
+  width: 1280,
+  height: 720,
+  maxDepth: 6,
+  samplesPerPixel: 8,
+  displayQuality: true,
+  meshes: [
+    {
+      id: 1,
+      positions: [-1, -1, 0, 1, -1, 0, 0, 1, 0],
+      indices: [0, 1, 2],
+      normals: [0, 0, 1, 0, 0, 1, 0, 0, 1],
+      emission: [8, 7, 5, 1],
+    },
+  ],
+});
+
+renderer.renderOnce();
+```
+
+Analytic scene objects remain available for debug fixtures:
+
+```js
+const debugRenderer = await createWavefrontPathTracingComputeRenderer({
+  canvas: document.querySelector("#debug-render"),
+  width: 1280,
+  height: 720,
+  maxDepth: 6,
+  sceneObjects: [
+    {
+      type: "sphere",
+      center: [0, 1.8, -0.5],
+      radius: 0.35,
+      emission: [8, 7, 5, 1],
+      materialKind: "emissive",
+    },
+  ],
+});
+
+debugRenderer.renderOnce();
+```
+
+Scene objects currently support analytic `sphere` and axis-aligned `box`
+records with colour, emission, roughness, metallic, opacity, and IOR fields.
+These records are debug fixtures only. Product Studio visual rendering requires
+the mesh BVH path described in
+`docs/adrs/adr-0007-triangle-mesh-wavefront-path-tracing.md`. This is a
+project-wide display-quality baseline for path-traced rendering, not a
+Product-Studio-only requirement.
+
+Mesh inputs are normalized into triangle records, packed into GPU buffers, and
+uploaded as source buffers for GPU triangle assembly and GPU BVH construction.
+Vertex normals are preserved for smooth shading; when normals are absent the
+triangle geometric normal is used. The display-quality path uses
+`accelerationBuildMode: "gpu"` and rejects CPU-built acceleration. The
+`createWavefrontMeshAcceleration(...)` helper remains available only for debug
+fixtures and deterministic layout tests. GPU BVH construction now uses
+Morton-style centroid keys to sort leaf references before sorted leaves and
+level-concurrent internal nodes are materialized. The current mesh path is the
+GPU runtime baseline under active hardening.
+
+`samplesPerPixel` controls how many GPU primary-ray samples are accumulated per
+screen pixel within a single render. This multiplies dispatch work but does not
+increase the tile queue memory footprint, so 720p/1080p/4K targets remain
+bounded by `tileSize`. When `denoise` is enabled the renderer writes raw
+linear radiance to an `rgba16float` texture first, then runs a two-stage
+full-frame GPU denoise through an `rgba16float` scratch texture before final
+tone mapping into the presented `rgba8unorm` output. Filtering in linear
+radiance space lets the denoise pass cross tile boundaries without compressing
+energy/detail before the final resolve. The renderer also stores compact
+emissive-triangle metadata in the existing BVH buffer tail and uses it to guide
+diffuse continuation rays toward finite mesh light geometry without adding a
+ninth trace storage buffer. This is not a separate shadow/direct-light pass: the
+active ray still has to hit emissive geometry or miss into the environment
+before radiance is accumulated. Guided emissive hits carry a bounded estimator
+weight so finite light guidance does not over-expose low-sample renders before
+full material PDFs/MIS are implemented. High-energy samples are clamped in
+linear radiance space to keep low-sample preview output stable while production
+sampling, temporal accumulation, and better material PDFs are hardened.
+Texture sampling, dynamic TLAS updates, higher-grade LBVH/SAH construction,
+runtime execution behind the `@plasius/gpu-worker` lock-free queue, and broader
+material lookup remain follow-up work.
+
 ## XR integration
 
 ```js
@@ -129,6 +227,17 @@ renderer.bindXrManager(xr, {
 - `getRendererWorkerProfile(name?)`
 - `getRendererWorkerManifest(name?)`
 - `createRayTracingRenderPlan(options)`
+- `createWavefrontPathTracingComputeRenderer(options)`
+- `createWavefrontPathTracingComputeConfig(options)`
+- `normalizeWavefrontMesh(input)`
+- `createWavefrontGpuMeshSource(meshes)`
+- `createWavefrontBvhSortStages(itemCount)`
+- `createWavefrontBvhBuildLevels(triangleCount)`
+- `createWavefrontMeshAcceleration(meshes)`
+- `normalizeWavefrontSceneObject(input)`
+- `packWavefrontSceneObjects(sceneObjects, capacity?)`
+- `packWavefrontTriangles(triangles, capacity?)`
+- `packWavefrontBvhNodes(nodes, capacity?)`
 - `bindRendererToXrManager(renderer, xrManager, options)`
 - `defaultRendererClearColor`
 - `rendererDebugOwner`
@@ -149,8 +258,11 @@ npm run demo
 
 Then open `http://localhost:8000/gpu-renderer/demo/`.
 
-The demo now reports explicit canvas state so it is clear whether the renderer
-is mounted, idle, running, or blocked by secure-context / WebGPU support.
+The demo now mounts the mesh BVH WebGPU wavefront renderer directly and passes a
+`@plasius/gpu-lighting` environment preset into the render. It reports the
+active wavefront depth, tile count, triangle/BVH counts, lighting preset, probe
+luminance, and hot buffer memory so it is clear whether the renderer is tracing
+mesh paths rather than only showing planning metadata.
 
 ## Development Checks
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -7,6 +7,6 @@
   </head>
   <body>
     <div id="app"></div>
-    <script type="module" src="./main.js"></script>
+    <script type="module" src="./main.js?v=mesh-bvh-2"></script>
   </body>
 </html>

--- a/demo/main.js
+++ b/demo/main.js
@@ -1,255 +1,422 @@
 import {
-  createGpuRenderer,
   createRayTracingRenderPlan,
-  createRendererDebugHooks,
-  defaultRendererWorkerProfile,
-  getRendererWorkerManifest,
-  getRendererWorkerProfile,
-  supportsWebGpu,
+  createWavefrontPathTracingComputeRenderer,
+  supportsWavefrontPathTracingCompute,
 } from "../dist/index.js";
-import { mountGpuShowcase } from "../node_modules/@plasius/gpu-shared/dist/index.js";
+import {
+  createWavefrontEnvironmentLightingOptions,
+} from "../../gpu-lighting/src/index.js";
 
 const root = globalThis.document?.getElementById("app");
 if (!root) {
   throw new Error("Renderer demo root element was not found.");
 }
 
-function createFrameRecorder() {
-  const samples = [];
-  let totalFrameTimeMs = 0;
-  let droppedCount = 0;
+const lightingOptions = createWavefrontEnvironmentLightingOptions({
+  preset: "moonlit-harbor",
+  intensity: 1.08,
+});
+const renderPlan = createRayTracingRenderPlan({
+  snapshotId: "wavefront-demo-mesh-bvh-lighting-owned-environment",
+  wavefront: {
+    maxDepth: 6,
+    queueCapacity: 128 * 128,
+  },
+});
+
+function createQuadMesh({ id, corners, color, emission, materialKind = "diffuse" }) {
+  const [a, b, c, d] = corners;
+  const edge1 = [b[0] - a[0], b[1] - a[1], b[2] - a[2]];
+  const edge2 = [c[0] - a[0], c[1] - a[1], c[2] - a[2]];
+  const normal = [
+    edge1[1] * edge2[2] - edge1[2] * edge2[1],
+    edge1[2] * edge2[0] - edge1[0] * edge2[2],
+    edge1[0] * edge2[1] - edge1[1] * edge2[0],
+  ];
+  const length = Math.hypot(...normal) || 1;
+  const unitNormal = normal.map((value) => value / length);
 
   return {
-    recordFrame(sample) {
-      const frameTimeMs = Number(sample?.frameTimeMs);
-      if (!Number.isFinite(frameTimeMs) || frameTimeMs <= 0) {
-        return false;
-      }
-
-      const targetFrameTimeMs =
-        typeof sample?.targetFrameTimeMs === "number" && Number.isFinite(sample.targetFrameTimeMs)
-          ? sample.targetFrameTimeMs
-          : null;
-      const dropped = targetFrameTimeMs != null ? frameTimeMs > targetFrameTimeMs * 1.08 : false;
-      const entry = {
-        frameId: typeof sample?.frameId === "string" ? sample.frameId : null,
-        frameTimeMs,
-        targetFrameTimeMs,
-        dropped,
-      };
-
-      samples.push(entry);
-      totalFrameTimeMs += frameTimeMs;
-      if (dropped) {
-        droppedCount += 1;
-      }
-      if (samples.length > 120) {
-        const removed = samples.shift();
-        totalFrameTimeMs -= removed.frameTimeMs;
-        if (removed.dropped) {
-          droppedCount -= 1;
-        }
-      }
-
-      return dropped;
-    },
-    getSnapshot() {
-      const lastSample = samples[samples.length - 1] ?? null;
-      const peakFrameTimeMs = samples.reduce(
-        (peak, sample) => Math.max(peak, sample.frameTimeMs),
-        0
-      );
-      return {
-        sampleCount: samples.length,
-        averageFrameTimeMs: samples.length > 0 ? totalFrameTimeMs / samples.length : 0,
-        peakFrameTimeMs,
-        droppedCount,
-        lastFrameId: lastSample?.frameId ?? null,
-        lastFrameTimeMs: lastSample?.frameTimeMs ?? null,
-        targetFrameTimeMs: lastSample?.targetFrameTimeMs ?? null,
-      };
-    },
+    id,
+    positions: corners.flat(),
+    indices: [0, 1, 2, 0, 2, 3],
+    normals: [unitNormal, unitNormal, unitNormal, unitNormal].flat(),
+    color,
+    emission,
+    materialKind,
   };
 }
 
-function createState() {
+function createBoxMesh({ id, min, max, color, materialKind = "diffuse", metallic = 0, roughness = 0.55 }) {
+  const [x0, y0, z0] = min;
+  const [x1, y1, z1] = max;
+  const faces = [
+    { normal: [0, 0, 1], corners: [[x0, y0, z1], [x1, y0, z1], [x1, y1, z1], [x0, y1, z1]] },
+    { normal: [0, 0, -1], corners: [[x1, y0, z0], [x0, y0, z0], [x0, y1, z0], [x1, y1, z0]] },
+    { normal: [1, 0, 0], corners: [[x1, y0, z1], [x1, y0, z0], [x1, y1, z0], [x1, y1, z1]] },
+    { normal: [-1, 0, 0], corners: [[x0, y0, z0], [x0, y0, z1], [x0, y1, z1], [x0, y1, z0]] },
+    { normal: [0, 1, 0], corners: [[x0, y1, z1], [x1, y1, z1], [x1, y1, z0], [x0, y1, z0]] },
+    { normal: [0, -1, 0], corners: [[x0, y0, z0], [x1, y0, z0], [x1, y0, z1], [x0, y0, z1]] },
+  ];
+  const positions = [];
+  const normals = [];
+  const indices = [];
+
+  faces.forEach((face, faceIndex) => {
+    const base = faceIndex * 4;
+    positions.push(...face.corners.flat());
+    normals.push(face.normal, face.normal, face.normal, face.normal);
+    indices.push(base, base + 1, base + 2, base, base + 2, base + 3);
+  });
+
   return {
-    profile: defaultRendererWorkerProfile,
-    secureContext: window.isSecureContext,
-    webGpuAvailable: supportsWebGpu(),
-    initStarted: false,
-    initStatus: "Staging offscreen renderer",
-    initError: null,
-    hiddenCanvas: document.createElement("canvas"),
-    frameRecorder: createFrameRecorder(),
-    renderer: null,
-    snapshot: null,
-    lastRender: null,
-    accumulator: 0,
-    lastTargetFrameTimeMs: 1000 / 30,
+    id,
+    positions,
+    indices,
+    normals: normals.flat(),
+    color,
+    materialKind,
+    metallic,
+    roughness,
   };
 }
 
-async function initializeRendererState(state) {
-  const hooks = createRendererDebugHooks({
-    debugSession: state.frameRecorder,
-    targetFrameTimeMs: 1000 / 30,
-    onFrameComplete(event) {
-      state.lastTargetFrameTimeMs = event.targetFrameTimeMs ?? state.lastTargetFrameTimeMs;
-    },
-  });
-
-  const renderer = await createGpuRenderer({
-    canvas: state.hiddenCanvas,
-    clearColor: "#071523",
-    frameIdFactory: ({ frame, xrActive }) =>
-      `renderer-demo-${state.profile}-${frame}${xrActive ? "-xr" : ""}`,
-    ...hooks,
-  });
-
-  renderer.resize(640, 360, 1);
-  state.renderer = renderer;
-  state.snapshot = renderer.getSnapshot();
-  state.lastRender = renderer.renderOnce(performance.now());
-  state.snapshot = renderer.getSnapshot();
-  state.initStatus = "Offscreen renderer live";
+function createDemoMeshes() {
+  return [
+    createQuadMesh({
+      id: 100,
+      corners: [[-3, -0.9, 2], [3, -0.9, 2], [3, -0.9, -3], [-3, -0.9, -3]],
+      color: [0.52, 0.6, 0.62, 1],
+    }),
+    createQuadMesh({
+      id: 101,
+      corners: [[-3, -0.9, -3], [3, -0.9, -3], [3, 3, -3], [-3, 3, -3]],
+      color: [0.5, 0.49, 0.46, 1],
+    }),
+    createQuadMesh({
+      id: 102,
+      corners: [[-3, -0.9, -3], [-3, 3, -3], [-3, 3, 2], [-3, -0.9, 2]],
+      color: [0.42, 0.52, 0.62, 1],
+    }),
+    createQuadMesh({
+      id: 103,
+      corners: [[3, -0.9, -3], [3, -0.9, 2], [3, 3, 2], [3, 3, -3]],
+      color: [0.58, 0.46, 0.42, 1],
+    }),
+    createQuadMesh({
+      id: 104,
+      corners: [[-0.65, 2.55, -0.9], [0.65, 2.55, -0.9], [0.65, 2.55, -1.9], [-0.65, 2.55, -1.9]],
+      color: [1, 0.93, 0.76, 1],
+      emission: [9, 8.2, 6.4, 1],
+      materialKind: "emissive",
+    }),
+    createBoxMesh({
+      id: 110,
+      min: [-1.55, -0.9, -1.65],
+      max: [-0.55, 0.2, -0.65],
+      color: [0.72, 0.7, 0.64, 1],
+      materialKind: "metal",
+      metallic: 0.7,
+      roughness: 0.18,
+    }),
+    createBoxMesh({
+      id: 111,
+      min: [0.35, -0.9, -1.25],
+      max: [1.35, 0.55, -0.25],
+      color: [0.54, 0.68, 0.78, 0.92],
+      materialKind: "dielectric",
+      roughness: 0.08,
+    }),
+    createBoxMesh({
+      id: 112,
+      min: [-0.25, -0.9, 0.05],
+      max: [0.65, -0.05, 0.95],
+      color: [0.05, 0.08, 0.13, 1],
+      materialKind: "diffuse",
+    }),
+  ];
 }
 
-function ensureRenderer(state) {
-  if (state.initStarted || !state.webGpuAvailable) {
+function renderShell() {
+  root.innerHTML = `
+    <main class="demo-shell">
+      <section class="render-stage" aria-label="Wavefront path tracing render">
+        <canvas id="wavefrontCanvas" width="1280" height="720"></canvas>
+      </section>
+      <aside class="inspector" aria-live="polite">
+        <p class="eyebrow">@plasius/gpu-renderer</p>
+        <h1>Mesh BVH Wavefront</h1>
+        <p class="copy">
+          Direct WebGPU wavefront execution with triangle mesh BVH construction
+          and emissive mesh path termination.
+        </p>
+        <dl class="metrics" id="metrics"></dl>
+      </aside>
+    </main>
+  `;
+
+  const style = document.createElement("style");
+  style.textContent = `
+    :root {
+      color-scheme: dark;
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: #080b0f;
+      color: #eef4f8;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      background: #080b0f;
+    }
+
+    .demo-shell {
+      min-height: 100vh;
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) 340px;
+      gap: 0;
+    }
+
+    .render-stage {
+      min-height: 100vh;
+      display: grid;
+      place-items: center;
+      background: #111820;
+      padding: 16px;
+      box-sizing: border-box;
+    }
+
+    canvas {
+      width: min(100%, calc((100vh - 32px) * 16 / 9));
+      height: auto;
+      max-height: calc(100vh - 32px);
+      aspect-ratio: 16 / 9;
+      display: block;
+    }
+
+    .inspector {
+      border-left: 1px solid rgba(255, 255, 255, 0.12);
+      padding: 28px;
+      background: #11161d;
+    }
+
+    .eyebrow {
+      margin: 0 0 10px;
+      color: #88c7ff;
+      font-size: 0.78rem;
+      font-weight: 700;
+      letter-spacing: 0;
+      text-transform: uppercase;
+    }
+
+    h1 {
+      margin: 0;
+      font-size: 1.7rem;
+      line-height: 1.15;
+      letter-spacing: 0;
+    }
+
+    .copy {
+      color: #bdc9d4;
+      line-height: 1.55;
+    }
+
+    .metrics {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 12px;
+      margin: 24px 0 0;
+    }
+
+    .metrics div {
+      display: grid;
+      gap: 4px;
+      padding-bottom: 12px;
+      border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+    }
+
+    dt {
+      color: #8f9fac;
+      font-size: 0.78rem;
+    }
+
+    dd {
+      margin: 0;
+      color: #f4f8fb;
+      font-weight: 700;
+    }
+
+    @media (max-width: 920px) {
+      .demo-shell {
+        grid-template-columns: 1fr;
+      }
+
+      .render-stage {
+        min-height: 62vh;
+      }
+
+      canvas {
+        width: 100%;
+        max-height: none;
+      }
+
+      .inspector {
+        border-left: 0;
+        border-top: 1px solid rgba(255, 255, 255, 0.12);
+      }
+    }
+  `;
+  document.head.appendChild(style);
+}
+
+function setMetricValues(values) {
+  const metrics = document.getElementById("metrics");
+  if (!metrics) {
     return;
   }
 
-  state.initStarted = true;
-  void initializeRendererState(state).catch((error) => {
-    state.initError = error instanceof Error ? error.message : String(error);
-    state.initStatus = "Renderer initialization failed";
+  metrics.innerHTML = values
+    .map(
+      ([label, value]) => `
+        <div>
+          <dt>${label}</dt>
+          <dd>${value}</dd>
+        </div>
+      `
+    )
+    .join("");
+}
+
+function summarizeMemory(memory) {
+  return `${(memory.totalHotBufferBytes / 1024 / 1024).toFixed(2)} MiB hot buffers`;
+}
+
+function withTimeout(promise, ms, fallback) {
+  let timer = null;
+  return Promise.race([
+    promise,
+    new Promise((resolve) => {
+      timer = window.setTimeout(() => resolve(fallback), ms);
+    }),
+  ]).finally(() => {
+    if (timer !== null) {
+      window.clearTimeout(timer);
+    }
   });
 }
 
-function updateState(state, scene, dt) {
-  state.profile = scene.stress ? "xr" : defaultRendererWorkerProfile;
-  ensureRenderer(state);
+async function mountDemo() {
+  renderShell();
+  const canvas = document.getElementById("wavefrontCanvas");
 
-  if (!state.renderer) {
-    return state;
+  if (!supportsWavefrontPathTracingCompute()) {
+    setMetricValues([
+      ["status", window.isSecureContext ? "WebGPU unavailable" : "secure context required"],
+      ["render method", "wavefront path tracing"],
+      ["environment source", lightingOptions.lightingEnvironment.preset],
+    ]);
+    return null;
   }
 
-  state.accumulator += dt;
-  const renderIntervalSeconds = scene.stress ? 0.18 : 0.32;
-  if (state.accumulator < renderIntervalSeconds) {
-    return state;
-  }
-
-  state.accumulator = 0;
-  state.renderer.setClearColor(scene.stress ? "#08111c" : "#071523");
-  state.lastRender = state.renderer.renderOnce(performance.now());
-  state.snapshot = state.renderer.getSnapshot();
-  return state;
-}
-
-function describeState(state, scene) {
-  ensureRenderer(state);
-
-  const profile = getRendererWorkerProfile(state.profile);
-  const manifest = getRendererWorkerManifest(state.profile);
-  const plan = createRayTracingRenderPlan({
-    snapshotId: `renderer-demo-${scene.frame}`,
-    profile: state.profile,
+  setMetricValues([
+    ["status", "creating renderer"],
+    ["render method", "mesh BVH tiled wavefront"],
+    ["environment source", lightingOptions.lightingEnvironment.preset],
+  ]);
+  const renderer = await createWavefrontPathTracingComputeRenderer({
+    canvas,
+    width: 1280,
+    height: 720,
+    maxDepth: 6,
+    tileSize: 128,
+    displayQuality: true,
+    denoise: true,
+    meshes: createDemoMeshes(),
+    ...lightingOptions,
   });
-  const frameStats = state.frameRecorder.getSnapshot();
-  const offscreenSnapshot = state.snapshot;
-  const premiumBands = plan.representationBands.filter(
-    (band) => "rtParticipation" in band && band.rtParticipation === "premium"
-  ).length;
-  const selectiveBands = plan.representationBands.filter(
-    (band) => "rtParticipation" in band && band.rtParticipation === "selective"
-  ).length;
+  setMetricValues([
+    ["status", "submitting frame"],
+    ["render method", "mesh BVH tiled wavefront"],
+    ["environment source", lightingOptions.lightingEnvironment.preset],
+  ]);
+  const stats = renderer.renderOnce();
+  setMetricValues([
+    ["status", `rendered frame ${stats.frame}`],
+    ["render method", "mesh BVH tiled wavefront"],
+    ["resolution", `${stats.width}x${stats.height}`],
+    ["primary rays", stats.primaryRays.toLocaleString("en-GB")],
+    ["triangles", stats.triangleCount.toLocaleString("en-GB")],
+    ["BVH nodes", stats.bvhNodeCount.toLocaleString("en-GB")],
+    ["max depth", `${stats.maxDepth} bounces`],
+    ["tiles", `${stats.tiles} @ ${stats.tileSize}px`],
+    ["lighting preset", lightingOptions.lightingEnvironment.preset],
+    ["environment mode", `${lightingOptions.environmentLighting.mode}`],
+    ["probe luminance", "pending"],
+    ["memory", summarizeMemory(stats.memory)],
+  ]);
+  await withTimeout(
+    renderer.device.queue.onSubmittedWorkDone?.() ?? Promise.resolve(),
+    1500,
+    null
+  );
+  const probe = await withTimeout(
+    renderer.readOutputProbe({ x: 640, y: 360 }).catch(() => null),
+    1500,
+    null
+  );
 
-  const status = state.initError
-    ? `Renderer init failed · ${state.initError}`
-    : !state.webGpuAvailable
-      ? "Renderer planning preview · WebGPU unavailable"
-      : state.renderer
-        ? `Renderer live · ${state.profile} profile · ${offscreenSnapshot?.frame ?? 0} offscreen frames`
-        : state.initStatus;
+  setMetricValues([
+    ["status", `rendered frame ${stats.frame}`],
+    ["render method", "mesh BVH tiled wavefront"],
+    ["resolution", `${stats.width}x${stats.height}`],
+    ["primary rays", stats.primaryRays.toLocaleString("en-GB")],
+    ["triangles", stats.triangleCount.toLocaleString("en-GB")],
+    ["BVH nodes", stats.bvhNodeCount.toLocaleString("en-GB")],
+    ["max depth", `${stats.maxDepth} bounces`],
+    ["tiles", `${stats.tiles} @ ${stats.tileSize}px`],
+    ["lighting preset", lightingOptions.lightingEnvironment.preset],
+    ["environment mode", `${lightingOptions.environmentLighting.mode}`],
+    ["probe luminance", probe ? probe.luminance.toFixed(4) : "timeout"],
+    ["memory", summarizeMemory(stats.memory)],
+  ]);
 
-  const details = state.initError
-    ? "The shared harbor is still rendering, but the renderer package could not bootstrap its offscreen WebGPU runtime."
-    : !state.webGpuAvailable
-      ? state.secureContext
-        ? "The harbor remains visible, but this browser or GPU stack cannot expose WebGPU for the offscreen renderer."
-        : "The harbor remains visible, but the renderer package needs localhost or HTTPS before it can mount its offscreen WebGPU surface."
-      : state.renderer
-        ? `A real offscreen WebGPU renderer is producing live frames under the shared harbor while the demo exposes the ${state.profile} worker profile, render-stage order, and band policy used to present the moonlit scene.`
-        : "Preparing an offscreen WebGPU renderer so the shared harbor can surface real renderer snapshots instead of placeholder metrics.";
+  window.render_game_to_text = () =>
+    JSON.stringify({
+      surface: "gpu-renderer-wavefront-demo",
+      geometryMode: "mesh-bvh-display-quality",
+      displayQuality: true,
+      requiresMeshBvhForDisplayQuality: true,
+      requiresTriangleMeshForProductStudio: true,
+      renderer: renderer.getSnapshot(),
+      lighting: lightingOptions.lightingEnvironment,
+      renderPlan: {
+        stages: renderPlan.renderStages.map((stage) => stage.key),
+        wavefrontPasses: renderPlan.wavefront.bounceSchedule[0]?.passOrder ?? [],
+      },
+      probe,
+    });
 
-  return {
-    status,
-    details,
-    sceneMetrics: [
-      `profile: ${state.profile}`,
-      `offscreen surface: ${offscreenSnapshot ? `${offscreenSnapshot.width}x${offscreenSnapshot.height}` : "booting"}`,
-      `snapshot id: ${plan.inputBoundary.snapshotId}`,
-      `render stages: ${plan.renderStages.length}`,
-      `representation bands: ${plan.representationBands.length}`,
-    ],
-    qualityMetrics: [
-      `worker jobs: ${manifest.jobs.length}`,
-      `profile jobs: ${profile.jobs.length}`,
-      `premium RT bands: ${premiumBands}`,
-      `selective RT bands: ${selectiveBands}`,
-      `suggested allocations: ${manifest.suggestedAllocationIds.length}`,
-    ],
-    debugMetrics: [
-      `recorded frames: ${frameStats.sampleCount}`,
-      `avg frame: ${frameStats.averageFrameTimeMs.toFixed(2)} ms`,
-      `peak frame: ${frameStats.peakFrameTimeMs.toFixed(2)} ms`,
-      `dropped frames: ${frameStats.droppedCount}`,
-      `last frame id: ${frameStats.lastFrameId ?? "pending"}`,
-    ],
-    notes: [
-      "gpu-renderer now uses the same moonlit harbor as the rest of the family instead of a standalone control-panel canvas.",
-      "The demo still exercises gpu-renderer public APIs directly: supportsWebGpu, createGpuRenderer, createRendererDebugHooks, getRendererWorkerManifest, getRendererWorkerProfile, and createRayTracingRenderPlan.",
-      "Stress mode promotes the planning view to the xr profile so the render-stage and representation policies widen without breaking the painterly harbor presentation.",
-    ],
-    textState: {
-      profile: state.profile,
-      renderPlanStageOrder: plan.renderStages.map((stage) => stage.key),
-      offscreenSnapshot,
-      frameStats,
-      workerJobs: manifest.jobs.map((job) => job.key),
-    },
-    visuals: {
-      reflectionStrength: state.renderer ? 0.28 : 0.18,
-      shadowAccent: scene.stress ? 0.14 : 0.09,
-      lanternReflectionStrength: scene.stress ? 0.62 : 0.5,
-      waveAmplitude: scene.stress ? 0.98 : 0.88,
-      ambientMist: scene.stress ? "rgba(56, 73, 111, 0.24)" : "rgba(39, 59, 92, 0.18)",
-      moonHalo: scene.stress ? "rgba(192, 210, 255, 0.34)" : "rgba(164, 186, 240, 0.24)",
-      waterNear: scene.stress ? { r: 0.11, g: 0.27, b: 0.38 } : { r: 0.08, g: 0.23, b: 0.33 },
-      waterFar: { r: 0.17, g: 0.35, b: 0.48 },
-    },
-  };
+  return renderer;
 }
 
-function destroyState(state) {
-  if (state?.renderer && typeof state.renderer.destroy === "function") {
-    state.renderer.destroy();
-  }
-}
+let activeRenderer = null;
+mountDemo()
+  .then((renderer) => {
+    activeRenderer = renderer;
+  })
+  .catch((error) => {
+    renderShell();
+    setMetricValues([
+      ["status", "render failed"],
+      ["error", error instanceof Error ? error.message : String(error)],
+      ["environment source", lightingOptions.lightingEnvironment.preset],
+    ]);
+  });
 
-const showcase = await mountGpuShowcase({
-  root,
-  focus: "lighting",
-  packageName: "@plasius/gpu-renderer",
-  title: "Moonlit Renderer Harbor",
-  subtitle:
-    "Painterly harbor composition backed by live gpu-renderer snapshots, render-plan staging, and offscreen WebGPU frame telemetry.",
-  createState,
-  updateState,
-  describeState,
-  destroyState,
-});
-
-window.addEventListener("pagehide", () => showcase.destroy(), { once: true });
+window.addEventListener(
+  "pagehide",
+  () => {
+    activeRenderer?.destroy?.();
+  },
+  { once: true }
+);

--- a/docs/adrs/adr-0006-webgpu-wavefront-scene-object-renderer.md
+++ b/docs/adrs/adr-0006-webgpu-wavefront-scene-object-renderer.md
@@ -1,0 +1,54 @@
+# ADR 0006: WebGPU Wavefront Scene-Object Renderer
+
+## Status
+
+Accepted for analytic debug fixtures. Superseded for all display-quality
+path-traced rendering by ADR 0007.
+
+## Context
+
+The renderer package had a wavefront path-tracing plan and buffer contract, but
+no executable WebGPU path-tracing runtime. The renderer needed a small
+screen-driven active-ray fixture without returning to CPU canvas tracing, and it
+must avoid full-screen ray queues that exceed browser storage-buffer limits at
+720p, 1080p, and future 4K targets.
+
+## Decision
+
+`@plasius/gpu-renderer` owns a framework-agnostic WebGPU compute wavefront
+renderer that:
+
+- generates primary rays per tile from the active camera;
+- uses ping-pong ray queues and hit buffers on the GPU;
+- evaluates all active rays breadth-first by bounce depth;
+- terminates paths on emissive or environment hits;
+- uses configurable ambient residual radiance for expired paths;
+- writes a storage texture and presents it through a WebGPU render pass;
+- accepts bounded analytic scene objects (`sphere` and `box`) as a debug-only
+  scene-submission shape.
+
+The renderer uses tiled queues rather than one full-screen queue. Tile size is
+clamped against device storage-buffer limits, keeping 4K presentation possible
+without allocating 4K-sized ray queues per bounce.
+
+## Consequences
+
+- Positive: demos can validate active-ray execution through a package API
+  instead of private viewer code.
+- Positive: queue memory now scales with tile size, not presentation resolution.
+- Positive: downstream packages can build scene adapters without owning WebGPU
+  shader orchestration.
+- Neutral: this is an analytic debug path, not a display-quality renderer.
+- Negative: direct light sampling remains intentionally absent; paths must hit
+  emissive geometry or the environment to contribute significant radiance.
+- Negative: no user-visible renderer can use this path for visual acceptance
+  because it does not preserve triangle silhouettes, per-vertex normals, UVs,
+  textures, or mesh material identity.
+
+## Follow-On Work
+
+- Add triangle mesh buffers and a BVH/BLAS/TLAS acceleration structure before
+  any path-traced output is considered display quality.
+- Add temporal accumulation history and a stronger denoise pass.
+- Add richer material and texture binding tables once mesh intersections are in
+  place.

--- a/docs/adrs/adr-0007-triangle-mesh-wavefront-path-tracing.md
+++ b/docs/adrs/adr-0007-triangle-mesh-wavefront-path-tracing.md
@@ -1,0 +1,117 @@
+# ADR 0007: Mesh BVH Wavefront Path Tracing As Display Quality Baseline
+
+## Status
+
+Accepted
+
+## Context
+
+The analytic `sphere`/`box` wavefront renderer is useful for validating tiled
+GPU queue execution, but it is not visually correct for display-quality output.
+Across the Plasius `gpu-*` rendering family, mesh BVH is the only acceptable
+baseline for user-visible display-quality path tracing. Product renders and
+other asset-backed scenes must preserve the source triangle mesh, triangle
+identity, geometric normals, interpolated shading normals, material lookup, and
+future medium interactions. Bounce directions must be derived from the resolved
+triangle surface at the hit point, not from coarse proxy objects.
+
+Future high-end modes also need room for inverse prismatic scatter experiments
+where paths are traced from light sources through refractive or participating
+media, then related back to screen-space contribution.
+
+## Decision
+
+`@plasius/gpu-renderer` will treat triangle mesh BVH path tracing as the display
+quality path for the whole project, not just Product Studio. The renderer will:
+
+- accept indexed triangle mesh buffers for positions, indices, vertex normals,
+  UVs, tangents where available, material references, and primitive metadata;
+- build or consume a GPU-friendly acceleration structure, initially BVH-style,
+  so tiled path tracing remains practical at 720p, 1080p, and future 4K targets;
+- intersect active rays against triangles on the GPU and select the nearest
+  valid triangle hit;
+- write barycentric coordinates, primitive id, material id, geometric normal,
+  interpolated shading normal, UV, front-face state, and medium/material
+  references into the hit record;
+- calculate reflection, refraction, transparency, and diffuse continuation
+  directions from the triangle hit using a repaired shading normal that remains
+  consistent with the geometric normal;
+- keep analytic `sphere` and `box` objects as debug fixtures only. They must not
+  be presented as display-quality renderer output.
+
+## Normal Handling
+
+The geometric normal is calculated from the hit triangle winding. The shading
+normal is interpolated from vertex normals with barycentric coordinates when
+normals are present; otherwise it falls back to the geometric normal. If a
+normal map is available later, it is transformed through the tangent frame after
+the barycentric normal is resolved. Invalid, zero-length, or back-facing shading
+normals must be repaired against the geometric normal before they affect bounce
+directions.
+
+## Future Medium And Prismatic Work
+
+Inverse prismatic scatter and light-source-originated path experiments are a
+later high-performance mode. This ADR does not require that mode in the first
+triangle implementation, but the mesh/material/medium records must not block it.
+The record model should leave explicit room for wavelength/dispersion controls,
+medium references, and light-surface emission metadata.
+
+## Consequences
+
+- Product Studio and any other user-visible renderer must not claim visual
+  correctness while it submits proxy boxes or other non-mesh geometry instead of
+  source triangles.
+- Any demo, page, or screenshot that uses analytic/proxy geometry must label it
+  as debug/test output and must not be used as visual acceptance evidence.
+- The first triangle implementation may ship with limited materials and no
+  texture sampling, but the intersection and normal path must be triangle-based.
+- CPU work is limited to source-buffer upload and WebGPU command submission.
+  Production BVH construction/update, triangle assembly, ray traversal,
+  nearest-hit selection, material evaluation, and accumulation must run on the
+  GPU.
+- The analytic debug renderer remains valuable for WebGPU capability checks,
+  buffer-limit validation, and small deterministic tests.
+
+## Current Implementation Boundary
+
+The first implementation slice in `@plasius/gpu-renderer` uploads indexed mesh
+source buffers for positions, indices, normals, UVs, mesh ranges, and material
+metadata. Display-quality configuration selects `accelerationBuildMode: "gpu"`
+and rejects `cpu-debug` acceleration. The GPU build pass assembles triangle
+records, writes Morton-style centroid keys into a leaf-reference buffer, sorts
+the leaf references on the GPU, materializes sorted BVH leaves, and builds a
+deterministic binary BVH before tiled wavefront tracing. Internal BVH nodes are
+built bottom-up with one compute dispatch per dependency level, so all parent
+nodes at the same depth execute concurrently on the GPU. The WGSL intersection
+path traverses the BVH, intersects triangles, selects the nearest valid hit, and
+writes primitive id, material reference, medium reference, barycentric
+coordinates, UVs, geometric normal, and repaired shading normal into the hit
+record.
+
+The wavefront renderer also supports configurable `samplesPerPixel` within the
+GPU render pass. Higher sample counts multiply primary-ray dispatches, but the
+queue and hit buffers stay tile-bounded. Ray, hit, triangle, BVH, and
+accumulation record sizes must match WGSL alignment exactly; buffer stride
+mismatches are treated as release-blocking visual corruption bugs. Resolved tile
+output is written to a linear `rgba16float` radiance texture, then an optional
+two-stage full-frame GPU denoise reads across tile boundaries, writes through an
+`rgba16float` scratch texture, and tone-maps into the presented `rgba8unorm`
+texture. Low-sample
+Product Studio preview output stores compact emissive-triangle guidance metadata
+in the existing BVH buffer tail and uses it to guide diffuse continuation rays
+toward finite mesh light geometry without adding a ninth trace storage buffer.
+This guide changes the next active-ray direction only; it does not add a
+separate shadow ray or direct-light contribution. Radiance is still accumulated
+when the active path hits emissive geometry, misses into the environment, or
+expires with the configured ambient residual. Guided emissive hits carry a
+bounded estimator weight until full material PDFs/MIS are implemented. Radiance
+clamping and damped diffuse throughput reduce fireflies while continuation rays
+still evaluate mesh BVH hits.
+
+The remaining production-hardening work is not optional: material-id lookup
+tables, texture sampling, direct-light PDF/MIS correction, dynamic TLAS instance
+records, higher-grade LBVH/SAH construction, runtime execution behind the
+`@plasius/gpu-worker` lock-free queue, runtime GPU smoke coverage, and
+larger-scene traversal benchmarks still need to land before the mesh renderer is
+treated as final production-quality output.

--- a/docs/adrs/index.md
+++ b/docs/adrs/index.md
@@ -5,3 +5,5 @@
 - [ADR 0003: Frame Lifecycle Hooks for Adaptive Integration](./adr-0003-frame-lifecycle-hooks-for-adaptive-integration.md)
 - [ADR 0004: Renderer Frame Stages as Worker DAG Manifests](./adr-0004-renderer-frame-stages-as-worker-dag-manifests.md)
 - [ADR 0005: Ray-Tracing-First Hybrid Render Graph](./adr-0005-ray-tracing-first-hybrid-render-graph.md)
+- [ADR 0006: WebGPU Wavefront Scene-Object Renderer](./adr-0006-webgpu-wavefront-scene-object-renderer.md)
+- [ADR 0007: Mesh BVH Wavefront Path Tracing As Display Quality Baseline](./adr-0007-triangle-mesh-wavefront-path-tracing.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@plasius/gpu-renderer",
-  "version": "0.1.12",
+  "version": "0.1.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@plasius/gpu-renderer",
-      "version": "0.1.12",
+      "version": "0.1.14",
       "funding": [
         {
           "type": "patreon",
@@ -19,7 +19,6 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "@plasius/gpu-shared": "^0.1.9",
         "@plasius/gpu-xr": "^0.1.11"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plasius/gpu-renderer",
-  "version": "0.1.12",
+  "version": "0.1.14",
   "description": "Framework-agnostic WebGPU renderer runtime for Plasius projects.",
   "type": "module",
   "sideEffects": false,
@@ -27,7 +27,7 @@
   "scripts": {
     "build": "tsup",
     "demo": "python3 -m http.server --directory ..",
-    "typecheck": "node --check src/index.js",
+    "typecheck": "node --check src/index.js && node --check src/wavefront-compute.js",
     "audit:eslint": "eslint . --max-warnings=0",
     "audit:deps": "npm ls --all --omit=optional --omit=peer > /dev/null 2>&1 || true",
     "audit:npm": "npm audit --audit-level=high --omit=dev",
@@ -49,7 +49,6 @@
   "author": "Plasius LTD <development@plasius.co.uk>",
   "license": "Apache-2.0",
   "dependencies": {
-    "@plasius/gpu-shared": "^0.1.9",
     "@plasius/gpu-xr": "^0.1.11"
   },
   "devDependencies": {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,4 +1,490 @@
 export type RendererColor = string | [number, number, number, number?];
+export type WavefrontSceneObjectKind = "sphere" | "box" | "aabb" | "bounds" | number;
+export type WavefrontMaterialKind =
+  | "diffuse"
+  | "metal"
+  | "reflective"
+  | "dielectric"
+  | "refractive"
+  | "glass"
+  | "transparent"
+  | "transmission"
+  | "emissive"
+  | "light"
+  | number;
+
+export interface WavefrontCameraOptions {
+  readonly position?: readonly [number, number, number] | readonly number[];
+  readonly target?: readonly [number, number, number] | readonly number[];
+  readonly up?: readonly [number, number, number] | readonly number[];
+  readonly fovYDegrees?: number;
+  readonly fov?: number;
+}
+
+export interface WavefrontSceneObjectInput {
+  readonly id?: number;
+  readonly kind?: WavefrontSceneObjectKind;
+  readonly type?: WavefrontSceneObjectKind;
+  readonly materialKind?: WavefrontMaterialKind;
+  readonly flags?: number;
+  readonly center?: readonly [number, number, number] | readonly number[];
+  readonly position?: readonly [number, number, number] | readonly number[];
+  readonly radius?: number;
+  readonly halfExtent?: readonly [number, number, number] | readonly number[];
+  readonly halfExtents?: readonly [number, number, number] | readonly number[];
+  readonly extents?: readonly [number, number, number] | readonly number[];
+  readonly min?: readonly [number, number, number] | readonly number[];
+  readonly max?: readonly [number, number, number] | readonly number[];
+  readonly bounds?: {
+    readonly min?: readonly [number, number, number] | readonly number[];
+    readonly max?: readonly [number, number, number] | readonly number[];
+  };
+  readonly color?: RendererColor | readonly number[];
+  readonly baseColor?: RendererColor | readonly number[];
+  readonly albedo?: RendererColor | readonly number[];
+  readonly emission?: readonly [number, number, number, number?] | readonly number[];
+  readonly emissive?: readonly [number, number, number, number?] | readonly number[];
+  readonly roughness?: number;
+  readonly metallic?: number;
+  readonly opacity?: number;
+  readonly ior?: number;
+  readonly material?: {
+    readonly kind?: WavefrontMaterialKind;
+    readonly color?: RendererColor | readonly number[];
+    readonly baseColor?: RendererColor | readonly number[];
+    readonly emission?: readonly [number, number, number, number?] | readonly number[];
+    readonly emissive?: readonly [number, number, number, number?] | readonly number[];
+    readonly roughness?: number;
+    readonly metallic?: number;
+    readonly opacity?: number;
+    readonly ior?: number;
+  };
+}
+
+export interface WavefrontSceneObject {
+  readonly id: number;
+  readonly kind: number;
+  readonly materialKind: number;
+  readonly flags: number;
+  readonly center: readonly [number, number, number] | readonly number[];
+  readonly halfExtent: readonly [number, number, number] | readonly number[];
+  readonly color: readonly [number, number, number, number] | readonly number[];
+  readonly emission: readonly [number, number, number, number] | readonly number[];
+  readonly roughness: number;
+  readonly metallic: number;
+  readonly opacity: number;
+  readonly ior: number;
+}
+
+export interface WavefrontMeshInput {
+  readonly id?: number;
+  readonly positions: readonly number[] | Float32Array;
+  readonly indices?: readonly number[] | Uint16Array | Uint32Array;
+  readonly normals?: readonly number[] | Float32Array | null;
+  readonly uvs?: readonly number[] | Float32Array | null;
+  readonly texcoords?: readonly number[] | Float32Array | null;
+  readonly uv?: readonly number[] | Float32Array | null;
+  readonly materialKind?: WavefrontMaterialKind;
+  readonly flags?: number;
+  readonly materialRefId?: number;
+  readonly materialId?: number;
+  readonly mediumRefId?: number;
+  readonly mediumId?: number;
+  readonly color?: RendererColor | readonly number[];
+  readonly baseColor?: RendererColor | readonly number[];
+  readonly albedo?: RendererColor | readonly number[];
+  readonly emission?: readonly [number, number, number, number?] | readonly number[];
+  readonly emissive?: readonly [number, number, number, number?] | readonly number[];
+  readonly roughness?: number;
+  readonly metallic?: number;
+  readonly opacity?: number;
+  readonly ior?: number;
+  readonly material?: {
+    readonly kind?: WavefrontMaterialKind;
+    readonly color?: RendererColor | readonly number[];
+    readonly baseColor?: RendererColor | readonly number[];
+    readonly emission?: readonly [number, number, number, number?] | readonly number[];
+    readonly emissive?: readonly [number, number, number, number?] | readonly number[];
+    readonly roughness?: number;
+    readonly metallic?: number;
+    readonly opacity?: number;
+    readonly ior?: number;
+    readonly id?: number;
+  };
+  readonly medium?: {
+    readonly id?: number;
+  };
+}
+
+export interface WavefrontTriangleRecord {
+  readonly triangleId: number;
+  readonly meshId: number;
+  readonly materialKind: number;
+  readonly flags: number;
+  readonly materialRefId: number;
+  readonly mediumRefId: number;
+  readonly v0: readonly number[];
+  readonly v1: readonly number[];
+  readonly v2: readonly number[];
+  readonly n0: readonly number[];
+  readonly n1: readonly number[];
+  readonly n2: readonly number[];
+  readonly uv0: readonly number[];
+  readonly uv1: readonly number[];
+  readonly uv2: readonly number[];
+  readonly color: readonly number[];
+  readonly emission: readonly number[];
+  readonly material: readonly number[];
+  readonly bounds: Readonly<{ min: readonly number[]; max: readonly number[] }>;
+  readonly centroid: readonly number[];
+}
+
+export interface WavefrontBvhNodeRecord {
+  readonly bounds: Readonly<{ min: readonly number[]; max: readonly number[] }>;
+  readonly firstTriangle: number;
+  readonly triangleCount: number;
+  readonly leftChild: number;
+  readonly rightChild: number;
+}
+
+export interface WavefrontBvhBuildLevel {
+  readonly start: number;
+  readonly count: number;
+}
+
+export interface WavefrontBvhSortStage {
+  readonly compareDistance: number;
+  readonly sequenceSize: number;
+}
+
+export interface WavefrontMeshAcceleration {
+  readonly nodes: readonly WavefrontBvhNodeRecord[];
+  readonly triangles: readonly WavefrontTriangleRecord[];
+}
+
+export type WavefrontAccelerationBuildMode = "gpu" | "cpu-debug";
+
+export interface WavefrontGpuMeshSource {
+  readonly vertices: Readonly<{
+    readonly buffer: ArrayBuffer;
+    readonly count: number;
+    readonly recordBytes: number;
+  }>;
+  readonly indices: Readonly<{
+    readonly buffer: ArrayBuffer;
+    readonly count: number;
+    readonly recordBytes: 4;
+  }>;
+  readonly meshes: Readonly<{
+    readonly buffer: ArrayBuffer;
+    readonly records: readonly Readonly<{
+      readonly id: number;
+      readonly positions: readonly number[];
+      readonly indices: readonly number[];
+      readonly normals: readonly number[] | null;
+      readonly uvs: readonly number[] | null;
+      readonly materialKind: number;
+      readonly flags: number;
+      readonly materialRefId: number;
+      readonly mediumRefId: number;
+      readonly color: readonly number[];
+      readonly emission: readonly number[];
+      readonly roughness: number;
+      readonly metallic: number;
+      readonly opacity: number;
+      readonly ior: number;
+    }>[];
+    readonly count: number;
+    readonly recordBytes: number;
+  }>;
+  readonly triangleCount: number;
+  readonly bvhNodeCapacity: number;
+}
+
+export interface WavefrontEmissiveTriangleIndexSource {
+  readonly buffer: ArrayBuffer;
+  readonly indices: readonly number[];
+  readonly count: number;
+  readonly capacity: number;
+  readonly recordBytes: 4;
+}
+
+export interface WavefrontPathTracingComputeConfig {
+  readonly width: number;
+  readonly height: number;
+  readonly maxDepth: number;
+  readonly tileSize: number;
+  readonly samplesPerPixel: number;
+  readonly tilePixelCapacity: number;
+  readonly sceneObjects: readonly WavefrontSceneObject[];
+  readonly sceneObjectCount: number;
+  readonly sceneObjectCapacity: number;
+  readonly accelerationBuildMode: WavefrontAccelerationBuildMode;
+  readonly gpuAccelerationBuildRequired: boolean;
+  readonly gpuMeshSource: WavefrontGpuMeshSource;
+  readonly meshAcceleration: WavefrontMeshAcceleration;
+  readonly emissiveTriangleIndices: WavefrontEmissiveTriangleIndexSource;
+  readonly emissiveTriangleCount: number;
+  readonly emissiveTriangleCapacity: number;
+  readonly triangleCount: number;
+  readonly triangleCapacity: number;
+  readonly bvhNodeCount: number;
+  readonly bvhNodeCapacity: number;
+  readonly bvhLeafSortCapacity: number;
+  readonly bvhSortStages: readonly WavefrontBvhSortStage[];
+  readonly bvhBuildLevels: readonly WavefrontBvhBuildLevel[];
+  readonly camera: Readonly<{
+    readonly position: readonly number[];
+    readonly forward: readonly number[];
+    readonly right: readonly number[];
+    readonly up: readonly number[];
+    readonly fovYDegrees: number;
+    readonly aspect: number;
+    readonly tanHalfFovY: number;
+  }>;
+  readonly environmentColor: readonly [number, number, number, number] | readonly number[];
+  readonly ambientColor: readonly [number, number, number, number] | readonly number[];
+  readonly environmentLighting: WavefrontEnvironmentLightingConfig;
+  readonly displayQuality: boolean;
+  readonly requiresMeshBvhForDisplayQuality: true;
+  readonly denoise: boolean;
+  readonly frameIndex: number;
+  readonly memory: WavefrontPathTracingMemoryEstimate;
+}
+
+export interface WavefrontEnvironmentLightingInput {
+  readonly environmentColor?: readonly [number, number, number, number?] | readonly number[];
+  readonly ambientColor?: readonly [number, number, number, number?] | readonly number[];
+  readonly horizonColor?: readonly [number, number, number, number?] | readonly number[];
+  readonly zenithColor?: readonly [number, number, number, number?] | readonly number[];
+  readonly sunDirection?: readonly [number, number, number] | readonly number[];
+  readonly sunColor?: readonly [number, number, number, number?] | readonly number[];
+  readonly intensity?: number;
+  readonly mode?: number;
+  readonly exposure?: number;
+}
+
+export interface WavefrontEnvironmentLightingConfig {
+  readonly environmentColor: readonly [number, number, number, number] | readonly number[];
+  readonly ambientColor: readonly [number, number, number, number] | readonly number[];
+  readonly horizonColor: readonly [number, number, number, number] | readonly number[];
+  readonly zenithColor: readonly [number, number, number, number] | readonly number[];
+  readonly sunDirection: readonly [number, number, number] | readonly number[];
+  readonly sunColor: readonly [number, number, number, number] | readonly number[];
+  readonly intensity: number;
+  readonly mode: number;
+  readonly exposure: number;
+}
+
+export interface WavefrontPathTracingMemoryEstimate {
+  readonly queueBytes: number;
+  readonly queuePairBytes: number;
+  readonly hitBytes: number;
+  readonly accumulationBytes: number;
+  readonly sceneObjectBytes: number;
+  readonly triangleBytes: number;
+  readonly bvhNodeBytes: number;
+  readonly bvhLeafReferenceBytes: number;
+  readonly emissiveTriangleMetadataBytes: number;
+  readonly configBytes: number;
+  readonly counterBytes: number;
+  readonly totalHotBufferBytes: number;
+}
+
+export interface CreateWavefrontPathTracingComputeRendererOptions {
+  readonly canvas?: HTMLCanvasElement | string;
+  readonly navigator?: Navigator | { gpu?: GPU };
+  readonly document?: Document;
+  readonly powerPreference?: GPUPowerPreference;
+  readonly alpha?: boolean;
+  readonly format?: GPUTextureFormat;
+  readonly width?: number;
+  readonly height?: number;
+  readonly maxDepth?: number;
+  readonly tileSize?: number;
+  readonly samplesPerPixel?: number;
+  readonly tilePixelCapacity?: number;
+  readonly sceneObjectCapacity?: number;
+  readonly sceneObjects?: readonly WavefrontSceneObjectInput[];
+  readonly mesh?: WavefrontMeshInput;
+  readonly meshes?: readonly WavefrontMeshInput[];
+  readonly triangleCapacity?: number;
+  readonly bvhNodeCapacity?: number;
+  readonly bvhLeafSortCapacity?: number;
+  readonly emissiveTriangleCapacity?: number;
+  readonly accelerationBuildMode?: WavefrontAccelerationBuildMode;
+  readonly camera?: WavefrontCameraOptions;
+  readonly environmentColor?: readonly [number, number, number, number?] | readonly number[];
+  readonly ambientColor?: readonly [number, number, number, number?] | readonly number[];
+  readonly environmentLighting?: WavefrontEnvironmentLightingInput;
+  readonly displayQuality?: boolean;
+  readonly denoise?: boolean;
+  readonly frameIndex?: number;
+}
+
+export interface WavefrontPathTracingComputeRenderer {
+  readonly canvas: HTMLCanvasElement;
+  readonly context: GPUCanvasContext;
+  readonly device: GPUDevice;
+  readonly format: GPUTextureFormat | string;
+  readonly config: WavefrontPathTracingComputeConfig;
+  renderOnce(): Readonly<{
+    frame: number;
+    width: number;
+    height: number;
+    maxDepth: number;
+    tiles: number;
+    tileSize: number;
+    samplesPerPixel: number;
+    screenRays: number;
+    primaryRays: number;
+    sceneObjectCount: number;
+    triangleCount: number;
+    emissiveTriangleCount: number;
+    bvhNodeCount: number;
+    displayQuality: boolean;
+    accelerationBuildMode: WavefrontAccelerationBuildMode;
+    gpuAccelerationBuildRequired: boolean;
+    memory: WavefrontPathTracingMemoryEstimate;
+  }>;
+  readOutputProbe(options?: { x?: number; y?: number }): Promise<
+    Readonly<{
+      x: number;
+      y: number;
+      rgba: readonly number[];
+      luminance: number;
+    }>
+  >;
+  updateSceneObjects(sceneObjects: readonly WavefrontSceneObjectInput[]): WavefrontPathTracingComputeConfig;
+  getSnapshot(): Readonly<{
+    frame: number;
+    width: number;
+    height: number;
+    maxDepth: number;
+    tiles: number;
+    tileSize: number;
+    samplesPerPixel: number;
+    sceneObjectCount: number;
+    triangleCount: number;
+    emissiveTriangleCount: number;
+    bvhNodeCount: number;
+    displayQuality: boolean;
+    accelerationBuildMode: WavefrontAccelerationBuildMode;
+    gpuAccelerationBuildRequired: boolean;
+    memory: WavefrontPathTracingMemoryEstimate;
+  }>;
+  destroy(): void;
+}
+
+export function normalizeWavefrontSceneObject(
+  input?: WavefrontSceneObjectInput,
+  index?: number
+): WavefrontSceneObject;
+export function createDefaultWavefrontSceneObjects(): readonly WavefrontSceneObject[];
+export function estimateWavefrontPathTracingMemory(options?: {
+  tilePixelCapacity?: number;
+  sceneObjectCapacity?: number;
+  triangleCapacity?: number;
+  bvhNodeCapacity?: number;
+  bvhLeafSortCapacity?: number;
+  emissiveTriangleCapacity?: number;
+}): WavefrontPathTracingMemoryEstimate;
+export function normalizeWavefrontMesh(
+  input: WavefrontMeshInput,
+  meshIndex?: number
+): Readonly<{
+  id: number;
+  positions: readonly number[];
+  indices: readonly number[];
+  normals: readonly number[] | null;
+  uvs: readonly number[] | null;
+  materialKind: number;
+  flags: number;
+  materialRefId: number;
+  mediumRefId: number;
+  color: readonly number[];
+  emission: readonly number[];
+  roughness: number;
+  metallic: number;
+  opacity: number;
+  ior: number;
+}>;
+export function createWavefrontMeshAcceleration(
+  meshes?: readonly WavefrontMeshInput[] | WavefrontMeshInput
+): WavefrontMeshAcceleration;
+export function createWavefrontGpuMeshSource(
+  meshes?: readonly WavefrontMeshInput[] | WavefrontMeshInput
+): WavefrontGpuMeshSource;
+export function createWavefrontEmissiveTriangleIndexSource(
+  meshes?: readonly WavefrontMeshInput[] | WavefrontMeshInput,
+  capacity?: number
+): WavefrontEmissiveTriangleIndexSource;
+export function createWavefrontBvhBuildLevels(
+  triangleCount: number
+): readonly WavefrontBvhBuildLevel[];
+export function createWavefrontBvhSortStages(
+  itemCount: number
+): readonly WavefrontBvhSortStage[];
+export function createWavefrontPathTracingComputeConfig(
+  options?: CreateWavefrontPathTracingComputeRendererOptions
+): WavefrontPathTracingComputeConfig;
+export function packWavefrontSceneObjects(
+  sceneObjects: readonly WavefrontSceneObjectInput[],
+  capacity?: number
+): Readonly<{
+  buffer: ArrayBuffer;
+  objects: readonly WavefrontSceneObject[];
+  count: number;
+  capacity: number;
+}>;
+export function packWavefrontTriangles(
+  triangles: readonly WavefrontTriangleRecord[],
+  capacity?: number
+): Readonly<{
+  buffer: ArrayBuffer;
+  triangles: readonly WavefrontTriangleRecord[];
+  count: number;
+  capacity: number;
+}>;
+export function packWavefrontBvhNodes(
+  nodes: readonly WavefrontBvhNodeRecord[],
+  capacity?: number
+): Readonly<{
+  buffer: ArrayBuffer;
+  nodes: readonly WavefrontBvhNodeRecord[];
+  count: number;
+  capacity: number;
+}>;
+export function supportsWavefrontPathTracingCompute(options?: {
+  navigator?: Navigator | { gpu?: GPU };
+}): boolean;
+export function createWavefrontPathTracingComputeRenderer(
+  options?: CreateWavefrontPathTracingComputeRendererOptions
+): Promise<WavefrontPathTracingComputeRenderer>;
+
+export const wavefrontPathTracingComputeLimits: Readonly<{
+  workgroupSize: 64;
+  rayRecordBytes: 80;
+  hitRecordBytes: 192;
+  sceneObjectRecordBytes: 96;
+  meshVertexRecordBytes: 48;
+  meshRangeRecordBytes: 96;
+  triangleRecordBytes: 208;
+  bvhNodeRecordBytes: 48;
+  bvhLeafReferenceRecordBytes: 16;
+  accumulationRecordBytes: 16;
+}>;
+export const wavefrontSceneObjectKinds: Readonly<{
+  sphere: 1;
+  box: 2;
+}>;
+export const wavefrontMaterialKinds: Readonly<{
+  diffuse: 0;
+  metal: 1;
+  dielectric: 2;
+  transparent: 3;
+  emissive: 4;
+}>;
 
 export interface RendererFrameEvent {
   frame: number;

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,25 @@
 const DEFAULT_CLEAR_COLOR = Object.freeze([0.07, 0.11, 0.18, 1.0]);
 const DEFAULT_CANVAS_SELECTOR = "canvas[data-plasius-gpu-renderer]";
+export {
+  createDefaultWavefrontSceneObjects,
+  createWavefrontBvhBuildLevels,
+  createWavefrontBvhSortStages,
+  createWavefrontEmissiveTriangleIndexSource,
+  createWavefrontGpuMeshSource,
+  createWavefrontMeshAcceleration,
+  createWavefrontPathTracingComputeConfig,
+  createWavefrontPathTracingComputeRenderer,
+  estimateWavefrontPathTracingMemory,
+  normalizeWavefrontMesh,
+  normalizeWavefrontSceneObject,
+  packWavefrontBvhNodes,
+  packWavefrontSceneObjects,
+  packWavefrontTriangles,
+  supportsWavefrontPathTracingCompute,
+  wavefrontMaterialKinds,
+  wavefrontPathTracingComputeLimits,
+  wavefrontSceneObjectKinds,
+} from "./wavefront-compute.js";
 export const rendererDebugOwner = "renderer";
 export const rendererWorkerQueueClass = "render";
 export const defaultRendererWorkerProfile = "realtime";

--- a/src/wavefront-compute.js
+++ b/src/wavefront-compute.js
@@ -1,0 +1,3460 @@
+const DEFAULT_WIDTH = 1280;
+const DEFAULT_HEIGHT = 720;
+const DEFAULT_MAX_DEPTH = 6;
+const DEFAULT_TILE_SIZE = 128;
+const DEFAULT_SAMPLES_PER_PIXEL = 1;
+const DEFAULT_SCENE_OBJECT_CAPACITY = 128;
+const WORKGROUP_SIZE = 64;
+const RAY_RECORD_BYTES = 80;
+const HIT_RECORD_BYTES = 208;
+const SCENE_OBJECT_RECORD_BYTES = 96;
+const MESH_VERTEX_RECORD_BYTES = 48;
+const MESH_RANGE_RECORD_BYTES = 96;
+const TRIANGLE_RECORD_BYTES = 208;
+const BVH_NODE_RECORD_BYTES = 48;
+const BVH_LEAF_REF_RECORD_BYTES = 16;
+const EMISSIVE_TRIANGLE_INDEX_BYTES = 4;
+const ACCUMULATION_RECORD_BYTES = 16;
+const CONFIG_BUFFER_BYTES = 256;
+const COUNTER_BUFFER_BYTES = 16;
+const HIT_TYPE_SURFACE = 0;
+const HIT_TYPE_EMISSIVE = 1;
+const MATERIAL_DIFFUSE = 0;
+const MATERIAL_METAL = 1;
+const MATERIAL_DIELECTRIC = 2;
+const MATERIAL_TRANSPARENT = 3;
+const MATERIAL_EMISSIVE = 4;
+const OBJECT_KIND_SPHERE = 1;
+const OBJECT_KIND_BOX = 2;
+
+const DEFAULT_CAMERA = Object.freeze({
+  position: Object.freeze([0, 1.15, 5.6]),
+  target: Object.freeze([0, 0.65, 0]),
+  up: Object.freeze([0, 1, 0]),
+  fovYDegrees: 46,
+});
+
+const DEFAULT_ENVIRONMENT_COLOR = Object.freeze([0.35, 0.43, 0.49, 1]);
+const DEFAULT_AMBIENT_COLOR = Object.freeze([0.018, 0.022, 0.026, 1]);
+const DEFAULT_ENVIRONMENT_LIGHTING = Object.freeze({
+  horizonColor: Object.freeze([0.46, 0.56, 0.68, 1]),
+  zenithColor: Object.freeze([0.04, 0.08, 0.16, 1]),
+  sunDirection: Object.freeze([0.22, 0.88, 0.42]),
+  sunColor: Object.freeze([2.8, 2.65, 2.35, 1]),
+  intensity: 1,
+  mode: 0,
+  exposure: 1,
+});
+
+export const wavefrontPathTracingComputeLimits = Object.freeze({
+  workgroupSize: WORKGROUP_SIZE,
+  rayRecordBytes: RAY_RECORD_BYTES,
+  hitRecordBytes: HIT_RECORD_BYTES,
+  sceneObjectRecordBytes: SCENE_OBJECT_RECORD_BYTES,
+  meshVertexRecordBytes: MESH_VERTEX_RECORD_BYTES,
+  meshRangeRecordBytes: MESH_RANGE_RECORD_BYTES,
+  triangleRecordBytes: TRIANGLE_RECORD_BYTES,
+  bvhNodeRecordBytes: BVH_NODE_RECORD_BYTES,
+  bvhLeafReferenceRecordBytes: BVH_LEAF_REF_RECORD_BYTES,
+  emissiveTriangleIndexBytes: EMISSIVE_TRIANGLE_INDEX_BYTES,
+  emissiveTriangleMetadataRecordBytes: BVH_NODE_RECORD_BYTES,
+  accumulationRecordBytes: ACCUMULATION_RECORD_BYTES,
+});
+
+export const wavefrontSceneObjectKinds = Object.freeze({
+  sphere: OBJECT_KIND_SPHERE,
+  box: OBJECT_KIND_BOX,
+});
+
+export const wavefrontMaterialKinds = Object.freeze({
+  diffuse: MATERIAL_DIFFUSE,
+  metal: MATERIAL_METAL,
+  dielectric: MATERIAL_DIELECTRIC,
+  transparent: MATERIAL_TRANSPARENT,
+  emissive: MATERIAL_EMISSIVE,
+});
+
+function readPositiveInteger(name, value, fallback) {
+  if (value === undefined || value === null) {
+    return fallback;
+  }
+  const numeric = Number(value);
+  if (!Number.isInteger(numeric) || numeric <= 0) {
+    throw new Error(`${name} must be a positive integer.`);
+  }
+  return numeric;
+}
+
+function readNonNegativeInteger(name, value, fallback) {
+  if (value === undefined || value === null) {
+    return fallback;
+  }
+  const numeric = Number(value);
+  if (!Number.isInteger(numeric) || numeric < 0) {
+    throw new Error(`${name} must be a non-negative integer.`);
+  }
+  return numeric;
+}
+
+function readFiniteNumber(name, value, fallback) {
+  if (value === undefined || value === null) {
+    return fallback;
+  }
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) {
+    throw new Error(`${name} must be a finite number.`);
+  }
+  return numeric;
+}
+
+function assertAnalyticDisplayQualityPolicy(options = {}) {
+  const meshes = Array.isArray(options.meshes)
+    ? options.meshes
+    : options.mesh
+      ? [options.mesh]
+      : [];
+  if (options.displayQuality === true && meshes.length === 0) {
+    throw new Error(
+      "Display-quality path tracing requires mesh BVH triangle intersections. " +
+        "The analytic sphere/box wavefront renderer is debug-only."
+    );
+  }
+}
+
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value));
+}
+
+function asVec3(value, fallback) {
+  if (!Array.isArray(value) && !(ArrayBuffer.isView(value) && value.length >= 3)) {
+    return [...fallback];
+  }
+  return [
+    readFiniteNumber("vector[0]", value[0], fallback[0]),
+    readFiniteNumber("vector[1]", value[1], fallback[1]),
+    readFiniteNumber("vector[2]", value[2], fallback[2]),
+  ];
+}
+
+function asColor(value, fallback = [1, 1, 1, 1]) {
+  if (!Array.isArray(value) && !(ArrayBuffer.isView(value) && value.length >= 3)) {
+    return [...fallback];
+  }
+  return [
+    clamp(readFiniteNumber("color[0]", value[0], fallback[0]), 0, 64),
+    clamp(readFiniteNumber("color[1]", value[1], fallback[1]), 0, 64),
+    clamp(readFiniteNumber("color[2]", value[2], fallback[2]), 0, 64),
+    clamp(readFiniteNumber("color[3]", value[3], fallback[3] ?? 1), 0, 1),
+  ];
+}
+
+function emissionPower(emission) {
+  return Math.max(0, emission?.[0] ?? 0) + Math.max(0, emission?.[1] ?? 0) + Math.max(0, emission?.[2] ?? 0);
+}
+
+function asUnitVec3(value, fallback) {
+  const vector = asVec3(value, fallback);
+  return normalize(vector, fallback);
+}
+
+function add(a, b) {
+  return [a[0] + b[0], a[1] + b[1], a[2] + b[2]];
+}
+
+function subtract(a, b) {
+  return [a[0] - b[0], a[1] - b[1], a[2] - b[2]];
+}
+
+function scale(a, scalar) {
+  return [a[0] * scalar, a[1] * scalar, a[2] * scalar];
+}
+
+function dot(a, b) {
+  return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+}
+
+function cross(a, b) {
+  return [
+    a[1] * b[2] - a[2] * b[1],
+    a[2] * b[0] - a[0] * b[2],
+    a[0] * b[1] - a[1] * b[0],
+  ];
+}
+
+function normalize(value, fallback = [0, 0, 1]) {
+  const length = Math.hypot(value[0], value[1], value[2]);
+  if (!Number.isFinite(length) || length <= 0.000001) {
+    return [...fallback];
+  }
+  return [value[0] / length, value[1] / length, value[2] / length];
+}
+
+function getArrayLikeLength(value) {
+  return Array.isArray(value) || ArrayBuffer.isView(value) ? value.length : 0;
+}
+
+function readVector(values, index, componentCount, fallback) {
+  const offset = index * componentCount;
+  const output = [];
+  for (let component = 0; component < componentCount; component += 1) {
+    output.push(readFiniteNumber("mesh attribute", values?.[offset + component], fallback[component] ?? 0));
+  }
+  return output;
+}
+
+function readVector2(values, index, fallback = [0, 0]) {
+  return readVector(values, index, 2, fallback);
+}
+
+function triangleBounds(v0, v1, v2) {
+  return {
+    min: [
+      Math.min(v0[0], v1[0], v2[0]),
+      Math.min(v0[1], v1[1], v2[1]),
+      Math.min(v0[2], v1[2], v2[2]),
+    ],
+    max: [
+      Math.max(v0[0], v1[0], v2[0]),
+      Math.max(v0[1], v1[1], v2[1]),
+      Math.max(v0[2], v1[2], v2[2]),
+    ],
+  };
+}
+
+function mergeBounds(left, right) {
+  if (!left) {
+    return {
+      min: [...right.min],
+      max: [...right.max],
+    };
+  }
+  return {
+    min: [
+      Math.min(left.min[0], right.min[0]),
+      Math.min(left.min[1], right.min[1]),
+      Math.min(left.min[2], right.min[2]),
+    ],
+    max: [
+      Math.max(left.max[0], right.max[0]),
+      Math.max(left.max[1], right.max[1]),
+      Math.max(left.max[2], right.max[2]),
+    ],
+  };
+}
+
+function boundsCentroid(bounds) {
+  return [
+    (bounds.min[0] + bounds.max[0]) * 0.5,
+    (bounds.min[1] + bounds.max[1]) * 0.5,
+    (bounds.min[2] + bounds.max[2]) * 0.5,
+  ];
+}
+
+function readMaterialKind(value) {
+  if (typeof value === "number") {
+    return clamp(Math.trunc(value), MATERIAL_DIFFUSE, MATERIAL_EMISSIVE);
+  }
+  switch (value) {
+    case "metal":
+    case "reflective":
+      return MATERIAL_METAL;
+    case "dielectric":
+    case "refractive":
+    case "glass":
+      return MATERIAL_DIELECTRIC;
+    case "transparent":
+    case "transmission":
+      return MATERIAL_TRANSPARENT;
+    case "emissive":
+    case "light":
+      return MATERIAL_EMISSIVE;
+    case "diffuse":
+    default:
+      return MATERIAL_DIFFUSE;
+  }
+}
+
+function readObjectKind(value) {
+  if (typeof value === "number") {
+    return value === OBJECT_KIND_BOX ? OBJECT_KIND_BOX : OBJECT_KIND_SPHERE;
+  }
+  switch (value) {
+    case "box":
+    case "aabb":
+    case "bounds":
+      return OBJECT_KIND_BOX;
+    case "sphere":
+    default:
+      return OBJECT_KIND_SPHERE;
+  }
+}
+
+function deriveBounds(input) {
+  if (Array.isArray(input?.min) && Array.isArray(input?.max)) {
+    const min = asVec3(input.min, [-0.5, -0.5, -0.5]);
+    const max = asVec3(input.max, [0.5, 0.5, 0.5]);
+    return {
+      center: scale(add(min, max), 0.5),
+      halfExtent: scale(subtract(max, min), 0.5).map((value) => Math.max(value, 0.001)),
+    };
+  }
+
+  if (Array.isArray(input?.bounds?.min) && Array.isArray(input?.bounds?.max)) {
+    return deriveBounds(input.bounds);
+  }
+
+  return null;
+}
+
+export function normalizeWavefrontSceneObject(input = {}, index = 0) {
+  const bounds = deriveBounds(input);
+  const kind = readObjectKind(input.kind ?? input.type ?? (bounds ? "box" : "sphere"));
+  const center = asVec3(input.center ?? input.position ?? bounds?.center, [0, 0, 0]);
+  const radius = readFiniteNumber("radius", input.radius, 0.5);
+  const halfExtent =
+    kind === OBJECT_KIND_SPHERE
+      ? [Math.max(radius, 0.001), Math.max(radius, 0.001), Math.max(radius, 0.001)]
+      : asVec3(
+          input.halfExtent ?? input.halfExtents ?? input.extents ?? bounds?.halfExtent,
+          [0.5, 0.5, 0.5]
+        ).map((value) => Math.max(value, 0.001));
+  const materialKind = readMaterialKind(input.materialKind ?? input.material?.kind);
+  const color = asColor(
+    input.color ??
+      input.baseColor ??
+      input.albedo ??
+      input.material?.color ??
+      input.material?.baseColor,
+    [0.72, 0.72, 0.68, 1]
+  );
+  const emission = asColor(
+    input.emission ?? input.emissive ?? input.material?.emission ?? input.material?.emissive,
+    [0, 0, 0, 1]
+  );
+
+  return Object.freeze({
+    id: readNonNegativeInteger("id", input.id, index + 1),
+    kind,
+    materialKind:
+      emission[0] > 0 || emission[1] > 0 || emission[2] > 0
+        ? MATERIAL_EMISSIVE
+        : materialKind,
+    flags: readNonNegativeInteger("flags", input.flags, 0),
+    center: Object.freeze(center),
+    halfExtent: Object.freeze(halfExtent),
+    color: Object.freeze(color),
+    emission: Object.freeze(emission),
+    roughness: clamp(readFiniteNumber("roughness", input.roughness ?? input.material?.roughness, 0.72), 0, 1),
+    metallic: clamp(readFiniteNumber("metallic", input.metallic ?? input.material?.metallic, 0), 0, 1),
+    opacity: clamp(readFiniteNumber("opacity", input.opacity ?? input.material?.opacity, color[3] ?? 1), 0, 1),
+    ior: clamp(readFiniteNumber("ior", input.ior ?? input.material?.ior, 1.45), 1, 3),
+  });
+}
+
+export function createDefaultWavefrontSceneObjects() {
+  return Object.freeze([
+    normalizeWavefrontSceneObject({
+      type: "box",
+      id: 1,
+      center: [0, -0.08, 0],
+      halfExtent: [3.25, 0.08, 3.25],
+      color: [0.45, 0.53, 0.54, 1],
+      roughness: 0.5,
+    }),
+    normalizeWavefrontSceneObject({
+      type: "box",
+      id: 2,
+      center: [0, 1.25, -1.65],
+      halfExtent: [2.45, 1.45, 0.08],
+      color: [0.42, 0.41, 0.38, 1],
+      roughness: 0.85,
+    }),
+    normalizeWavefrontSceneObject({
+      type: "sphere",
+      id: 3,
+      center: [-0.9, 0.72, 0.05],
+      radius: 0.72,
+      color: [0.76, 0.72, 0.64, 1],
+      materialKind: "metal",
+      roughness: 0.08,
+      metallic: 0.7,
+    }),
+    normalizeWavefrontSceneObject({
+      type: "sphere",
+      id: 4,
+      center: [0.85, 0.65, -0.05],
+      radius: 0.58,
+      color: [0.68, 0.82, 0.86, 0.72],
+      materialKind: "dielectric",
+      roughness: 0.02,
+      opacity: 0.72,
+      ior: 1.35,
+    }),
+    normalizeWavefrontSceneObject({
+      type: "sphere",
+      id: 5,
+      center: [0, 2.55, -0.65],
+      radius: 0.34,
+      color: [1, 0.94, 0.78, 1],
+      emission: [7.2, 6.5, 4.2, 1],
+      materialKind: "emissive",
+    }),
+  ]);
+}
+
+export function normalizeWavefrontMesh(input = {}, meshIndex = 0) {
+  const positions = input.positions;
+  const positionLength = getArrayLikeLength(positions);
+  if (positionLength < 9 || positionLength % 3 !== 0) {
+    throw new Error("Wavefront mesh positions must contain at least three vec3 vertices.");
+  }
+
+  const vertexCount = positionLength / 3;
+  const indices =
+    getArrayLikeLength(input.indices) > 0
+      ? Array.from(input.indices, (value) => readNonNegativeInteger("mesh index", value, 0))
+      : Array.from({ length: vertexCount }, (_, index) => index);
+  if (indices.length < 3 || indices.length % 3 !== 0) {
+    throw new Error("Wavefront mesh indices must contain complete triangles.");
+  }
+  if (indices.some((index) => index >= vertexCount)) {
+    throw new Error("Wavefront mesh index references a vertex outside the position buffer.");
+  }
+
+  const normals =
+    getArrayLikeLength(input.normals) >= positionLength
+      ? Array.from(input.normals, (value) => readFiniteNumber("mesh normal", value, 0))
+      : null;
+  const uvs =
+    getArrayLikeLength(input.uvs ?? input.texcoords ?? input.uv) >= vertexCount * 2
+      ? Array.from(input.uvs ?? input.texcoords ?? input.uv, (value) =>
+          readFiniteNumber("mesh uv", value, 0)
+        )
+      : null;
+  const materialKind = readMaterialKind(input.materialKind ?? input.material?.kind);
+  const color = asColor(
+    input.color ??
+      input.baseColor ??
+      input.albedo ??
+      input.material?.color ??
+      input.material?.baseColor,
+    [0.72, 0.72, 0.68, 1]
+  );
+  const emission = asColor(
+    input.emission ?? input.emissive ?? input.material?.emission ?? input.material?.emissive,
+    [0, 0, 0, 1]
+  );
+
+  return Object.freeze({
+    id: readNonNegativeInteger("mesh id", input.id, meshIndex + 1),
+    positions: Object.freeze(Array.from(positions, (value) => readFiniteNumber("mesh position", value, 0))),
+    indices: Object.freeze(indices),
+    normals: normals ? Object.freeze(normals) : null,
+    uvs: uvs ? Object.freeze(uvs) : null,
+    materialKind:
+      emission[0] > 0 || emission[1] > 0 || emission[2] > 0
+        ? MATERIAL_EMISSIVE
+        : materialKind,
+    flags: readNonNegativeInteger("mesh flags", input.flags, 0),
+    materialRefId: readNonNegativeInteger(
+      "mesh materialRefId",
+      input.materialRefId ?? input.material?.id ?? input.materialId,
+      meshIndex
+    ),
+    mediumRefId: readNonNegativeInteger(
+      "mesh mediumRefId",
+      input.mediumRefId ?? input.medium?.id ?? input.mediumId,
+      0
+    ),
+    color: Object.freeze(color),
+    emission: Object.freeze(emission),
+    roughness: clamp(readFiniteNumber("roughness", input.roughness ?? input.material?.roughness, 0.72), 0, 1),
+    metallic: clamp(readFiniteNumber("metallic", input.metallic ?? input.material?.metallic, 0), 0, 1),
+    opacity: clamp(readFiniteNumber("opacity", input.opacity ?? input.material?.opacity, color[3] ?? 1), 0, 1),
+    ior: clamp(readFiniteNumber("ior", input.ior ?? input.material?.ior, 1.45), 1, 3),
+  });
+}
+
+function createMeshTriangleRecords(meshes) {
+  const source = Array.isArray(meshes) ? meshes : [];
+  let nextTriangleId = 0;
+  return source.flatMap((meshInput, meshIndex) => {
+    const mesh = normalizeWavefrontMesh(meshInput, meshIndex);
+    const triangles = [];
+    for (let index = 0; index < mesh.indices.length; index += 3) {
+      const a = mesh.indices[index];
+      const b = mesh.indices[index + 1];
+      const c = mesh.indices[index + 2];
+      const v0 = readVector(mesh.positions, a, 3, [0, 0, 0]);
+      const v1 = readVector(mesh.positions, b, 3, [0, 0, 0]);
+      const v2 = readVector(mesh.positions, c, 3, [0, 0, 0]);
+      const faceNormal = normalize(cross(subtract(v1, v0), subtract(v2, v0)), [0, 1, 0]);
+      const n0 = mesh.normals ? normalize(readVector(mesh.normals, a, 3, faceNormal), faceNormal) : faceNormal;
+      const n1 = mesh.normals ? normalize(readVector(mesh.normals, b, 3, faceNormal), faceNormal) : faceNormal;
+      const n2 = mesh.normals ? normalize(readVector(mesh.normals, c, 3, faceNormal), faceNormal) : faceNormal;
+      const uv0 = mesh.uvs ? readVector2(mesh.uvs, a) : [0, 0];
+      const uv1 = mesh.uvs ? readVector2(mesh.uvs, b) : [0, 0];
+      const uv2 = mesh.uvs ? readVector2(mesh.uvs, c) : [0, 0];
+      const bounds = triangleBounds(v0, v1, v2);
+
+      triangles.push(
+        Object.freeze({
+          triangleId: nextTriangleId,
+          meshId: mesh.id,
+          materialKind: mesh.materialKind,
+          flags: mesh.flags,
+          materialRefId: mesh.materialRefId,
+          mediumRefId: mesh.mediumRefId,
+          v0: Object.freeze(v0),
+          v1: Object.freeze(v1),
+          v2: Object.freeze(v2),
+          n0: Object.freeze(n0),
+          n1: Object.freeze(n1),
+          n2: Object.freeze(n2),
+          uv0: Object.freeze(uv0),
+          uv1: Object.freeze(uv1),
+          uv2: Object.freeze(uv2),
+          color: mesh.color,
+          emission: mesh.emission,
+          material: Object.freeze([mesh.roughness, mesh.metallic, mesh.opacity, mesh.ior]),
+          bounds: Object.freeze({
+            min: Object.freeze(bounds.min),
+            max: Object.freeze(bounds.max),
+          }),
+          centroid: Object.freeze(boundsCentroid(bounds)),
+        })
+      );
+      nextTriangleId += 1;
+    }
+    return triangles;
+  });
+}
+
+function chooseSplitAxis(triangles) {
+  const centroidBounds = triangles.reduce(
+    (bounds, triangle) => {
+      const pointBounds = { min: triangle.centroid, max: triangle.centroid };
+      return mergeBounds(bounds, pointBounds);
+    },
+    null
+  );
+  const extent = subtract(centroidBounds.max, centroidBounds.min);
+  if (extent[0] >= extent[1] && extent[0] >= extent[2]) {
+    return 0;
+  }
+  return extent[1] >= extent[2] ? 1 : 2;
+}
+
+function buildBvh(triangles, maxLeafTriangles = 4) {
+  if (triangles.length === 0) {
+    return Object.freeze({ nodes: Object.freeze([]), triangles: Object.freeze([]) });
+  }
+
+  const nodes = [];
+  const orderedTriangles = [];
+
+  function buildNode(nodeTriangles) {
+    const nodeIndex = nodes.length;
+    nodes.push(null);
+    const bounds = nodeTriangles.reduce((current, triangle) => mergeBounds(current, triangle.bounds), null);
+
+    if (nodeTriangles.length <= maxLeafTriangles) {
+      const firstTriangle = orderedTriangles.length;
+      orderedTriangles.push(...nodeTriangles);
+      nodes[nodeIndex] = Object.freeze({
+        bounds: Object.freeze({
+          min: Object.freeze(bounds.min),
+          max: Object.freeze(bounds.max),
+        }),
+        firstTriangle,
+        triangleCount: nodeTriangles.length,
+        leftChild: 0,
+        rightChild: 0,
+      });
+      return nodeIndex;
+    }
+
+    const axis = chooseSplitAxis(nodeTriangles);
+    const sorted = [...nodeTriangles].sort((left, right) => left.centroid[axis] - right.centroid[axis]);
+    const midpoint = Math.max(1, Math.floor(sorted.length / 2));
+    const leftChild = buildNode(sorted.slice(0, midpoint));
+    const rightChild = buildNode(sorted.slice(midpoint));
+    nodes[nodeIndex] = Object.freeze({
+      bounds: Object.freeze({
+        min: Object.freeze(bounds.min),
+        max: Object.freeze(bounds.max),
+      }),
+      firstTriangle: leftChild,
+      triangleCount: 0,
+      leftChild,
+      rightChild,
+    });
+    return nodeIndex;
+  }
+
+  buildNode(triangles);
+  return Object.freeze({
+    nodes: Object.freeze(nodes),
+    triangles: Object.freeze(orderedTriangles),
+  });
+}
+
+export function createWavefrontMeshAcceleration(meshes = []) {
+  const source = Array.isArray(meshes) ? meshes : [meshes];
+  const triangles = createMeshTriangleRecords(source);
+  return buildBvh(triangles);
+}
+
+function estimateMeshSourceShape(meshes) {
+  const source = Array.isArray(meshes) ? meshes : [];
+  return source.reduce(
+    (shape, meshInput, meshIndex) => {
+      const mesh = normalizeWavefrontMesh(meshInput, meshIndex);
+      return {
+        vertexCount: shape.vertexCount + mesh.positions.length / 3,
+        indexCount: shape.indexCount + mesh.indices.length,
+        meshCount: shape.meshCount + 1,
+        triangleCount: shape.triangleCount + mesh.indices.length / 3,
+      };
+    },
+    {
+      vertexCount: 0,
+      indexCount: 0,
+      meshCount: 0,
+      triangleCount: 0,
+    }
+  );
+}
+
+function estimateBinaryBvhNodeCapacity(triangleCount) {
+  return triangleCount <= 0 ? 0 : Math.max(1, triangleCount * 2 - 1);
+}
+
+function nextPowerOfTwo(value) {
+  if (value <= 1) {
+    return Math.max(0, value);
+  }
+  return 2 ** Math.ceil(Math.log2(value));
+}
+
+function estimateBvhLeafSortCapacity(triangleCount) {
+  return triangleCount <= 0 ? 0 : nextPowerOfTwo(triangleCount);
+}
+
+export function createWavefrontBvhSortStages(itemCountInput) {
+  const itemCount = readNonNegativeInteger("itemCount", itemCountInput, 0);
+  const sortCount = estimateBvhLeafSortCapacity(itemCount);
+  if (sortCount <= 1) {
+    return Object.freeze([]);
+  }
+
+  const stages = [];
+  for (let sequenceSize = 2; sequenceSize <= sortCount; sequenceSize *= 2) {
+    for (
+      let compareDistance = sequenceSize / 2;
+      compareDistance >= 1;
+      compareDistance /= 2
+    ) {
+      stages.push(
+        Object.freeze({
+          compareDistance,
+          sequenceSize,
+        })
+      );
+    }
+  }
+
+  return Object.freeze(stages);
+}
+
+export function createWavefrontBvhBuildLevels(triangleCountInput) {
+  const triangleCount = readNonNegativeInteger("triangleCount", triangleCountInput, 0);
+  const internalCount = Math.max(0, triangleCount - 1);
+  if (internalCount === 0) {
+    return Object.freeze([]);
+  }
+
+  const levels = [];
+  let depth = 0;
+  while (Math.pow(2, depth) - 1 < internalCount) {
+    depth += 1;
+  }
+
+  for (let level = depth - 1; level >= 0; level -= 1) {
+    const start = Math.pow(2, level) - 1;
+    const end = Math.min(Math.pow(2, level + 1) - 2, internalCount - 1);
+    if (end >= start) {
+      levels.push(
+        Object.freeze({
+          start,
+          count: end - start + 1,
+        })
+      );
+    }
+  }
+
+  return Object.freeze(levels);
+}
+
+function resolveAccelerationBuildMode(options = {}) {
+  const mode = options.accelerationBuildMode ?? (options.displayQuality === true ? "gpu" : "cpu-debug");
+  if (mode !== "gpu" && mode !== "cpu-debug") {
+    throw new Error("accelerationBuildMode must be either \"gpu\" or \"cpu-debug\".");
+  }
+  if (options.displayQuality === true && mode !== "gpu") {
+    throw new Error("Display-quality path tracing requires GPU-built mesh acceleration.");
+  }
+  return mode;
+}
+
+export function createWavefrontGpuMeshSource(meshes = []) {
+  const source = Array.isArray(meshes) ? meshes : [meshes];
+  const normalized = source.map((meshInput, meshIndex) => normalizeWavefrontMesh(meshInput, meshIndex));
+  const vertexCount = normalized.reduce((count, mesh) => count + mesh.positions.length / 3, 0);
+  const indexCount = normalized.reduce((count, mesh) => count + mesh.indices.length, 0);
+  const triangleCount = Math.floor(indexCount / 3);
+  const vertexBytes = new ArrayBuffer(Math.max(1, vertexCount) * MESH_VERTEX_RECORD_BYTES);
+  const indexBytes = new ArrayBuffer(Math.max(1, indexCount) * 4);
+  const meshBytes = new ArrayBuffer(Math.max(1, normalized.length) * MESH_RANGE_RECORD_BYTES);
+  const vertexFloats = new Float32Array(vertexBytes);
+  const indexUints = new Uint32Array(indexBytes);
+  const meshUints = new Uint32Array(meshBytes);
+  const meshFloats = new Float32Array(meshBytes);
+
+  let vertexCursor = 0;
+  let indexCursor = 0;
+  let triangleCursor = 0;
+
+  normalized.forEach((mesh, meshIndex) => {
+    const meshVertexBase = vertexCursor;
+    const meshIndexBase = indexCursor;
+    const meshTriangleBase = triangleCursor;
+    const meshVertexCount = mesh.positions.length / 3;
+
+    for (let vertexIndex = 0; vertexIndex < meshVertexCount; vertexIndex += 1) {
+      const recordOffset = (vertexCursor + vertexIndex) * (MESH_VERTEX_RECORD_BYTES / 4);
+      const position = readVector(mesh.positions, vertexIndex, 3, [0, 0, 0]);
+      const normal = mesh.normals ? readVector(mesh.normals, vertexIndex, 3, [0, 0, 0]) : [0, 0, 0];
+      const uv = mesh.uvs ? readVector2(mesh.uvs, vertexIndex) : [0, 0];
+      vertexFloats[recordOffset] = position[0];
+      vertexFloats[recordOffset + 1] = position[1];
+      vertexFloats[recordOffset + 2] = position[2];
+      vertexFloats[recordOffset + 3] = 1;
+      vertexFloats[recordOffset + 4] = normal[0];
+      vertexFloats[recordOffset + 5] = normal[1];
+      vertexFloats[recordOffset + 6] = normal[2];
+      vertexFloats[recordOffset + 7] = mesh.normals ? 1 : 0;
+      vertexFloats[recordOffset + 8] = uv[0];
+      vertexFloats[recordOffset + 9] = uv[1];
+      vertexFloats[recordOffset + 10] = mesh.uvs ? 1 : 0;
+      vertexFloats[recordOffset + 11] = 0;
+    }
+
+    mesh.indices.forEach((indexValue, localIndex) => {
+      indexUints[indexCursor + localIndex] = meshVertexBase + indexValue;
+    });
+
+    const meshOffset = meshIndex * (MESH_RANGE_RECORD_BYTES / 4);
+    meshUints[meshOffset] = mesh.id;
+    meshUints[meshOffset + 1] = mesh.materialKind;
+    meshUints[meshOffset + 2] = mesh.flags;
+    meshUints[meshOffset + 3] = mesh.materialRefId;
+    meshUints[meshOffset + 4] = mesh.mediumRefId;
+    meshUints[meshOffset + 5] = meshIndexBase;
+    meshUints[meshOffset + 6] = mesh.indices.length;
+    meshUints[meshOffset + 7] = meshTriangleBase;
+    meshUints[meshOffset + 8] = mesh.indices.length / 3;
+    meshUints[meshOffset + 9] = meshVertexBase;
+    meshUints[meshOffset + 10] = meshVertexCount;
+    meshUints[meshOffset + 11] = 0;
+    const floatOffset = meshOffset;
+    writeVec4(meshFloats, floatOffset * 4 + 48, mesh.color);
+    writeVec4(meshFloats, floatOffset * 4 + 64, mesh.emission);
+    writeVec4(meshFloats, floatOffset * 4 + 80, [
+      mesh.roughness,
+      mesh.metallic,
+      mesh.opacity,
+      mesh.ior,
+    ]);
+
+    vertexCursor += meshVertexCount;
+    indexCursor += mesh.indices.length;
+    triangleCursor += mesh.indices.length / 3;
+  });
+
+  return Object.freeze({
+    vertices: Object.freeze({
+      buffer: vertexBytes,
+      count: vertexCount,
+      recordBytes: MESH_VERTEX_RECORD_BYTES,
+    }),
+    indices: Object.freeze({
+      buffer: indexBytes,
+      count: indexCount,
+      recordBytes: 4,
+    }),
+    meshes: Object.freeze({
+      buffer: meshBytes,
+      records: Object.freeze(normalized),
+      count: normalized.length,
+      recordBytes: MESH_RANGE_RECORD_BYTES,
+    }),
+    triangleCount,
+    bvhNodeCapacity: estimateBinaryBvhNodeCapacity(triangleCount),
+  });
+}
+
+export function createWavefrontEmissiveTriangleIndexSource(meshes = [], capacityInput) {
+  const source = Array.isArray(meshes) ? meshes : [meshes];
+  const normalized = source.map((meshInput, meshIndex) => normalizeWavefrontMesh(meshInput, meshIndex));
+  const indices = [];
+  let triangleCursor = 0;
+
+  normalized.forEach((mesh) => {
+    const triangleCount = Math.floor(mesh.indices.length / 3);
+    const isEmissive =
+      mesh.materialKind === MATERIAL_EMISSIVE || emissionPower(mesh.emission) > 0.0001;
+    if (isEmissive) {
+      for (let triangleOffset = 0; triangleOffset < triangleCount; triangleOffset += 1) {
+        indices.push(triangleCursor + triangleOffset);
+      }
+    }
+    triangleCursor += triangleCount;
+  });
+
+  const capacity = Math.max(
+    indices.length,
+    readNonNegativeInteger("emissiveTriangleCapacity", capacityInput, indices.length)
+  );
+  const bytes = new ArrayBuffer(capacity * EMISSIVE_TRIANGLE_INDEX_BYTES);
+  const uints = new Uint32Array(bytes);
+  uints.fill(0xffffffff);
+  indices.forEach((triangleIndex, index) => {
+    uints[index] = triangleIndex;
+  });
+
+  return Object.freeze({
+    buffer: bytes,
+    indices: Object.freeze(indices),
+    count: indices.length,
+    capacity,
+    recordBytes: EMISSIVE_TRIANGLE_INDEX_BYTES,
+  });
+}
+
+function normalizeSceneObjects(sceneObjects, useDefaultScene = true) {
+  const source =
+    Array.isArray(sceneObjects) && sceneObjects.length > 0
+      ? sceneObjects
+      : useDefaultScene
+        ? createDefaultWavefrontSceneObjects()
+        : [];
+  return source.map((object, index) => normalizeWavefrontSceneObject(object, index));
+}
+
+function normalizeMeshes(options = {}) {
+  if (Array.isArray(options.meshes)) {
+    return options.meshes;
+  }
+  if (options.mesh) {
+    return [options.mesh];
+  }
+  return [];
+}
+
+function resolveEnvironmentLighting(input, environmentColor, ambientColor) {
+  const source = input ?? {};
+  return Object.freeze({
+    environmentColor: Object.freeze(asColor(source.environmentColor, environmentColor)),
+    ambientColor: Object.freeze(asColor(source.ambientColor, ambientColor)),
+    horizonColor: Object.freeze(asColor(source.horizonColor, environmentColor)),
+    zenithColor: Object.freeze(asColor(source.zenithColor, DEFAULT_ENVIRONMENT_LIGHTING.zenithColor)),
+    sunDirection: Object.freeze(asUnitVec3(source.sunDirection, DEFAULT_ENVIRONMENT_LIGHTING.sunDirection)),
+    sunColor: Object.freeze(asColor(source.sunColor, DEFAULT_ENVIRONMENT_LIGHTING.sunColor)),
+    intensity: Math.max(0.0001, readFiniteNumber("environmentLighting.intensity", source.intensity, DEFAULT_ENVIRONMENT_LIGHTING.intensity)),
+    mode: readNonNegativeInteger("environmentLighting.mode", source.mode, DEFAULT_ENVIRONMENT_LIGHTING.mode),
+    exposure: Math.max(0.0001, readFiniteNumber("environmentLighting.exposure", source.exposure, DEFAULT_ENVIRONMENT_LIGHTING.exposure)),
+  });
+}
+
+function getCanvasDimension(canvas, key, fallback) {
+  const value = Number(canvas?.[key]);
+  if (Number.isFinite(value) && value > 0) {
+    return Math.trunc(value);
+  }
+  return fallback;
+}
+
+function resolveCamera(input, width, height) {
+  const camera = input ?? DEFAULT_CAMERA;
+  const position = asVec3(camera.position, DEFAULT_CAMERA.position);
+  const target = asVec3(camera.target, DEFAULT_CAMERA.target);
+  const upInput = normalize(asVec3(camera.up, DEFAULT_CAMERA.up), DEFAULT_CAMERA.up);
+  const forward = normalize(subtract(target, position), [0, 0, -1]);
+  const right = normalize(cross(forward, upInput), [1, 0, 0]);
+  const up = normalize(cross(right, forward), [0, 1, 0]);
+  const fovYDegrees = clamp(
+    readFiniteNumber("camera.fovYDegrees", camera.fovYDegrees ?? camera.fov, DEFAULT_CAMERA.fovYDegrees),
+    10,
+    120
+  );
+  const aspect = width / Math.max(1, height);
+  const tanHalfFovY = Math.tan((fovYDegrees * Math.PI) / 360);
+
+  return Object.freeze({
+    position: Object.freeze(position),
+    forward: Object.freeze(forward),
+    right: Object.freeze(right),
+    up: Object.freeze(up),
+    fovYDegrees,
+    aspect,
+    tanHalfFovY,
+  });
+}
+
+export function estimateWavefrontPathTracingMemory(options = {}) {
+  const tilePixelCapacity = readPositiveInteger(
+    "tilePixelCapacity",
+    options.tilePixelCapacity,
+    DEFAULT_TILE_SIZE * DEFAULT_TILE_SIZE
+  );
+  const sceneObjectCapacity = readPositiveInteger(
+    "sceneObjectCapacity",
+    options.sceneObjectCapacity,
+    DEFAULT_SCENE_OBJECT_CAPACITY
+  );
+  const triangleCapacity = readNonNegativeInteger("triangleCapacity", options.triangleCapacity, 0);
+  const bvhNodeCapacity = readNonNegativeInteger("bvhNodeCapacity", options.bvhNodeCapacity, 0);
+  const bvhLeafSortCapacity = readNonNegativeInteger(
+    "bvhLeafSortCapacity",
+    options.bvhLeafSortCapacity,
+    0
+  );
+  const emissiveTriangleCapacity = readNonNegativeInteger(
+    "emissiveTriangleCapacity",
+    options.emissiveTriangleCapacity,
+    0
+  );
+  const queueBytes = tilePixelCapacity * RAY_RECORD_BYTES;
+  const hitBytes = tilePixelCapacity * HIT_RECORD_BYTES;
+  const accumulationBytes = tilePixelCapacity * ACCUMULATION_RECORD_BYTES;
+  const sceneObjectBytes = sceneObjectCapacity * SCENE_OBJECT_RECORD_BYTES;
+  const triangleBytes = triangleCapacity * TRIANGLE_RECORD_BYTES;
+  const bvhNodeBytes = bvhNodeCapacity * BVH_NODE_RECORD_BYTES;
+  const bvhLeafReferenceBytes = bvhLeafSortCapacity * BVH_LEAF_REF_RECORD_BYTES;
+  const emissiveTriangleMetadataBytes =
+    emissiveTriangleCapacity * BVH_NODE_RECORD_BYTES;
+
+  return Object.freeze({
+    queueBytes,
+    queuePairBytes: queueBytes * 2,
+    hitBytes,
+    accumulationBytes,
+    sceneObjectBytes,
+    triangleBytes,
+    bvhNodeBytes,
+    bvhLeafReferenceBytes,
+    emissiveTriangleMetadataBytes,
+    configBytes: CONFIG_BUFFER_BYTES,
+    counterBytes: COUNTER_BUFFER_BYTES,
+    totalHotBufferBytes:
+      queueBytes * 2 +
+      hitBytes +
+      accumulationBytes +
+      sceneObjectBytes +
+      triangleBytes +
+      bvhNodeBytes +
+      bvhLeafReferenceBytes +
+      emissiveTriangleMetadataBytes +
+      CONFIG_BUFFER_BYTES +
+      COUNTER_BUFFER_BYTES,
+  });
+}
+
+export function createWavefrontPathTracingComputeConfig(options = {}) {
+  assertAnalyticDisplayQualityPolicy(options);
+  const accelerationBuildMode = resolveAccelerationBuildMode(options);
+  const canvas = options.canvas;
+  const width = readPositiveInteger("width", options.width, getCanvasDimension(canvas, "width", DEFAULT_WIDTH));
+  const height = readPositiveInteger("height", options.height, getCanvasDimension(canvas, "height", DEFAULT_HEIGHT));
+  const maxDepth = clamp(readPositiveInteger("maxDepth", options.maxDepth, DEFAULT_MAX_DEPTH), 1, 16);
+  const tileSize = clamp(readPositiveInteger("tileSize", options.tileSize, DEFAULT_TILE_SIZE), 16, 512);
+  const samplesPerPixel = clamp(
+    readPositiveInteger("samplesPerPixel", options.samplesPerPixel, DEFAULT_SAMPLES_PER_PIXEL),
+    1,
+    64
+  );
+  const tilePixelCapacity = readPositiveInteger(
+    "tilePixelCapacity",
+    options.tilePixelCapacity,
+    tileSize * tileSize
+  );
+  const meshes = normalizeMeshes(options);
+  const meshSourceShape = estimateMeshSourceShape(meshes);
+  const gpuMeshSource =
+    meshes.length > 0
+      ? createWavefrontGpuMeshSource(meshes)
+      : createWavefrontGpuMeshSource([]);
+  const meshAcceleration =
+    accelerationBuildMode === "cpu-debug"
+      ? createWavefrontMeshAcceleration(meshes)
+      : Object.freeze({ nodes: Object.freeze([]), triangles: Object.freeze([]) });
+  const emissiveTriangleIndices = createWavefrontEmissiveTriangleIndexSource(
+    meshes,
+    options.emissiveTriangleCapacity
+  );
+  const triangleCount =
+    accelerationBuildMode === "gpu"
+      ? meshSourceShape.triangleCount
+      : meshAcceleration.triangles.length;
+  const bvhNodeCount =
+    accelerationBuildMode === "gpu"
+      ? estimateBinaryBvhNodeCapacity(triangleCount)
+      : meshAcceleration.nodes.length;
+  const sceneObjects = Object.freeze(
+    normalizeSceneObjects(options.sceneObjects, meshes.length === 0)
+  );
+  const sceneObjectCapacity = Math.max(
+    sceneObjects.length,
+    readPositiveInteger("sceneObjectCapacity", options.sceneObjectCapacity, DEFAULT_SCENE_OBJECT_CAPACITY)
+  );
+  const triangleCapacity = Math.max(
+    triangleCount,
+    readNonNegativeInteger("triangleCapacity", options.triangleCapacity, triangleCount)
+  );
+  const bvhNodeCapacity = Math.max(
+    accelerationBuildMode === "gpu" ? estimateBinaryBvhNodeCapacity(triangleCount) : bvhNodeCount,
+    readNonNegativeInteger(
+      "bvhNodeCapacity",
+      options.bvhNodeCapacity,
+      accelerationBuildMode === "gpu" ? estimateBinaryBvhNodeCapacity(triangleCount) : bvhNodeCount
+    )
+  );
+  const bvhLeafSortCapacity =
+    accelerationBuildMode === "gpu" ? estimateBvhLeafSortCapacity(triangleCount) : 0;
+  const bvhSortStages =
+    accelerationBuildMode === "gpu"
+      ? createWavefrontBvhSortStages(triangleCount)
+      : Object.freeze([]);
+  const bvhBuildLevels =
+    accelerationBuildMode === "gpu"
+      ? createWavefrontBvhBuildLevels(triangleCount)
+      : Object.freeze([]);
+  const camera = resolveCamera(options.camera, width, height);
+  const environmentColor = Object.freeze(asColor(options.environmentColor, DEFAULT_ENVIRONMENT_COLOR));
+  const ambientColor = Object.freeze(asColor(options.ambientColor, DEFAULT_AMBIENT_COLOR));
+  const environmentLighting = resolveEnvironmentLighting(
+    options.environmentLighting,
+    environmentColor,
+    ambientColor
+  );
+
+  return Object.freeze({
+    width,
+    height,
+    maxDepth,
+    tileSize,
+    samplesPerPixel,
+    tilePixelCapacity,
+    sceneObjects,
+    sceneObjectCount: sceneObjects.length,
+    sceneObjectCapacity,
+    accelerationBuildMode,
+    gpuAccelerationBuildRequired: accelerationBuildMode === "gpu" && triangleCount > 0,
+    gpuMeshSource,
+    meshAcceleration,
+    emissiveTriangleIndices,
+    emissiveTriangleCount: emissiveTriangleIndices.count,
+    emissiveTriangleCapacity: emissiveTriangleIndices.capacity,
+    triangleCount,
+    triangleCapacity,
+    bvhNodeCount,
+    bvhNodeCapacity,
+    bvhLeafSortCapacity,
+    bvhSortStages,
+    bvhBuildLevels,
+    camera,
+    environmentColor: environmentLighting.environmentColor,
+    ambientColor: environmentLighting.ambientColor,
+    environmentLighting,
+    displayQuality: options.displayQuality === true,
+    requiresMeshBvhForDisplayQuality: true,
+    denoise: options.denoise !== false,
+    frameIndex: readNonNegativeInteger("frameIndex", options.frameIndex, 0),
+    memory: estimateWavefrontPathTracingMemory({
+      tilePixelCapacity,
+      sceneObjectCapacity,
+      triangleCapacity,
+      bvhNodeCapacity,
+      bvhLeafSortCapacity,
+      emissiveTriangleCapacity: emissiveTriangleIndices.capacity,
+    }),
+  });
+}
+
+export function supportsWavefrontPathTracingCompute(options = {}) {
+  const navigatorRef = options.navigator ?? globalThis.navigator;
+  return typeof navigatorRef?.gpu?.requestAdapter === "function";
+}
+
+function getGpuUsageConstants() {
+  if (
+    typeof GPUBufferUsage === "undefined" ||
+    typeof GPUTextureUsage === "undefined" ||
+    typeof GPUShaderStage === "undefined"
+  ) {
+    throw new Error("WebGPU runtime unavailable. Required GPU constants are missing.");
+  }
+
+  return {
+    buffer: GPUBufferUsage,
+    texture: GPUTextureUsage,
+    shader: GPUShaderStage,
+    map: typeof GPUMapMode === "undefined" ? null : GPUMapMode,
+  };
+}
+
+function resolveCanvas(canvasOrSelector, documentRef = globalThis.document) {
+  if (typeof canvasOrSelector === "string") {
+    const resolved = documentRef?.querySelector?.(canvasOrSelector);
+    if (!resolved) {
+      throw new Error(`Unable to find canvas for selector: ${canvasOrSelector}`);
+    }
+    return resolved;
+  }
+
+  if (canvasOrSelector?.getContext) {
+    return canvasOrSelector;
+  }
+
+  const fallback = documentRef?.querySelector?.("canvas[data-plasius-wavefront-path-tracing]");
+  if (!fallback) {
+    throw new Error("A canvas is required for WebGPU wavefront path tracing.");
+  }
+  return fallback;
+}
+
+function writeVec4(floatView, byteOffset, value) {
+  const index = byteOffset / 4;
+  floatView[index] = value[0] ?? 0;
+  floatView[index + 1] = value[1] ?? 0;
+  floatView[index + 2] = value[2] ?? 0;
+  floatView[index + 3] = value[3] ?? 0;
+}
+
+export function packWavefrontSceneObjects(sceneObjects, capacity = sceneObjects.length) {
+  const normalized =
+    Array.isArray(sceneObjects) && sceneObjects.length === 0
+      ? []
+      : normalizeSceneObjects(sceneObjects);
+  if (normalized.length > capacity) {
+    throw new Error(
+      `Scene object capacity ${capacity} is too small for ${normalized.length} objects.`
+    );
+  }
+
+  const bytes = new ArrayBuffer(Math.max(1, capacity) * SCENE_OBJECT_RECORD_BYTES);
+  const uintView = new Uint32Array(bytes);
+  const floatView = new Float32Array(bytes);
+
+  normalized.forEach((object, index) => {
+    const byteOffset = index * SCENE_OBJECT_RECORD_BYTES;
+    const u32 = byteOffset / 4;
+    uintView[u32] = object.kind;
+    uintView[u32 + 1] = object.id;
+    uintView[u32 + 2] = object.materialKind;
+    uintView[u32 + 3] = object.flags;
+    writeVec4(floatView, byteOffset + 16, [...object.center, 0]);
+    writeVec4(floatView, byteOffset + 32, [...object.halfExtent, 0]);
+    writeVec4(floatView, byteOffset + 48, object.color);
+    writeVec4(floatView, byteOffset + 64, object.emission);
+    writeVec4(floatView, byteOffset + 80, [
+      object.roughness,
+      object.metallic,
+      object.opacity,
+      object.ior,
+    ]);
+  });
+
+  return Object.freeze({
+    buffer: bytes,
+    objects: Object.freeze(normalized),
+    count: normalized.length,
+    capacity,
+  });
+}
+
+export function packWavefrontTriangles(triangles, capacity = triangles.length) {
+  if (triangles.length > capacity) {
+    throw new Error(`Triangle capacity ${capacity} is too small for ${triangles.length} triangles.`);
+  }
+
+  const bytes = new ArrayBuffer(Math.max(1, capacity) * TRIANGLE_RECORD_BYTES);
+  const uintView = new Uint32Array(bytes);
+  const floatView = new Float32Array(bytes);
+
+  triangles.forEach((triangle, index) => {
+    const byteOffset = index * TRIANGLE_RECORD_BYTES;
+    const u32 = byteOffset / 4;
+    uintView[u32] = triangle.triangleId;
+    uintView[u32 + 1] = triangle.meshId;
+    uintView[u32 + 2] = triangle.materialKind;
+    uintView[u32 + 3] = triangle.flags;
+    uintView[u32 + 4] = triangle.materialRefId;
+    uintView[u32 + 5] = triangle.mediumRefId;
+    uintView[u32 + 6] = 0;
+    uintView[u32 + 7] = 0;
+    writeVec4(floatView, byteOffset + 32, [...triangle.v0, 0]);
+    writeVec4(floatView, byteOffset + 48, [...triangle.v1, 0]);
+    writeVec4(floatView, byteOffset + 64, [...triangle.v2, 0]);
+    writeVec4(floatView, byteOffset + 80, [...triangle.n0, 0]);
+    writeVec4(floatView, byteOffset + 96, [...triangle.n1, 0]);
+    writeVec4(floatView, byteOffset + 112, [...triangle.n2, 0]);
+    writeVec4(floatView, byteOffset + 128, [...triangle.uv0, ...triangle.uv1]);
+    writeVec4(floatView, byteOffset + 144, [...triangle.uv2, 0, 0]);
+    writeVec4(floatView, byteOffset + 160, triangle.color);
+    writeVec4(floatView, byteOffset + 176, triangle.emission);
+    writeVec4(floatView, byteOffset + 192, triangle.material);
+  });
+
+  return Object.freeze({
+    buffer: bytes,
+    triangles: Object.freeze(triangles),
+    count: triangles.length,
+    capacity,
+  });
+}
+
+export function packWavefrontBvhNodes(nodes, capacity = nodes.length) {
+  if (nodes.length > capacity) {
+    throw new Error(`BVH node capacity ${capacity} is too small for ${nodes.length} nodes.`);
+  }
+
+  const bytes = new ArrayBuffer(Math.max(1, capacity) * BVH_NODE_RECORD_BYTES);
+  const uintView = new Uint32Array(bytes);
+  const floatView = new Float32Array(bytes);
+
+  nodes.forEach((node, index) => {
+    const byteOffset = index * BVH_NODE_RECORD_BYTES;
+    const u32 = byteOffset / 4;
+    writeVec4(floatView, byteOffset, [...node.bounds.min, 0]);
+    writeVec4(floatView, byteOffset + 16, [...node.bounds.max, 0]);
+    uintView[u32 + 8] = node.triangleCount > 0 ? node.firstTriangle : node.leftChild;
+    uintView[u32 + 9] = node.triangleCount;
+    uintView[u32 + 10] = node.rightChild;
+    uintView[u32 + 11] = 0;
+  });
+
+  return Object.freeze({
+    buffer: bytes,
+    nodes: Object.freeze(nodes),
+    count: nodes.length,
+    capacity,
+  });
+}
+
+function createConfigPayload(config, tile, frameIndex, buildRange = {}) {
+  const bytes = new ArrayBuffer(CONFIG_BUFFER_BYTES);
+  const data = new DataView(bytes);
+  const floatView = new Float32Array(bytes);
+  const sampleIndex = buildRange.sampleIndex ?? 0;
+  const sampleWeight = buildRange.sampleWeight ?? 1;
+  data.setUint32(0, config.width, true);
+  data.setUint32(4, config.height, true);
+  data.setUint32(8, tile.x, true);
+  data.setUint32(12, tile.y, true);
+  data.setUint32(16, tile.width, true);
+  data.setUint32(20, tile.height, true);
+  data.setUint32(24, tile.width * tile.height, true);
+  data.setUint32(28, config.maxDepth, true);
+  data.setUint32(32, config.sceneObjectCount, true);
+  data.setUint32(36, frameIndex, true);
+  data.setUint32(40, config.denoise ? 1 : 0, true);
+  data.setUint32(44, config.triangleCount, true);
+  data.setUint32(48, config.bvhNodeCount, true);
+  data.setUint32(52, config.displayQuality ? 1 : 0, true);
+  data.setUint32(56, config.gpuMeshSource.meshes.count, true);
+  data.setUint32(60, config.bvhNodeCapacity, true);
+  writeVec4(floatView, 64, [...config.camera.position, 1]);
+  writeVec4(floatView, 80, [...config.camera.forward, 0]);
+  writeVec4(floatView, 96, [...config.camera.right, 0]);
+  writeVec4(floatView, 112, [...config.camera.up, 0]);
+  writeVec4(floatView, 128, [
+    config.camera.tanHalfFovY,
+    config.camera.aspect,
+    sampleWeight,
+    sampleIndex,
+  ]);
+  writeVec4(floatView, 144, config.environmentColor);
+  writeVec4(floatView, 160, config.ambientColor);
+  writeVec4(floatView, 176, config.environmentLighting.horizonColor);
+  writeVec4(floatView, 192, config.environmentLighting.zenithColor);
+  writeVec4(floatView, 208, [
+    ...config.environmentLighting.sunDirection,
+    config.environmentLighting.intensity,
+  ]);
+  writeVec4(floatView, 224, config.environmentLighting.sunColor);
+  data.setUint32(240, buildRange.start ?? 0, true);
+  data.setUint32(244, buildRange.count ?? 0, true);
+  data.setUint32(248, buildRange.sortItemCount ?? 0, true);
+  data.setUint32(252, config.emissiveTriangleCount ?? 0, true);
+  return bytes;
+}
+
+function createTiles(width, height, tileSize) {
+  const tiles = [];
+  for (let y = 0; y < height; y += tileSize) {
+    for (let x = 0; x < width; x += tileSize) {
+      tiles.push(
+        Object.freeze({
+          x,
+          y,
+          width: Math.min(tileSize, width - x),
+          height: Math.min(tileSize, height - y),
+        })
+      );
+    }
+  }
+  return Object.freeze(tiles);
+}
+
+function clampTileSizeForDevice(config, device) {
+  const limit = Number(device?.limits?.maxStorageBufferBindingSize);
+  if (!Number.isFinite(limit) || limit <= 0) {
+    return config.tileSize;
+  }
+
+  const maxPixelsByRay = Math.floor(limit / RAY_RECORD_BYTES);
+  const maxPixelsByHit = Math.floor(limit / HIT_RECORD_BYTES);
+  const maxPixels = Math.max(256, Math.min(maxPixelsByRay, maxPixelsByHit));
+  if (config.tilePixelCapacity <= maxPixels) {
+    return config.tileSize;
+  }
+
+  return Math.max(16, Math.floor(Math.sqrt(maxPixels)));
+}
+
+function createBuffer(device, usage, size, label) {
+  return device.createBuffer({
+    label,
+    size: Math.max(4, size),
+    usage,
+  });
+}
+
+function alignTo(value, alignment) {
+  const resolvedAlignment = Math.max(1, alignment);
+  return Math.ceil(value / resolvedAlignment) * resolvedAlignment;
+}
+
+async function getPipelineDiagnostics(shaderModule) {
+  if (typeof shaderModule?.compilationInfo !== "function") {
+    return "";
+  }
+  try {
+    const info = await shaderModule.compilationInfo();
+    const messages = info.messages ?? [];
+    if (messages.length === 0) {
+      return "";
+    }
+    return messages
+      .map((message) => {
+        const line = message.lineNum ?? "?";
+        const column = message.linePos ?? "?";
+        return `line ${line}:${column} ${message.message}`;
+      })
+      .join("\n");
+  } catch {
+    return "";
+  }
+}
+
+async function createComputePipeline(device, shaderModule, layout, entryPoint, label) {
+  const descriptor = {
+    label,
+    layout,
+    compute: {
+      module: shaderModule,
+      entryPoint,
+    },
+  };
+
+  try {
+    if (typeof device.createComputePipelineAsync === "function") {
+      return await device.createComputePipelineAsync(descriptor);
+    }
+    return device.createComputePipeline(descriptor);
+  } catch (error) {
+    const diagnostics = await getPipelineDiagnostics(shaderModule);
+    const suffix = diagnostics ? `\n${diagnostics}` : "";
+    throw new Error(`WGSL compilation failed for ${label}: ${error.message}${suffix}`, {
+      cause: error,
+    });
+  }
+}
+
+async function createRenderPipeline(device, descriptor) {
+  if (typeof device.createRenderPipelineAsync === "function") {
+    return device.createRenderPipelineAsync(descriptor);
+  }
+  return device.createRenderPipeline(descriptor);
+}
+
+const WAVEFRONT_COMPUTE_WGSL = `
+const RAY_FLAG_GUIDED_EMISSIVE: u32 = 1u;
+
+struct RayRecord {
+  rayId: u32,
+  parentRayId: u32,
+  sourcePixelId: u32,
+  sampleId: u32,
+  bounce: u32,
+  mediumRefId: u32,
+  flags: u32,
+  pad0: u32,
+  origin: vec4<f32>,
+  direction: vec4<f32>,
+  throughput: vec4<f32>,
+};
+
+struct HitRecord {
+  rayId: u32,
+  sourcePixelId: u32,
+  hitType: u32,
+  objectId: u32,
+  materialKind: u32,
+  frontFace: u32,
+  primitiveId: u32,
+  materialRefId: u32,
+  mediumRefId: u32,
+  pad0: u32,
+  pad1: u32,
+  pad2: u32,
+  distance: f32,
+  pad3: vec3<f32>,
+  position: vec4<f32>,
+  geometricNormal: vec4<f32>,
+  shadingNormal: vec4<f32>,
+  barycentric: vec4<f32>,
+  uv: vec4<f32>,
+  color: vec4<f32>,
+  emission: vec4<f32>,
+  material: vec4<f32>,
+};
+
+struct SceneObject {
+  kind: u32,
+  objectId: u32,
+  materialKind: u32,
+  flags: u32,
+  center: vec4<f32>,
+  halfExtent: vec4<f32>,
+  color: vec4<f32>,
+  emission: vec4<f32>,
+  material: vec4<f32>,
+};
+
+struct TriangleRecord {
+  triangleId: u32,
+  meshId: u32,
+  materialKind: u32,
+  flags: u32,
+  materialRefId: u32,
+  mediumRefId: u32,
+  pad0: u32,
+  pad1: u32,
+  v0: vec4<f32>,
+  v1: vec4<f32>,
+  v2: vec4<f32>,
+  n0: vec4<f32>,
+  n1: vec4<f32>,
+  n2: vec4<f32>,
+  uv0uv1: vec4<f32>,
+  uv2Pad: vec4<f32>,
+  color: vec4<f32>,
+  emission: vec4<f32>,
+  material: vec4<f32>,
+};
+
+struct BvhNode {
+  boundsMin: vec4<f32>,
+  boundsMax: vec4<f32>,
+  childOrFirst: u32,
+  triangleCount: u32,
+  rightChild: u32,
+  pad0: u32,
+};
+
+struct BvhLeafRef {
+  key: u32,
+  triangleIndex: u32,
+  pad0: u32,
+  pad1: u32,
+};
+
+struct ScatterResult {
+  direction: vec4<f32>,
+  flags: u32,
+  pad0: u32,
+  pad1: u32,
+  pad2: u32,
+};
+
+struct MeshVertex {
+  position: vec4<f32>,
+  normal: vec4<f32>,
+  uv: vec4<f32>,
+};
+
+struct MeshRange {
+  meshId: u32,
+  materialKind: u32,
+  flags: u32,
+  materialRefId: u32,
+  mediumRefId: u32,
+  firstIndex: u32,
+  indexCount: u32,
+  firstTriangle: u32,
+  triangleCount: u32,
+  firstVertex: u32,
+  vertexCount: u32,
+  pad0: u32,
+  color: vec4<f32>,
+  emission: vec4<f32>,
+  material: vec4<f32>,
+};
+
+struct FrameConfig {
+  canvasWidth: u32,
+  canvasHeight: u32,
+  tileX: u32,
+  tileY: u32,
+  tileWidth: u32,
+  tileHeight: u32,
+  tilePixelCount: u32,
+  maxDepth: u32,
+  sceneObjectCount: u32,
+  frameIndex: u32,
+  denoise: u32,
+  triangleCount: u32,
+  bvhNodeCount: u32,
+  displayQuality: u32,
+  meshSourceCount: u32,
+  bvhNodeCapacity: u32,
+  cameraPosition: vec4<f32>,
+  cameraForward: vec4<f32>,
+  cameraRight: vec4<f32>,
+  cameraUp: vec4<f32>,
+  projectionAndSampling: vec4<f32>,
+  environmentColor: vec4<f32>,
+  ambientColor: vec4<f32>,
+  environmentHorizonColor: vec4<f32>,
+  environmentZenithColor: vec4<f32>,
+  environmentSunDirectionIntensity: vec4<f32>,
+  environmentSunColor: vec4<f32>,
+  bvhBuildNodeStart: u32,
+  bvhBuildNodeCount: u32,
+  bvhSortItemCount: u32,
+  emissiveTriangleCount: u32,
+};
+
+struct Counters {
+  activeCount: atomic<u32>,
+  nextCount: atomic<u32>,
+  terminatedCount: atomic<u32>,
+  hitCount: atomic<u32>,
+};
+
+struct Candidate {
+  hit: u32,
+  distance: f32,
+  geometricNormal: vec3<f32>,
+  shadingNormal: vec3<f32>,
+  barycentric: vec3<f32>,
+  uv: vec2<f32>,
+  frontFace: u32,
+  triangleIndex: u32,
+  primitiveId: u32,
+  materialRefId: u32,
+  mediumRefId: u32,
+};
+
+@group(0) @binding(0) var<storage, read_write> activeQueue: array<RayRecord>;
+@group(0) @binding(1) var<storage, read_write> nextQueue: array<RayRecord>;
+@group(0) @binding(2) var<storage, read_write> hits: array<HitRecord>;
+@group(0) @binding(3) var<storage, read_write> accumulation: array<vec4<f32>>;
+@group(0) @binding(4) var<storage, read> sceneObjects: array<SceneObject>;
+@group(0) @binding(5) var<uniform> config: FrameConfig;
+@group(0) @binding(6) var<storage, read_write> counters: Counters;
+@group(0) @binding(7) var outputImage: texture_storage_2d<rgba8unorm, write>;
+@group(0) @binding(8) var<storage, read_write> triangles: array<TriangleRecord>;
+@group(0) @binding(9) var<storage, read_write> bvhNodes: array<BvhNode>;
+@group(0) @binding(10) var<storage, read> meshVertices: array<MeshVertex>;
+@group(0) @binding(11) var<storage, read> meshIndices: array<u32>;
+@group(0) @binding(12) var<storage, read> meshRanges: array<MeshRange>;
+@group(0) @binding(13) var<storage, read_write> bvhLeafRefs: array<BvhLeafRef>;
+@group(0) @binding(14) var denoiseInputRadiance: texture_2d<f32>;
+@group(0) @binding(15) var denoisedRadianceImage: texture_storage_2d<rgba16float, write>;
+@group(0) @binding(16) var radianceImage: texture_storage_2d<rgba16float, write>;
+@group(0) @binding(17) var finalDenoiseInputRadiance: texture_2d<f32>;
+@group(0) @binding(18) var denoisedOutputImage: texture_storage_2d<rgba8unorm, write>;
+
+fn hash_u32(value: u32) -> u32 {
+  var x = value;
+  x = ((x >> 16u) ^ x) * 0x45d9f3bu;
+  x = ((x >> 16u) ^ x) * 0x45d9f3bu;
+  x = (x >> 16u) ^ x;
+  return x;
+}
+
+fn mix_seed(pixelId: u32, sampleId: u32, bounce: u32, frameIndex: u32, dimension: u32) -> u32 {
+  var x =
+    (pixelId * 747796405u) ^
+    (sampleId * 2891336453u) ^
+    (bounce * 277803737u) ^
+    (frameIndex * 1442695041u) ^
+    (dimension * 1597334677u);
+  x = x ^ (x >> 16u);
+  x = x * 0x7feb352du;
+  x = x ^ (x >> 15u);
+  x = x * 0x846ca68bu;
+  x = x ^ (x >> 16u);
+  return x;
+}
+
+fn random01(seed: u32) -> f32 {
+  return f32(hash_u32(seed) & 0x00ffffffu) / 16777215.0;
+}
+
+fn safe_normalize(value: vec3<f32>, fallback: vec3<f32>) -> vec3<f32> {
+  let len = length(value);
+  if (len <= 0.000001) {
+    return fallback;
+  }
+  return value / len;
+}
+
+fn saturate(value: f32) -> f32 {
+  return clamp(value, 0.0, 1.0);
+}
+
+fn environment_radiance(direction: vec3<f32>) -> vec3<f32> {
+  let rayDirection = safe_normalize(direction, vec3<f32>(0.0, 1.0, 0.0));
+  let upFactor = saturate(rayDirection.y * 0.5 + 0.5);
+  let sunDirection = safe_normalize(
+    config.environmentSunDirectionIntensity.xyz,
+    vec3<f32>(0.0, 1.0, 0.0)
+  );
+  let sunGlow = pow(saturate(dot(rayDirection, sunDirection)), 192.0);
+  let gradient =
+    config.environmentHorizonColor.xyz * (1.0 - upFactor) +
+    config.environmentZenithColor.xyz * upFactor;
+  return (
+    gradient +
+    config.environmentSunColor.xyz * sunGlow
+  ) * max(config.environmentSunDirectionIntensity.w, 0.0001);
+}
+
+fn default_mesh_range() -> MeshRange {
+  return MeshRange(
+    0u,
+    0u,
+    0u,
+    0u,
+    0u,
+    0u,
+    0u,
+    0u,
+    0u,
+    0u,
+    0u,
+    0u,
+    vec4<f32>(0.72, 0.72, 0.68, 1.0),
+    vec4<f32>(0.0),
+    vec4<f32>(0.72, 0.0, 1.0, 1.45)
+  );
+}
+
+fn mesh_range_for_triangle(triangleIndex: u32) -> MeshRange {
+  var selected = default_mesh_range();
+  for (var meshIndex = 0u; meshIndex < config.meshSourceCount; meshIndex = meshIndex + 1u) {
+    let mesh = meshRanges[meshIndex];
+    let triangleStart = mesh.firstTriangle;
+    let triangleEnd = mesh.firstTriangle + mesh.triangleCount;
+    if (triangleIndex >= triangleStart && triangleIndex < triangleEnd) {
+      selected = mesh;
+      break;
+    }
+  }
+  return selected;
+}
+
+fn node_bounds_min(left: BvhNode, right: BvhNode) -> vec3<f32> {
+  return min(left.boundsMin.xyz, right.boundsMin.xyz);
+}
+
+fn node_bounds_max(left: BvhNode, right: BvhNode) -> vec3<f32> {
+  return max(left.boundsMax.xyz, right.boundsMax.xyz);
+}
+
+fn ordered_float_key(value: f32) -> u32 {
+  let bits = bitcast<u32>(value);
+  let sign = bits & 0x80000000u;
+  let mask = select(0x80000000u, 0xffffffffu, sign != 0u);
+  return bits ^ mask;
+}
+
+fn split_by_3(value: u32) -> u32 {
+  var x = value & 0x000003ffu;
+  x = (x | (x << 16u)) & 0x030000ffu;
+  x = (x | (x << 8u)) & 0x0300f00fu;
+  x = (x | (x << 4u)) & 0x030c30c3u;
+  x = (x | (x << 2u)) & 0x09249249u;
+  return x;
+}
+
+fn morton_key_from_centroid(centroid: vec3<f32>) -> u32 {
+  let x = (ordered_float_key(centroid.x) >> 12u) & 0x000003ffu;
+  let y = (ordered_float_key(centroid.y) >> 12u) & 0x000003ffu;
+  let z = (ordered_float_key(centroid.z) >> 12u) & 0x000003ffu;
+  return (split_by_3(x) << 2u) | (split_by_3(y) << 1u) | split_by_3(z);
+}
+
+fn leaf_ref_less(left: BvhLeafRef, right: BvhLeafRef) -> bool {
+  if (left.key < right.key) {
+    return true;
+  }
+  if (left.key > right.key) {
+    return false;
+  }
+  return left.triangleIndex < right.triangleIndex;
+}
+
+@compute @workgroup_size(64)
+fn prepareMeshTrianglesAndLeaves(@builtin(global_invocation_id) globalId: vec3<u32>) {
+  let triangleIndex = globalId.x;
+  if (triangleIndex >= config.triangleCount) {
+    if (triangleIndex < config.bvhSortItemCount) {
+      bvhLeafRefs[triangleIndex] = BvhLeafRef(0xffffffffu, 0xffffffffu, 0u, 0u);
+    }
+    return;
+  }
+
+  let mesh = mesh_range_for_triangle(triangleIndex);
+  let localTriangle = triangleIndex - mesh.firstTriangle;
+  let indexOffset = mesh.firstIndex + localTriangle * 3u;
+  let index0 = meshIndices[indexOffset];
+  let index1 = meshIndices[indexOffset + 1u];
+  let index2 = meshIndices[indexOffset + 2u];
+  let vertex0 = meshVertices[index0];
+  let vertex1 = meshVertices[index1];
+  let vertex2 = meshVertices[index2];
+  let edge1 = vertex1.position.xyz - vertex0.position.xyz;
+  let edge2 = vertex2.position.xyz - vertex0.position.xyz;
+  let centroid = (vertex0.position.xyz + vertex1.position.xyz + vertex2.position.xyz) / 3.0;
+  let faceNormal = safe_normalize(cross(edge1, edge2), vec3<f32>(0.0, 1.0, 0.0));
+  let n0 = select(faceNormal, safe_normalize(vertex0.normal.xyz, faceNormal), vertex0.normal.w > 0.5);
+  let n1 = select(faceNormal, safe_normalize(vertex1.normal.xyz, faceNormal), vertex1.normal.w > 0.5);
+  let n2 = select(faceNormal, safe_normalize(vertex2.normal.xyz, faceNormal), vertex2.normal.w > 0.5);
+  let uv0 = select(vec2<f32>(0.0), vertex0.uv.xy, vertex0.uv.z > 0.5);
+  let uv1 = select(vec2<f32>(0.0), vertex1.uv.xy, vertex1.uv.z > 0.5);
+  let uv2 = select(vec2<f32>(0.0), vertex2.uv.xy, vertex2.uv.z > 0.5);
+
+  triangles[triangleIndex] = TriangleRecord(
+    triangleIndex,
+    mesh.meshId,
+    mesh.materialKind,
+    mesh.flags,
+    mesh.materialRefId,
+    mesh.mediumRefId,
+    0u,
+    0u,
+    vec4<f32>(vertex0.position.xyz, 0.0),
+    vec4<f32>(vertex1.position.xyz, 0.0),
+    vec4<f32>(vertex2.position.xyz, 0.0),
+    vec4<f32>(n0, 0.0),
+    vec4<f32>(n1, 0.0),
+    vec4<f32>(n2, 0.0),
+    vec4<f32>(uv0, uv1),
+    vec4<f32>(uv2, 0.0, 0.0),
+    mesh.color,
+    mesh.emission,
+    mesh.material
+  );
+
+  let leafBase = config.triangleCount - 1u;
+  let nodeIndex = leafBase + triangleIndex;
+  let boundsMin = min(vertex0.position.xyz, min(vertex1.position.xyz, vertex2.position.xyz));
+  let boundsMax = max(vertex0.position.xyz, max(vertex1.position.xyz, vertex2.position.xyz));
+  bvhLeafRefs[triangleIndex] = BvhLeafRef(
+    morton_key_from_centroid(centroid),
+    triangleIndex,
+    0u,
+    0u
+  );
+  bvhNodes[nodeIndex] = BvhNode(
+    vec4<f32>(boundsMin, 0.0),
+    vec4<f32>(boundsMax, 0.0),
+    triangleIndex,
+    1u,
+    0u,
+    0u
+  );
+}
+
+@compute @workgroup_size(64)
+fn sortBvhLeafRefs(@builtin(global_invocation_id) globalId: vec3<u32>) {
+  let index = globalId.x;
+  let sortCount = config.bvhSortItemCount;
+  if (sortCount <= 1u || index >= sortCount) {
+    return;
+  }
+
+  let compareDistance = config.bvhBuildNodeStart;
+  let sequenceSize = config.bvhBuildNodeCount;
+  if (compareDistance == 0u || sequenceSize == 0u) {
+    return;
+  }
+
+  let partner = index ^ compareDistance;
+  if (partner <= index || partner >= sortCount) {
+    return;
+  }
+
+  let left = bvhLeafRefs[index];
+  let right = bvhLeafRefs[partner];
+  let ascending = (index & sequenceSize) == 0u;
+  let leftIsLess = leaf_ref_less(left, right);
+  let rightIsLess = leaf_ref_less(right, left);
+  let shouldSwap = select(leftIsLess, rightIsLess, ascending);
+  if (shouldSwap) {
+    bvhLeafRefs[index] = right;
+    bvhLeafRefs[partner] = left;
+  }
+}
+
+@compute @workgroup_size(64)
+fn writeSortedBvhLeaves(@builtin(global_invocation_id) globalId: vec3<u32>) {
+  let sortedIndex = globalId.x;
+  if (sortedIndex >= config.triangleCount || config.triangleCount == 0u) {
+    return;
+  }
+
+  let leafRef = bvhLeafRefs[sortedIndex];
+  if (leafRef.triangleIndex >= config.triangleCount) {
+    return;
+  }
+
+  let triangle = triangles[leafRef.triangleIndex];
+  let boundsMin = min(triangle.v0.xyz, min(triangle.v1.xyz, triangle.v2.xyz));
+  let boundsMax = max(triangle.v0.xyz, max(triangle.v1.xyz, triangle.v2.xyz));
+  let leafBase = config.triangleCount - 1u;
+  let nodeIndex = leafBase + sortedIndex;
+  bvhNodes[nodeIndex] = BvhNode(
+    vec4<f32>(boundsMin, 0.0),
+    vec4<f32>(boundsMax, 0.0),
+    leafRef.triangleIndex,
+    1u,
+    0u,
+    0u
+  );
+}
+
+@compute @workgroup_size(64)
+fn buildBvhInternalLevel(@builtin(global_invocation_id) globalId: vec3<u32>) {
+  if (config.triangleCount <= 1u || globalId.x >= config.bvhBuildNodeCount) {
+    return;
+  }
+
+  let internalCount = config.triangleCount - 1u;
+  let nodeIndex = config.bvhBuildNodeStart + globalId.x;
+  if (nodeIndex >= internalCount || nodeIndex >= config.bvhNodeCapacity) {
+    return;
+  }
+
+  let leftIndex = nodeIndex * 2u + 1u;
+  let rightIndex = nodeIndex * 2u + 2u;
+  if (rightIndex >= config.bvhNodeCapacity || rightIndex >= config.bvhNodeCount) {
+    return;
+  }
+
+  let left = bvhNodes[leftIndex];
+  let right = bvhNodes[rightIndex];
+  bvhNodes[nodeIndex] = BvhNode(
+    vec4<f32>(node_bounds_min(left, right), 0.0),
+    vec4<f32>(node_bounds_max(left, right), 0.0),
+    leftIndex,
+    0u,
+    rightIndex,
+    0u
+  );
+}
+
+fn make_ray(pixelIndex: u32) -> RayRecord {
+  let localX = pixelIndex % config.tileWidth;
+  let localY = pixelIndex / config.tileWidth;
+  let px = config.tileX + localX;
+  let py = config.tileY + localY;
+  let sampleId = u32(config.projectionAndSampling.w);
+  let sourcePixelId = py * config.canvasWidth + px;
+  let jitterX = random01(mix_seed(sourcePixelId, sampleId, 0u, config.frameIndex, 1u)) - 0.5;
+  let jitterY = random01(mix_seed(sourcePixelId, sampleId, 0u, config.frameIndex, 2u)) - 0.5;
+  let ndcX = ((f32(px) + 0.5 + jitterX * 0.35) / f32(config.canvasWidth)) * 2.0 - 1.0;
+  let ndcY = 1.0 - ((f32(py) + 0.5 + jitterY * 0.35) / f32(config.canvasHeight)) * 2.0;
+  let viewX = ndcX * config.projectionAndSampling.x * config.projectionAndSampling.y;
+  let viewY = ndcY * config.projectionAndSampling.x;
+  let direction = safe_normalize(
+    config.cameraForward.xyz + config.cameraRight.xyz * viewX + config.cameraUp.xyz * viewY,
+    config.cameraForward.xyz
+  );
+  return RayRecord(
+    pixelIndex,
+    0xffffffffu,
+    sourcePixelId,
+    sampleId,
+    0u,
+    0u,
+    0u,
+    0u,
+    vec4<f32>(config.cameraPosition.xyz, 1.0),
+    vec4<f32>(direction, 0.0),
+    vec4<f32>(1.0, 1.0, 1.0, 1.0)
+  );
+}
+
+fn make_miss(ray: RayRecord) -> HitRecord {
+  let radiance = environment_radiance(ray.direction.xyz);
+  return HitRecord(
+    ray.rayId,
+    ray.sourcePixelId,
+    2u,
+    0u,
+    0u,
+    1u,
+    0u,
+    0u,
+    0u,
+    0u,
+    0u,
+    0u,
+    -1.0,
+    vec3<f32>(0.0),
+    vec4<f32>(ray.origin.xyz + ray.direction.xyz * 1000.0, 1.0),
+    vec4<f32>(-ray.direction.xyz, 0.0),
+    vec4<f32>(-ray.direction.xyz, 0.0),
+    vec4<f32>(0.0),
+    vec4<f32>(0.0),
+    vec4<f32>(radiance, 1.0),
+    vec4<f32>(0.0),
+    vec4<f32>(1.0, 0.0, 1.0, 1.0)
+  );
+}
+
+fn intersect_sphere(ray: RayRecord, object: SceneObject) -> Candidate {
+  let oc = ray.origin.xyz - object.center.xyz;
+  let radius = max(object.halfExtent.x, 0.001);
+  let halfB = dot(oc, ray.direction.xyz);
+  let c = dot(oc, oc) - radius * radius;
+  let discriminant = halfB * halfB - c;
+  if (discriminant < 0.0) {
+    return no_candidate();
+  }
+  let sqrtD = sqrt(discriminant);
+  var distance = -halfB - sqrtD;
+  if (distance <= 0.001) {
+    distance = -halfB + sqrtD;
+  }
+  if (distance <= 0.001) {
+    return no_candidate();
+  }
+  let position = ray.origin.xyz + ray.direction.xyz * distance;
+  let outward = safe_normalize((position - object.center.xyz) / radius, vec3<f32>(0.0, 1.0, 0.0));
+  let frontFace = select(0u, 1u, dot(ray.direction.xyz, outward) < 0.0);
+  let normal = select(-outward, outward, frontFace == 1u);
+  return surface_candidate(
+    distance,
+    normal,
+    normal,
+    vec3<f32>(1.0, 0.0, 0.0),
+    vec2<f32>(0.0),
+    frontFace,
+    0xffffffffu,
+    object.objectId,
+    object.objectId,
+    0u
+  );
+}
+
+fn safe_inverse(value: f32) -> f32 {
+  if (abs(value) < 0.000001) {
+    return select(-1000000.0, 1000000.0, value >= 0.0);
+  }
+  return 1.0 / value;
+}
+
+fn intersect_box(ray: RayRecord, object: SceneObject) -> Candidate {
+  let boxMin = object.center.xyz - object.halfExtent.xyz;
+  let boxMax = object.center.xyz + object.halfExtent.xyz;
+  let inv = vec3<f32>(
+    safe_inverse(ray.direction.x),
+    safe_inverse(ray.direction.y),
+    safe_inverse(ray.direction.z)
+  );
+  let t0 = (boxMin - ray.origin.xyz) * inv;
+  let t1 = (boxMax - ray.origin.xyz) * inv;
+  let tNear = min(t0, t1);
+  let tFar = max(t0, t1);
+  let entry = max(max(tNear.x, tNear.y), tNear.z);
+  let exit = min(min(tFar.x, tFar.y), tFar.z);
+  if (exit < max(entry, 0.001)) {
+    return no_candidate();
+  }
+  let distance = max(entry, 0.001);
+  let position = ray.origin.xyz + ray.direction.xyz * distance;
+  let rel = (position - object.center.xyz) / max(object.halfExtent.xyz, vec3<f32>(0.001));
+  let absRel = abs(rel);
+  var outward = vec3<f32>(0.0, 1.0, 0.0);
+  if (absRel.x >= absRel.y && absRel.x >= absRel.z) {
+    outward = vec3<f32>(select(-1.0, 1.0, rel.x >= 0.0), 0.0, 0.0);
+  } else if (absRel.y >= absRel.z) {
+    outward = vec3<f32>(0.0, select(-1.0, 1.0, rel.y >= 0.0), 0.0);
+  } else {
+    outward = vec3<f32>(0.0, 0.0, select(-1.0, 1.0, rel.z >= 0.0));
+  }
+  let frontFace = select(0u, 1u, dot(ray.direction.xyz, outward) < 0.0);
+  let normal = select(-outward, outward, frontFace == 1u);
+  return surface_candidate(
+    distance,
+    normal,
+    normal,
+    vec3<f32>(1.0, 0.0, 0.0),
+    vec2<f32>(0.0),
+    frontFace,
+    0xffffffffu,
+    object.objectId,
+    object.objectId,
+    0u
+  );
+}
+
+fn intersect_bounds(ray: RayRecord, boundsMin: vec3<f32>, boundsMax: vec3<f32>, nearest: f32) -> bool {
+  let inv = vec3<f32>(
+    safe_inverse(ray.direction.x),
+    safe_inverse(ray.direction.y),
+    safe_inverse(ray.direction.z)
+  );
+  let t0 = (boundsMin - ray.origin.xyz) * inv;
+  let t1 = (boundsMax - ray.origin.xyz) * inv;
+  let tNear = min(t0, t1);
+  let tFar = max(t0, t1);
+  let entry = max(max(tNear.x, tNear.y), tNear.z);
+  let exit = min(min(tFar.x, tFar.y), tFar.z);
+  return exit >= max(entry, 0.001) && entry <= nearest;
+}
+
+fn repair_shading_normal(geometricNormal: vec3<f32>, shadingNormal: vec3<f32>) -> vec3<f32> {
+  var normal = safe_normalize(shadingNormal, geometricNormal);
+  if (dot(normal, geometricNormal) < 0.0) {
+    normal = -normal;
+  }
+  return normal;
+}
+
+fn no_candidate() -> Candidate {
+  return Candidate(
+    0u,
+    0.0,
+    vec3<f32>(0.0, 1.0, 0.0),
+    vec3<f32>(0.0, 1.0, 0.0),
+    vec3<f32>(0.0),
+    vec2<f32>(0.0),
+    1u,
+    0xffffffffu,
+    0xffffffffu,
+    0u,
+    0u
+  );
+}
+
+fn surface_candidate(
+  distance: f32,
+  geometricNormal: vec3<f32>,
+  shadingNormal: vec3<f32>,
+  barycentric: vec3<f32>,
+  uv: vec2<f32>,
+  frontFace: u32,
+  triangleIndex: u32,
+  primitiveId: u32,
+  materialRefId: u32,
+  mediumRefId: u32
+) -> Candidate {
+  return Candidate(
+    1u,
+    distance,
+    geometricNormal,
+    shadingNormal,
+    barycentric,
+    uv,
+    frontFace,
+    triangleIndex,
+    primitiveId,
+    materialRefId,
+    mediumRefId
+  );
+}
+
+fn intersect_triangle(ray: RayRecord, triangle: TriangleRecord, triangleIndex: u32) -> Candidate {
+  let edge1 = triangle.v1.xyz - triangle.v0.xyz;
+  let edge2 = triangle.v2.xyz - triangle.v0.xyz;
+  let pvec = cross(ray.direction.xyz, edge2);
+  let det = dot(edge1, pvec);
+  if (abs(det) < 0.0000001) {
+    return no_candidate();
+  }
+
+  let invDet = 1.0 / det;
+  let tvec = ray.origin.xyz - triangle.v0.xyz;
+  let u = dot(tvec, pvec) * invDet;
+  if (u < 0.0 || u > 1.0) {
+    return no_candidate();
+  }
+
+  let qvec = cross(tvec, edge1);
+  let v = dot(ray.direction.xyz, qvec) * invDet;
+  if (v < 0.0 || u + v > 1.0) {
+    return no_candidate();
+  }
+
+  let distance = dot(edge2, qvec) * invDet;
+  if (distance <= 0.001) {
+    return no_candidate();
+  }
+
+  let geometric = safe_normalize(cross(edge1, edge2), vec3<f32>(0.0, 1.0, 0.0));
+  let frontFace = select(0u, 1u, dot(ray.direction.xyz, geometric) < 0.0);
+  let orientedGeometric = select(-geometric, geometric, frontFace == 1u);
+  let w = 1.0 - u - v;
+  let interpolated =
+    triangle.n0.xyz * w +
+    triangle.n1.xyz * u +
+    triangle.n2.xyz * v;
+  let shading = repair_shading_normal(orientedGeometric, interpolated);
+  let barycentric = vec3<f32>(w, u, v);
+  let uv =
+    triangle.uv0uv1.xy * w +
+    triangle.uv0uv1.zw * u +
+    triangle.uv2Pad.xy * v;
+  return surface_candidate(
+    distance,
+    orientedGeometric,
+    shading,
+    barycentric,
+    uv,
+    frontFace,
+    triangleIndex,
+    triangle.triangleId,
+    triangle.materialRefId,
+    triangle.mediumRefId
+  );
+}
+
+fn intersect_bvh(ray: RayRecord, initialNearest: f32) -> Candidate {
+  var nearest = initialNearest;
+  var best = no_candidate();
+  if (config.bvhNodeCount == 0u || config.triangleCount == 0u) {
+    return best;
+  }
+
+  var stack = array<u32, 64>();
+  var stackSize = 1u;
+  stack[0] = 0u;
+
+  loop {
+    if (stackSize == 0u) {
+      break;
+    }
+
+    stackSize = stackSize - 1u;
+    let nodeIndex = stack[stackSize];
+    if (nodeIndex >= config.bvhNodeCount) {
+      continue;
+    }
+
+    let node = bvhNodes[nodeIndex];
+    if (!intersect_bounds(ray, node.boundsMin.xyz, node.boundsMax.xyz, nearest)) {
+      continue;
+    }
+
+    if (node.triangleCount > 0u) {
+      for (var offset = 0u; offset < node.triangleCount; offset = offset + 1u) {
+        let triangleIndex = node.childOrFirst + offset;
+        if (triangleIndex >= config.triangleCount) {
+          continue;
+        }
+        let current = intersect_triangle(ray, triangles[triangleIndex], triangleIndex);
+        if (current.hit == 1u && current.distance < nearest) {
+          nearest = current.distance;
+          best = current;
+        }
+      }
+    } else {
+      if (stackSize + 2u <= 64u) {
+        stack[stackSize] = node.childOrFirst;
+        stack[stackSize + 1u] = node.rightChild;
+        stackSize = stackSize + 2u;
+      }
+    }
+  }
+
+  return best;
+}
+
+fn emission_power(emission: vec4<f32>) -> f32 {
+  return emission.x + emission.y + emission.z;
+}
+
+fn sample_weight() -> f32 {
+  return max(config.projectionAndSampling.z, 0.000001);
+}
+
+fn clamp_sample_radiance(value: vec3<f32>) -> vec3<f32> {
+  return min(max(value, vec3<f32>(0.0)), vec3<f32>(4.0));
+}
+
+fn tone_map_radiance(value: vec3<f32>) -> vec3<f32> {
+  let mapped = value / (vec3<f32>(1.0) + value);
+  return pow(clamp(mapped, vec3<f32>(0.0), vec3<f32>(1.0)), vec3<f32>(1.0 / 2.2));
+}
+
+fn denoise_range_space(value: vec3<f32>) -> vec3<f32> {
+  return value / (vec3<f32>(1.0) + value);
+}
+
+@compute @workgroup_size(64)
+fn generatePrimaryRays(@builtin(global_invocation_id) globalId: vec3<u32>) {
+  let index = globalId.x;
+  if (index == 0u) {
+    atomicStore(&counters.activeCount, config.tilePixelCount);
+    atomicStore(&counters.nextCount, 0u);
+    atomicStore(&counters.terminatedCount, 0u);
+    atomicStore(&counters.hitCount, 0u);
+  }
+  if (index >= config.tilePixelCount) {
+    return;
+  }
+  activeQueue[index] = make_ray(index);
+  if (u32(config.projectionAndSampling.w) == 0u) {
+    accumulation[index] = vec4<f32>(0.0);
+  }
+}
+
+@compute @workgroup_size(64)
+fn intersectActiveQueue(@builtin(global_invocation_id) globalId: vec3<u32>) {
+  let index = globalId.x;
+  let activeCount = atomicLoad(&counters.activeCount);
+  if (index >= activeCount) {
+    return;
+  }
+  let ray = activeQueue[index];
+  var nearest = 1000000.0;
+  var hitObject = SceneObject(
+    0u,
+    0u,
+    0u,
+    0u,
+    vec4<f32>(0.0),
+    vec4<f32>(0.0),
+    vec4<f32>(0.0),
+    vec4<f32>(0.0),
+    vec4<f32>(1.0, 0.0, 1.0, 1.0)
+  );
+  var candidate = no_candidate();
+  var hitTriangle = TriangleRecord(
+    0u,
+    0u,
+    0u,
+    0u,
+    0u,
+    0u,
+    0u,
+    0u,
+    vec4<f32>(0.0),
+    vec4<f32>(0.0),
+    vec4<f32>(0.0),
+    vec4<f32>(0.0, 1.0, 0.0, 0.0),
+    vec4<f32>(0.0, 1.0, 0.0, 0.0),
+    vec4<f32>(0.0, 1.0, 0.0, 0.0),
+    vec4<f32>(0.0),
+    vec4<f32>(0.0),
+    vec4<f32>(0.0),
+    vec4<f32>(0.0),
+    vec4<f32>(1.0, 0.0, 1.0, 1.0)
+  );
+
+  for (var objectIndex = 0u; objectIndex < config.sceneObjectCount; objectIndex = objectIndex + 1u) {
+    let object = sceneObjects[objectIndex];
+    var current = no_candidate();
+    if (object.kind == 1u) {
+      current = intersect_sphere(ray, object);
+    } else if (object.kind == 2u) {
+      current = intersect_box(ray, object);
+    }
+    if (current.hit == 1u && current.distance < nearest) {
+      nearest = current.distance;
+      hitObject = object;
+      candidate = current;
+    }
+  }
+
+  let meshCandidate = intersect_bvh(ray, nearest);
+  if (meshCandidate.hit == 1u && meshCandidate.distance < nearest) {
+    nearest = meshCandidate.distance;
+    candidate = meshCandidate;
+    hitTriangle = triangles[meshCandidate.triangleIndex];
+  }
+
+  if (candidate.hit == 0u) {
+    hits[index] = make_miss(ray);
+    return;
+  }
+
+  let position = ray.origin.xyz + ray.direction.xyz * candidate.distance;
+  let hitMaterialKind = select(hitObject.materialKind, hitTriangle.materialKind, candidate.triangleIndex != 0xffffffffu);
+  let hitObjectId = select(hitObject.objectId, hitTriangle.meshId, candidate.triangleIndex != 0xffffffffu);
+  let hitColor = select(hitObject.color, hitTriangle.color, candidate.triangleIndex != 0xffffffffu);
+  let hitEmission = select(hitObject.emission, hitTriangle.emission, candidate.triangleIndex != 0xffffffffu);
+  let hitMaterial = select(hitObject.material, hitTriangle.material, candidate.triangleIndex != 0xffffffffu);
+  let hitPrimitiveId = select(candidate.primitiveId, hitTriangle.triangleId, candidate.triangleIndex != 0xffffffffu);
+  let hitMaterialRefId = select(candidate.materialRefId, hitTriangle.materialRefId, candidate.triangleIndex != 0xffffffffu);
+  let hitMediumRefId = select(candidate.mediumRefId, hitTriangle.mediumRefId, candidate.triangleIndex != 0xffffffffu);
+  var hitType = 0u;
+  if (hitMaterialKind == 4u || emission_power(hitEmission) > 0.0001) {
+    hitType = 1u;
+  } else if (hitMaterialKind == 3u || hitMaterial.z < 0.999) {
+    hitType = 3u;
+  }
+  atomicAdd(&counters.hitCount, 1u);
+  hits[index] = HitRecord(
+    ray.rayId,
+    ray.sourcePixelId,
+    hitType,
+    hitObjectId,
+    hitMaterialKind,
+    candidate.frontFace,
+    hitPrimitiveId,
+    hitMaterialRefId,
+    hitMediumRefId,
+    0u,
+    0u,
+    0u,
+    candidate.distance,
+    vec3<f32>(0.0),
+    vec4<f32>(position, 1.0),
+    vec4<f32>(candidate.geometricNormal, 0.0),
+    vec4<f32>(candidate.shadingNormal, 0.0),
+    vec4<f32>(candidate.barycentric, 0.0),
+    vec4<f32>(candidate.uv, 0.0, 0.0),
+    hitColor,
+    hitEmission,
+    hitMaterial
+  );
+}
+
+fn offset_origin(position: vec3<f32>, normal: vec3<f32>) -> vec3<f32> {
+  return position + normal * 0.0025;
+}
+
+fn random_unit_vector(seed: u32) -> vec3<f32> {
+  let z = random01(seed) * 2.0 - 1.0;
+  let a = random01(seed + 11u) * 6.28318530718;
+  let r = sqrt(max(0.0, 1.0 - z * z));
+  return vec3<f32>(r * cos(a), r * sin(a), z);
+}
+
+fn schlick(cosine: f32, refractionRatio: f32) -> f32 {
+  var r0 = (1.0 - refractionRatio) / (1.0 + refractionRatio);
+  r0 = r0 * r0;
+  return r0 + (1.0 - r0) * pow(1.0 - cosine, 5.0);
+}
+
+fn refract_direction(unitDirection: vec3<f32>, normal: vec3<f32>, etaRatio: f32) -> vec3<f32> {
+  let cosTheta = min(dot(-unitDirection, normal), 1.0);
+  let rOutPerp = etaRatio * (unitDirection + cosTheta * normal);
+  let rOutParallel = -sqrt(abs(1.0 - dot(rOutPerp, rOutPerp))) * normal;
+  return safe_normalize(rOutPerp + rOutParallel, reflect(unitDirection, normal));
+}
+
+fn sample_emissive_triangle_direction(hit: HitRecord, seed: u32, fallback: vec3<f32>) -> vec3<f32> {
+  if (config.emissiveTriangleCount == 0u) {
+    return fallback;
+  }
+  let lightSlot = min(u32(random01(seed + 71u) * f32(config.emissiveTriangleCount)), config.emissiveTriangleCount - 1u);
+  let lightMetadata = bvhNodes[config.bvhNodeCapacity + lightSlot];
+  let triangleIndex = lightMetadata.childOrFirst;
+  if (triangleIndex >= config.triangleCount) {
+    return fallback;
+  }
+
+  let lightTriangle = triangles[triangleIndex];
+  let r1 = random01(seed + 101u);
+  let r2 = random01(seed + 193u);
+  let root = sqrt(r1);
+  let b0 = 1.0 - root;
+  let b1 = root * (1.0 - r2);
+  let b2 = root * r2;
+  let lightPoint =
+    lightTriangle.v0.xyz * b0 +
+    lightTriangle.v1.xyz * b1 +
+    lightTriangle.v2.xyz * b2;
+  return safe_normalize(lightPoint - hit.position.xyz, fallback);
+}
+
+fn scatter_direction(ray: RayRecord, hit: HitRecord, seed: u32) -> ScatterResult {
+  let roughness = clamp(hit.material.x, 0.0, 1.0);
+  if (hit.materialKind == 1u) {
+    return ScatterResult(
+      vec4<f32>(
+        safe_normalize(
+          reflect(ray.direction.xyz, hit.shadingNormal.xyz) + random_unit_vector(seed) * roughness,
+          hit.shadingNormal.xyz
+        ),
+        0.0
+      ),
+      0u,
+      0u,
+      0u,
+      0u
+    );
+  }
+
+  if (hit.materialKind == 2u || hit.materialKind == 3u) {
+    let ior = max(hit.material.w, 1.01);
+    let etaRatio = select(ior, 1.0 / ior, hit.frontFace == 1u);
+    let cosTheta = min(dot(-ray.direction.xyz, hit.shadingNormal.xyz), 1.0);
+    let sinTheta = sqrt(max(0.0, 1.0 - cosTheta * cosTheta));
+    let cannotRefract = etaRatio * sinTheta > 1.0;
+    let reflectChance = schlick(cosTheta, etaRatio);
+    if (cannotRefract || random01(seed + 23u) < reflectChance) {
+      return ScatterResult(vec4<f32>(reflect(ray.direction.xyz, hit.shadingNormal.xyz), 0.0), 0u, 0u, 0u, 0u);
+    }
+    return ScatterResult(vec4<f32>(refract_direction(ray.direction.xyz, hit.shadingNormal.xyz, etaRatio), 0.0), 0u, 0u, 0u, 0u);
+  }
+
+  let randomDiffuse = safe_normalize(
+    hit.shadingNormal.xyz + random_unit_vector(seed),
+    hit.shadingNormal.xyz
+  );
+  let guidedLight = sample_emissive_triangle_direction(hit, seed, randomDiffuse);
+  let canSampleLight = dot(hit.shadingNormal.xyz, guidedLight) > -0.04;
+  let guideProbability = select(0.38, 0.72, ray.bounce == 0u);
+  let useGuidedLight = canSampleLight && random01(seed + 37u) < guideProbability;
+  return ScatterResult(
+    vec4<f32>(select(randomDiffuse, guidedLight, useGuidedLight), 0.0),
+    select(0u, RAY_FLAG_GUIDED_EMISSIVE, useGuidedLight),
+    0u,
+    0u,
+    0u
+  );
+}
+
+@compute @workgroup_size(64)
+fn resolveSurfaceRecords(@builtin(global_invocation_id) globalId: vec3<u32>) {
+  let index = globalId.x;
+  let activeCount = atomicLoad(&counters.activeCount);
+  if (index >= activeCount) {
+    return;
+  }
+
+  let ray = activeQueue[index];
+  let hit = hits[index];
+  var contribution = vec3<f32>(0.0);
+
+  if (hit.hitType == 1u) {
+    let guidedLightWeight = select(1.0, 0.24, (ray.flags & RAY_FLAG_GUIDED_EMISSIVE) != 0u);
+    contribution = clamp_sample_radiance(
+      ray.throughput.xyz * max(hit.emission.xyz, hit.color.xyz) * guidedLightWeight
+    );
+    accumulation[ray.rayId] =
+      accumulation[ray.rayId] + vec4<f32>(contribution * sample_weight(), 1.0);
+    atomicAdd(&counters.terminatedCount, 1u);
+    return;
+  }
+
+  if (hit.hitType == 2u) {
+    contribution = clamp_sample_radiance(ray.throughput.xyz * max(hit.color.xyz, config.ambientColor.xyz));
+    accumulation[ray.rayId] =
+      accumulation[ray.rayId] + vec4<f32>(contribution * sample_weight(), 1.0);
+    atomicAdd(&counters.terminatedCount, 1u);
+    return;
+  }
+
+  if (ray.bounce + 1u >= config.maxDepth) {
+    accumulation[ray.rayId] =
+      accumulation[ray.rayId] +
+      vec4<f32>(ray.throughput.xyz * config.ambientColor.xyz * sample_weight(), 1.0);
+    atomicAdd(&counters.terminatedCount, 1u);
+    return;
+  }
+
+  let seed = mix_seed(ray.sourcePixelId, ray.sampleId, ray.bounce, config.frameIndex, 11u);
+  let scatter = scatter_direction(ray, hit, seed);
+  let nextIndex = atomicAdd(&counters.nextCount, 1u);
+  if (nextIndex >= config.tilePixelCount) {
+    return;
+  }
+  let color = clamp(hit.color.xyz, vec3<f32>(0.0), vec3<f32>(1.0));
+  let opacity = clamp(hit.material.z, 0.0, 1.0);
+  let materialEnergy = select(0.68, 0.92, hit.materialKind == 1u || hit.materialKind == 2u);
+  let transparentEnergy = select(materialEnergy, 0.9, hit.hitType == 3u);
+  let throughput = ray.throughput.xyz * mix(vec3<f32>(1.0), color, max(opacity, 0.18)) * transparentEnergy;
+  nextQueue[nextIndex] = RayRecord(
+    ray.rayId,
+    ray.rayId,
+    ray.sourcePixelId,
+    ray.sampleId,
+    ray.bounce + 1u,
+    ray.mediumRefId,
+    scatter.flags,
+    0u,
+    vec4<f32>(offset_origin(hit.position.xyz, hit.shadingNormal.xyz), 1.0),
+    scatter.direction,
+    vec4<f32>(throughput, ray.throughput.w)
+  );
+}
+
+@compute @workgroup_size(1)
+fn compactAndSwapQueues(@builtin(global_invocation_id) globalId: vec3<u32>) {
+  if (globalId.x > 0u) {
+    return;
+  }
+  let nextCount = atomicLoad(&counters.nextCount);
+  atomicStore(&counters.activeCount, min(nextCount, config.tilePixelCount));
+  atomicStore(&counters.nextCount, 0u);
+}
+
+@compute @workgroup_size(64)
+fn accumulateTerminalRadiance(@builtin(global_invocation_id) globalId: vec3<u32>) {
+  let index = globalId.x;
+  if (index >= config.tilePixelCount) {
+    return;
+  }
+  let localX = index % config.tileWidth;
+  let localY = index / config.tileWidth;
+  let pixel = vec2<i32>(i32(config.tileX + localX), i32(config.tileY + localY));
+  let radiance = max(accumulation[index].xyz, vec3<f32>(0.0));
+
+  textureStore(radianceImage, pixel, vec4<f32>(radiance, 1.0));
+  if (config.denoise == 0u) {
+    textureStore(outputImage, pixel, vec4<f32>(tone_map_radiance(radiance), 1.0));
+  }
+}
+
+@compute @workgroup_size(8, 8)
+fn denoiseLinearRadiance(@builtin(global_invocation_id) globalId: vec3<u32>) {
+  let x = globalId.x;
+  let y = globalId.y;
+  if (x >= config.canvasWidth || y >= config.canvasHeight) {
+    return;
+  }
+
+  let pixel = vec2<i32>(i32(x), i32(y));
+  let center = textureLoad(denoiseInputRadiance, pixel, 0).xyz;
+  var sum = center * 1.4;
+  var totalWeight = 1.4;
+  let centerRange = denoise_range_space(center);
+
+  for (var oy = -2i; oy <= 2i; oy = oy + 1i) {
+    for (var ox = -2i; ox <= 2i; ox = ox + 1i) {
+      if (ox == 0i && oy == 0i) {
+        continue;
+      }
+      let sx = clamp(i32(x) + ox, 0i, i32(config.canvasWidth) - 1i);
+      let sy = clamp(i32(y) + oy, 0i, i32(config.canvasHeight) - 1i);
+      let sampleColor = textureLoad(denoiseInputRadiance, vec2<i32>(sx, sy), 0).xyz;
+      let colorDistance = length(denoise_range_space(sampleColor) - centerRange);
+      let rangeWeight = 1.0 / (1.0 + colorDistance * 7.0);
+      let distanceWeight = 1.0 / (1.0 + f32(ox * ox + oy * oy) * 0.24);
+      let diagonalWeight = select(1.0, 0.78, abs(ox) + abs(oy) > 2i);
+      let weight = rangeWeight * diagonalWeight * distanceWeight;
+      sum = sum + sampleColor * weight;
+      totalWeight = totalWeight + weight;
+    }
+  }
+
+  let filtered = sum / max(totalWeight, 0.0001);
+  let outlier = saturate(length(denoise_range_space(center) - denoise_range_space(filtered)) * 2.4);
+  let color = min(mix(center, filtered, 0.52 + outlier * 0.18), vec3<f32>(16.0));
+  textureStore(denoisedRadianceImage, pixel, vec4<f32>(color, 1.0));
+}
+
+@compute @workgroup_size(8, 8)
+fn resolveDenoisedOutputImage(@builtin(global_invocation_id) globalId: vec3<u32>) {
+  let x = globalId.x;
+  let y = globalId.y;
+  if (x >= config.canvasWidth || y >= config.canvasHeight) {
+    return;
+  }
+
+  let pixel = vec2<i32>(i32(x), i32(y));
+  let center = textureLoad(finalDenoiseInputRadiance, pixel, 0).xyz;
+  var sum = center * 1.25;
+  var totalWeight = 1.25;
+  let centerRange = denoise_range_space(center);
+
+  for (var oy = -1i; oy <= 1i; oy = oy + 1i) {
+    for (var ox = -1i; ox <= 1i; ox = ox + 1i) {
+      if (ox == 0i && oy == 0i) {
+        continue;
+      }
+      let sx = clamp(i32(x) + ox, 0i, i32(config.canvasWidth) - 1i);
+      let sy = clamp(i32(y) + oy, 0i, i32(config.canvasHeight) - 1i);
+      let sampleColor = textureLoad(finalDenoiseInputRadiance, vec2<i32>(sx, sy), 0).xyz;
+      let colorDistance = length(denoise_range_space(sampleColor) - centerRange);
+      let rangeWeight = 1.0 / (1.0 + colorDistance * 9.0);
+      let distanceWeight = 1.0 / (1.0 + f32(ox * ox + oy * oy) * 0.4);
+      let weight = rangeWeight * distanceWeight;
+      sum = sum + sampleColor * weight;
+      totalWeight = totalWeight + weight;
+    }
+  }
+
+  let filtered = sum / max(totalWeight, 0.0001);
+  let outlier = saturate(length(denoise_range_space(center) - denoise_range_space(filtered)) * 2.8);
+  let radiance = min(mix(center, filtered, 0.28 + outlier * 0.12), vec3<f32>(16.0));
+  textureStore(denoisedOutputImage, pixel, vec4<f32>(tone_map_radiance(radiance), 1.0));
+}
+`;
+
+const PRESENT_WGSL = `
+struct VertexOut {
+  @builtin(position) position: vec4<f32>,
+  @location(0) uv: vec2<f32>,
+};
+
+@vertex
+fn vertexMain(@builtin(vertex_index) vertexIndex: u32) -> VertexOut {
+  var positions = array<vec2<f32>, 3>(
+    vec2<f32>(-1.0, -1.0),
+    vec2<f32>(3.0, -1.0),
+    vec2<f32>(-1.0, 3.0)
+  );
+  var uvs = array<vec2<f32>, 3>(
+    vec2<f32>(0.0, 1.0),
+    vec2<f32>(2.0, 1.0),
+    vec2<f32>(0.0, -1.0)
+  );
+  var out: VertexOut;
+  out.position = vec4<f32>(positions[vertexIndex], 0.0, 1.0);
+  out.uv = uvs[vertexIndex];
+  return out;
+}
+
+@group(0) @binding(0) var renderTexture: texture_2d<f32>;
+@group(0) @binding(1) var renderSampler: sampler;
+
+@fragment
+fn fragmentMain(in: VertexOut) -> @location(0) vec4<f32> {
+  return textureSample(renderTexture, renderSampler, in.uv);
+}
+`;
+
+export async function createWavefrontPathTracingComputeRenderer(options = {}) {
+  assertAnalyticDisplayQualityPolicy(options);
+  const constants = getGpuUsageConstants();
+  const navigatorRef = options.navigator ?? globalThis.navigator;
+  if (!supportsWavefrontPathTracingCompute({ navigator: navigatorRef })) {
+    throw new Error("WebGPU wavefront path tracing requires navigator.gpu.");
+  }
+
+  const canvas = resolveCanvas(options.canvas, options.document);
+  const initialConfig = createWavefrontPathTracingComputeConfig({
+    ...options,
+    canvas,
+  });
+  const adapter = await navigatorRef.gpu.requestAdapter({
+    powerPreference: options.powerPreference ?? "high-performance",
+  });
+  if (!adapter) {
+    throw new Error("Unable to acquire a WebGPU adapter for wavefront path tracing.");
+  }
+
+  const device = await adapter.requestDevice();
+  const context = canvas.getContext("webgpu");
+  if (!context || typeof context.configure !== "function") {
+    throw new Error("Canvas WebGPU context does not support configure().");
+  }
+
+  const format =
+    options.format ??
+    (typeof navigatorRef.gpu.getPreferredCanvasFormat === "function"
+      ? navigatorRef.gpu.getPreferredCanvasFormat()
+      : "bgra8unorm");
+  let config = initialConfig;
+  const safeTileSize = clampTileSizeForDevice(config, device);
+  if (safeTileSize !== config.tileSize) {
+    config = createWavefrontPathTracingComputeConfig({
+      ...options,
+      canvas,
+      width: config.width,
+      height: config.height,
+      tileSize: safeTileSize,
+    });
+  }
+  canvas.width = config.width;
+  canvas.height = config.height;
+  context.configure({
+    device,
+    format,
+    alphaMode: options.alpha === true ? "premultiplied" : "opaque",
+  });
+
+  const bufferUsage = constants.buffer.STORAGE | constants.buffer.COPY_DST;
+  const rayQueueBytes = config.tilePixelCapacity * RAY_RECORD_BYTES;
+  const hitBytes = config.tilePixelCapacity * HIT_RECORD_BYTES;
+  const accumulationBytes = config.tilePixelCapacity * ACCUMULATION_RECORD_BYTES;
+  const activeQueue = createBuffer(device, bufferUsage, rayQueueBytes, "plasius.wavefront.activeQueue");
+  const nextQueue = createBuffer(device, bufferUsage, rayQueueBytes, "plasius.wavefront.nextQueue");
+  const hitBuffer = createBuffer(device, bufferUsage, hitBytes, "plasius.wavefront.hitBuffer");
+  const accumulationBuffer = createBuffer(
+    device,
+    bufferUsage,
+    accumulationBytes,
+    "plasius.wavefront.accumulation"
+  );
+  const sceneObjectBuffer = createBuffer(
+    device,
+    constants.buffer.STORAGE | constants.buffer.COPY_DST,
+    config.sceneObjectCapacity * SCENE_OBJECT_RECORD_BYTES,
+    "plasius.wavefront.sceneObjects"
+  );
+  const triangleBuffer = createBuffer(
+    device,
+    constants.buffer.STORAGE | constants.buffer.COPY_DST,
+    Math.max(1, config.triangleCapacity) * TRIANGLE_RECORD_BYTES,
+    "plasius.wavefront.triangles"
+  );
+  const bvhNodeBuffer = createBuffer(
+    device,
+    constants.buffer.STORAGE | constants.buffer.COPY_DST,
+    Math.max(1, config.bvhNodeCapacity + config.emissiveTriangleCapacity) *
+      BVH_NODE_RECORD_BYTES,
+    "plasius.wavefront.bvhNodes"
+  );
+  const meshVertexBuffer = createBuffer(
+    device,
+    constants.buffer.STORAGE | constants.buffer.COPY_DST,
+    Math.max(1, config.gpuMeshSource.vertices.count) * MESH_VERTEX_RECORD_BYTES,
+    "plasius.wavefront.meshVertices"
+  );
+  const meshIndexBuffer = createBuffer(
+    device,
+    constants.buffer.STORAGE | constants.buffer.COPY_DST,
+    Math.max(1, config.gpuMeshSource.indices.count) * 4,
+    "plasius.wavefront.meshIndices"
+  );
+  const meshRangeBuffer = createBuffer(
+    device,
+    constants.buffer.STORAGE | constants.buffer.COPY_DST,
+    Math.max(1, config.gpuMeshSource.meshes.count) * MESH_RANGE_RECORD_BYTES,
+    "plasius.wavefront.meshRanges"
+  );
+  const bvhLeafRefBuffer = createBuffer(
+    device,
+    constants.buffer.STORAGE | constants.buffer.COPY_DST,
+    Math.max(1, config.bvhLeafSortCapacity) * BVH_LEAF_REF_RECORD_BYTES,
+    "plasius.wavefront.bvhLeafRefs"
+  );
+  const configBuffer = createBuffer(
+    device,
+    constants.buffer.UNIFORM | constants.buffer.COPY_DST,
+    CONFIG_BUFFER_BYTES,
+    "plasius.wavefront.frameConfig"
+  );
+  const uniformOffsetAlignment = Number(device?.limits?.minUniformBufferOffsetAlignment);
+  const configBufferStride = alignTo(
+    CONFIG_BUFFER_BYTES,
+    Number.isFinite(uniformOffsetAlignment) && uniformOffsetAlignment > 0
+      ? uniformOffsetAlignment
+      : CONFIG_BUFFER_BYTES
+  );
+  const bvhBuildConfigSlots =
+    1 + config.bvhSortStages.length + config.bvhBuildLevels.length;
+  const bvhBuildConfigBuffer = createBuffer(
+    device,
+    constants.buffer.UNIFORM | constants.buffer.COPY_DST,
+    Math.max(1, bvhBuildConfigSlots) * configBufferStride,
+    "plasius.wavefront.bvhBuildConfig"
+  );
+  const counterBuffer = createBuffer(
+    device,
+    constants.buffer.STORAGE | constants.buffer.COPY_DST,
+    COUNTER_BUFFER_BYTES,
+    "plasius.wavefront.counters"
+  );
+
+  let packedScene = packWavefrontSceneObjects(config.sceneObjects, config.sceneObjectCapacity);
+  device.queue.writeBuffer(sceneObjectBuffer, 0, packedScene.buffer);
+  const packedTriangles = packWavefrontTriangles(
+    config.meshAcceleration.triangles,
+    Math.max(1, config.triangleCapacity)
+  );
+  const packedBvhNodes = packWavefrontBvhNodes(
+    config.meshAcceleration.nodes,
+    Math.max(1, config.bvhNodeCapacity + config.emissiveTriangleCapacity)
+  );
+  const packedBvhNodeUints = new Uint32Array(packedBvhNodes.buffer);
+  config.emissiveTriangleIndices.indices.forEach((triangleIndex, index) => {
+    const nodeOffset = (config.bvhNodeCapacity + index) * (BVH_NODE_RECORD_BYTES / 4);
+    packedBvhNodeUints[nodeOffset + 8] = triangleIndex;
+  });
+  device.queue.writeBuffer(triangleBuffer, 0, packedTriangles.buffer);
+  device.queue.writeBuffer(bvhNodeBuffer, 0, packedBvhNodes.buffer);
+  device.queue.writeBuffer(meshVertexBuffer, 0, config.gpuMeshSource.vertices.buffer);
+  device.queue.writeBuffer(meshIndexBuffer, 0, config.gpuMeshSource.indices.buffer);
+  device.queue.writeBuffer(meshRangeBuffer, 0, config.gpuMeshSource.meshes.buffer);
+
+  const radianceTexture = device.createTexture({
+    label: "plasius.wavefront.radiance",
+    size: { width: config.width, height: config.height },
+    format: "rgba16float",
+    usage:
+      constants.texture.STORAGE_BINDING |
+      constants.texture.TEXTURE_BINDING,
+  });
+  const radianceView = radianceTexture.createView();
+  const denoiseScratchTexture = device.createTexture({
+    label: "plasius.wavefront.denoiseScratch",
+    size: { width: config.width, height: config.height },
+    format: "rgba16float",
+    usage:
+      constants.texture.STORAGE_BINDING |
+      constants.texture.TEXTURE_BINDING,
+  });
+  const denoiseScratchView = denoiseScratchTexture.createView();
+  const outputTexture = device.createTexture({
+    label: "plasius.wavefront.output",
+    size: { width: config.width, height: config.height },
+    format: "rgba8unorm",
+    usage:
+      constants.texture.STORAGE_BINDING |
+      constants.texture.TEXTURE_BINDING |
+      constants.texture.COPY_SRC,
+  });
+  const outputView = outputTexture.createView();
+  const sampler = device.createSampler({
+    label: "plasius.wavefront.presentSampler",
+    magFilter: "nearest",
+    minFilter: "nearest",
+  });
+
+  const traceBindGroupLayout = device.createBindGroupLayout({
+    label: "plasius.wavefront.traceBindGroupLayout",
+    entries: [
+      { binding: 0, visibility: constants.shader.COMPUTE, buffer: { type: "storage" } },
+      { binding: 1, visibility: constants.shader.COMPUTE, buffer: { type: "storage" } },
+      { binding: 2, visibility: constants.shader.COMPUTE, buffer: { type: "storage" } },
+      { binding: 3, visibility: constants.shader.COMPUTE, buffer: { type: "storage" } },
+      { binding: 4, visibility: constants.shader.COMPUTE, buffer: { type: "read-only-storage" } },
+      {
+        binding: 5,
+        visibility: constants.shader.COMPUTE,
+        buffer: { type: "uniform", hasDynamicOffset: true, minBindingSize: CONFIG_BUFFER_BYTES },
+      },
+      { binding: 6, visibility: constants.shader.COMPUTE, buffer: { type: "storage" } },
+      {
+        binding: 7,
+        visibility: constants.shader.COMPUTE,
+        storageTexture: { access: "write-only", format: "rgba8unorm" },
+      },
+      { binding: 8, visibility: constants.shader.COMPUTE, buffer: { type: "storage" } },
+      { binding: 9, visibility: constants.shader.COMPUTE, buffer: { type: "storage" } },
+      {
+        binding: 16,
+        visibility: constants.shader.COMPUTE,
+        storageTexture: { access: "write-only", format: "rgba16float" },
+      },
+    ],
+  });
+  const accelerationBindGroupLayout = device.createBindGroupLayout({
+    label: "plasius.wavefront.accelerationBindGroupLayout",
+    entries: [
+      {
+        binding: 5,
+        visibility: constants.shader.COMPUTE,
+        buffer: { type: "uniform", hasDynamicOffset: true, minBindingSize: CONFIG_BUFFER_BYTES },
+      },
+      { binding: 8, visibility: constants.shader.COMPUTE, buffer: { type: "storage" } },
+      { binding: 9, visibility: constants.shader.COMPUTE, buffer: { type: "storage" } },
+      { binding: 10, visibility: constants.shader.COMPUTE, buffer: { type: "read-only-storage" } },
+      { binding: 11, visibility: constants.shader.COMPUTE, buffer: { type: "read-only-storage" } },
+      { binding: 12, visibility: constants.shader.COMPUTE, buffer: { type: "read-only-storage" } },
+      { binding: 13, visibility: constants.shader.COMPUTE, buffer: { type: "storage" } },
+    ],
+  });
+  const denoiseRadianceBindGroupLayout = device.createBindGroupLayout({
+    label: "plasius.wavefront.denoiseRadianceBindGroupLayout",
+    entries: [
+      {
+        binding: 5,
+        visibility: constants.shader.COMPUTE,
+        buffer: { type: "uniform", hasDynamicOffset: true, minBindingSize: CONFIG_BUFFER_BYTES },
+      },
+      {
+        binding: 14,
+        visibility: constants.shader.COMPUTE,
+        texture: { sampleType: "float" },
+      },
+      {
+        binding: 15,
+        visibility: constants.shader.COMPUTE,
+        storageTexture: { access: "write-only", format: "rgba16float" },
+      },
+    ],
+  });
+  const denoiseResolveBindGroupLayout = device.createBindGroupLayout({
+    label: "plasius.wavefront.denoiseResolveBindGroupLayout",
+    entries: [
+      {
+        binding: 5,
+        visibility: constants.shader.COMPUTE,
+        buffer: { type: "uniform", hasDynamicOffset: true, minBindingSize: CONFIG_BUFFER_BYTES },
+      },
+      {
+        binding: 17,
+        visibility: constants.shader.COMPUTE,
+        texture: { sampleType: "float" },
+      },
+      {
+        binding: 18,
+        visibility: constants.shader.COMPUTE,
+        storageTexture: { access: "write-only", format: "rgba8unorm" },
+      },
+    ],
+  });
+  const tracePipelineLayout = device.createPipelineLayout({
+    label: "plasius.wavefront.tracePipelineLayout",
+    bindGroupLayouts: [traceBindGroupLayout],
+  });
+  const accelerationPipelineLayout = device.createPipelineLayout({
+    label: "plasius.wavefront.accelerationPipelineLayout",
+    bindGroupLayouts: [accelerationBindGroupLayout],
+  });
+  const denoiseRadiancePipelineLayout = device.createPipelineLayout({
+    label: "plasius.wavefront.denoiseRadiancePipelineLayout",
+    bindGroupLayouts: [denoiseRadianceBindGroupLayout],
+  });
+  const denoiseResolvePipelineLayout = device.createPipelineLayout({
+    label: "plasius.wavefront.denoiseResolvePipelineLayout",
+    bindGroupLayouts: [denoiseResolveBindGroupLayout],
+  });
+  const computeShader = device.createShaderModule({
+    label: "plasius.wavefront.computeShader",
+    code: WAVEFRONT_COMPUTE_WGSL,
+  });
+
+  const pipelines = {
+    prepareMeshTrianglesAndLeaves: await createComputePipeline(
+      device,
+      computeShader,
+      accelerationPipelineLayout,
+      "prepareMeshTrianglesAndLeaves",
+      "plasius.wavefront.prepareMeshTrianglesAndLeaves"
+    ),
+    sortBvhLeafRefs: await createComputePipeline(
+      device,
+      computeShader,
+      accelerationPipelineLayout,
+      "sortBvhLeafRefs",
+      "plasius.wavefront.sortBvhLeafRefs"
+    ),
+    writeSortedBvhLeaves: await createComputePipeline(
+      device,
+      computeShader,
+      accelerationPipelineLayout,
+      "writeSortedBvhLeaves",
+      "plasius.wavefront.writeSortedBvhLeaves"
+    ),
+    buildBvhInternalLevel: await createComputePipeline(
+      device,
+      computeShader,
+      accelerationPipelineLayout,
+      "buildBvhInternalLevel",
+      "plasius.wavefront.buildBvhInternalLevel"
+    ),
+    generatePrimaryRays: await createComputePipeline(
+      device,
+      computeShader,
+      tracePipelineLayout,
+      "generatePrimaryRays",
+      "plasius.wavefront.generatePrimaryRays"
+    ),
+    intersectActiveQueue: await createComputePipeline(
+      device,
+      computeShader,
+      tracePipelineLayout,
+      "intersectActiveQueue",
+      "plasius.wavefront.intersectActiveQueue"
+    ),
+    resolveSurfaceRecords: await createComputePipeline(
+      device,
+      computeShader,
+      tracePipelineLayout,
+      "resolveSurfaceRecords",
+      "plasius.wavefront.resolveSurfaceRecords"
+    ),
+    compactAndSwapQueues: await createComputePipeline(
+      device,
+      computeShader,
+      tracePipelineLayout,
+      "compactAndSwapQueues",
+      "plasius.wavefront.compactAndSwapQueues"
+    ),
+    accumulateTerminalRadiance: await createComputePipeline(
+      device,
+      computeShader,
+      tracePipelineLayout,
+      "accumulateTerminalRadiance",
+      "plasius.wavefront.accumulateTerminalRadiance"
+    ),
+    denoiseLinearRadiance: await createComputePipeline(
+      device,
+      computeShader,
+      denoiseRadiancePipelineLayout,
+      "denoiseLinearRadiance",
+      "plasius.wavefront.denoiseLinearRadiance"
+    ),
+    resolveDenoisedOutputImage: await createComputePipeline(
+      device,
+      computeShader,
+      denoiseResolvePipelineLayout,
+      "resolveDenoisedOutputImage",
+      "plasius.wavefront.resolveDenoisedOutputImage"
+    ),
+  };
+
+  function createTraceBindGroup(activeBuffer, nextBuffer, label, frameConfigBuffer = configBuffer) {
+    return device.createBindGroup({
+      label,
+      layout: traceBindGroupLayout,
+      entries: [
+        { binding: 0, resource: { buffer: activeBuffer } },
+        { binding: 1, resource: { buffer: nextBuffer } },
+        { binding: 2, resource: { buffer: hitBuffer } },
+        { binding: 3, resource: { buffer: accumulationBuffer } },
+        { binding: 4, resource: { buffer: sceneObjectBuffer } },
+        { binding: 5, resource: { buffer: frameConfigBuffer, size: CONFIG_BUFFER_BYTES } },
+        { binding: 6, resource: { buffer: counterBuffer } },
+        { binding: 7, resource: outputView },
+        { binding: 8, resource: { buffer: triangleBuffer } },
+        { binding: 9, resource: { buffer: bvhNodeBuffer } },
+        { binding: 16, resource: radianceView },
+      ],
+    });
+  }
+
+  const bindGroups = [
+    createTraceBindGroup(activeQueue, nextQueue, "plasius.wavefront.bind.activeNext"),
+    createTraceBindGroup(nextQueue, activeQueue, "plasius.wavefront.bind.nextActive"),
+  ];
+  const bvhBuildBindGroup = device.createBindGroup({
+    label: "plasius.wavefront.bind.bvhBuild",
+    layout: accelerationBindGroupLayout,
+    entries: [
+      { binding: 5, resource: { buffer: bvhBuildConfigBuffer, size: CONFIG_BUFFER_BYTES } },
+      { binding: 8, resource: { buffer: triangleBuffer } },
+      { binding: 9, resource: { buffer: bvhNodeBuffer } },
+      { binding: 10, resource: { buffer: meshVertexBuffer } },
+      { binding: 11, resource: { buffer: meshIndexBuffer } },
+      { binding: 12, resource: { buffer: meshRangeBuffer } },
+      { binding: 13, resource: { buffer: bvhLeafRefBuffer } },
+    ],
+  });
+  function createDenoiseRadianceBindGroup(inputView, targetView, label) {
+    return device.createBindGroup({
+      label,
+      layout: denoiseRadianceBindGroupLayout,
+      entries: [
+        { binding: 5, resource: { buffer: configBuffer, size: CONFIG_BUFFER_BYTES } },
+        { binding: 14, resource: inputView },
+        { binding: 15, resource: targetView },
+      ],
+    });
+  }
+
+  function createDenoiseResolveBindGroup(inputView, targetView, label) {
+    return device.createBindGroup({
+      label,
+      layout: denoiseResolveBindGroupLayout,
+      entries: [
+        { binding: 5, resource: { buffer: configBuffer, size: CONFIG_BUFFER_BYTES } },
+        { binding: 17, resource: inputView },
+        { binding: 18, resource: targetView },
+      ],
+    });
+  }
+
+  const denoiseRadianceBindGroup = createDenoiseRadianceBindGroup(
+    radianceView,
+    denoiseScratchView,
+    "plasius.wavefront.bind.denoise.radianceToScratch"
+  );
+  const denoiseResolveBindGroup = createDenoiseResolveBindGroup(
+    denoiseScratchView,
+    outputView,
+    "plasius.wavefront.bind.denoise.scratchToOutput"
+  );
+
+  const presentBindGroupLayout = device.createBindGroupLayout({
+    label: "plasius.wavefront.presentBindGroupLayout",
+    entries: [
+      { binding: 0, visibility: constants.shader.FRAGMENT, texture: { sampleType: "float" } },
+      { binding: 1, visibility: constants.shader.FRAGMENT, sampler: { type: "filtering" } },
+    ],
+  });
+  const presentShader = device.createShaderModule({
+    label: "plasius.wavefront.presentShader",
+    code: PRESENT_WGSL,
+  });
+  const presentPipeline = await createRenderPipeline(device, {
+    label: "plasius.wavefront.presentPipeline",
+    layout: device.createPipelineLayout({
+      label: "plasius.wavefront.presentPipelineLayout",
+      bindGroupLayouts: [presentBindGroupLayout],
+    }),
+    vertex: { module: presentShader, entryPoint: "vertexMain" },
+    fragment: {
+      module: presentShader,
+      entryPoint: "fragmentMain",
+      targets: [{ format }],
+    },
+    primitive: { topology: "triangle-list" },
+  });
+  const presentBindGroup = device.createBindGroup({
+    label: "plasius.wavefront.presentBindGroup",
+    layout: presentBindGroupLayout,
+    entries: [
+      { binding: 0, resource: outputView },
+      { binding: 1, resource: sampler },
+    ],
+  });
+
+  let frame = 0;
+  const tiles = createTiles(config.width, config.height, config.tileSize);
+
+  function dispatchGpuAccelerationBuild(frameIndex) {
+    if (!config.gpuAccelerationBuildRequired) {
+      return;
+    }
+    const buildTile = tiles[0] ?? { x: 0, y: 0, width: 1, height: 1 };
+    const encoder = device.createCommandEncoder({
+      label: `plasius.wavefront.buildAcceleration.${frameIndex}`,
+    });
+    device.queue.writeBuffer(
+      bvhBuildConfigBuffer,
+      0,
+      createConfigPayload(config, buildTile, frameIndex, {
+        sortItemCount: config.bvhLeafSortCapacity,
+      })
+    );
+    config.bvhSortStages.forEach((sortStage, stageIndex) => {
+      device.queue.writeBuffer(
+        bvhBuildConfigBuffer,
+        (stageIndex + 1) * configBufferStride,
+        createConfigPayload(config, buildTile, frameIndex, {
+          start: sortStage.compareDistance,
+          count: sortStage.sequenceSize,
+          sortItemCount: config.bvhLeafSortCapacity,
+        })
+      );
+    });
+    const buildLevelConfigStart = 1 + config.bvhSortStages.length;
+    config.bvhBuildLevels.forEach((buildLevel, levelIndex) => {
+      device.queue.writeBuffer(
+        bvhBuildConfigBuffer,
+        (buildLevelConfigStart + levelIndex) * configBufferStride,
+        createConfigPayload(config, buildTile, frameIndex, buildLevel)
+      );
+    });
+    const passEncoder = encoder.beginComputePass({
+      label: "plasius.wavefront.buildAccelerationPass",
+    });
+    passEncoder.setBindGroup(0, bvhBuildBindGroup, [0]);
+    passEncoder.setPipeline(pipelines.prepareMeshTrianglesAndLeaves);
+    passEncoder.dispatchWorkgroups(Math.ceil(config.bvhLeafSortCapacity / WORKGROUP_SIZE));
+    passEncoder.setPipeline(pipelines.sortBvhLeafRefs);
+    for (let stageIndex = 0; stageIndex < config.bvhSortStages.length; stageIndex += 1) {
+      passEncoder.setBindGroup(0, bvhBuildBindGroup, [
+        (stageIndex + 1) * configBufferStride,
+      ]);
+      passEncoder.dispatchWorkgroups(Math.ceil(config.bvhLeafSortCapacity / WORKGROUP_SIZE));
+    }
+    passEncoder.setBindGroup(0, bvhBuildBindGroup, [0]);
+    passEncoder.setPipeline(pipelines.writeSortedBvhLeaves);
+    passEncoder.dispatchWorkgroups(Math.ceil(config.triangleCount / WORKGROUP_SIZE));
+    passEncoder.setPipeline(pipelines.buildBvhInternalLevel);
+    for (let levelIndex = 0; levelIndex < config.bvhBuildLevels.length; levelIndex += 1) {
+      const buildLevel = config.bvhBuildLevels[levelIndex];
+      passEncoder.setBindGroup(0, bvhBuildBindGroup, [
+        (buildLevelConfigStart + levelIndex) * configBufferStride,
+      ]);
+      passEncoder.dispatchWorkgroups(Math.ceil(buildLevel.count / WORKGROUP_SIZE));
+    }
+    passEncoder.end();
+    device.queue.submit([encoder.finish()]);
+  }
+
+  function dispatchTileSample(tile, frameIndex, sampleIndex) {
+    const sampleWeight = 1 / config.samplesPerPixel;
+    const configPayload = createConfigPayload(config, tile, frameIndex, {
+      sampleIndex,
+      sampleWeight,
+    });
+    device.queue.writeBuffer(configBuffer, 0, configPayload);
+    const encoder = device.createCommandEncoder({
+      label: `plasius.wavefront.frame.${frameIndex}.tile.${tile.x}.${tile.y}.sample.${sampleIndex}`,
+    });
+    const passEncoder = encoder.beginComputePass({
+      label: "plasius.wavefront.computePass",
+    });
+    const tileWorkgroups = Math.ceil((tile.width * tile.height) / WORKGROUP_SIZE);
+    const capacityWorkgroups = Math.ceil(config.tilePixelCapacity / WORKGROUP_SIZE);
+
+    passEncoder.setBindGroup(0, bindGroups[0], [0]);
+    passEncoder.setPipeline(pipelines.generatePrimaryRays);
+    passEncoder.dispatchWorkgroups(tileWorkgroups);
+
+    for (let bounceIndex = 0; bounceIndex < config.maxDepth; bounceIndex += 1) {
+      passEncoder.setBindGroup(0, bindGroups[bounceIndex % 2], [0]);
+      passEncoder.setPipeline(pipelines.intersectActiveQueue);
+      passEncoder.dispatchWorkgroups(capacityWorkgroups);
+      passEncoder.setPipeline(pipelines.resolveSurfaceRecords);
+      passEncoder.dispatchWorkgroups(capacityWorkgroups);
+      passEncoder.setPipeline(pipelines.compactAndSwapQueues);
+      passEncoder.dispatchWorkgroups(1);
+    }
+
+    passEncoder.end();
+    device.queue.submit([encoder.finish()]);
+  }
+
+  function dispatchTileOutput(tile, frameIndex) {
+    const configPayload = createConfigPayload(config, tile, frameIndex, {
+      sampleIndex: 0,
+      sampleWeight: 1 / config.samplesPerPixel,
+    });
+    device.queue.writeBuffer(configBuffer, 0, configPayload);
+    const encoder = device.createCommandEncoder({
+      label: `plasius.wavefront.frame.${frameIndex}.tile.${tile.x}.${tile.y}.output`,
+    });
+    const passEncoder = encoder.beginComputePass({
+      label: "plasius.wavefront.outputPass",
+    });
+    const tileWorkgroups = Math.ceil((tile.width * tile.height) / WORKGROUP_SIZE);
+
+    passEncoder.setBindGroup(0, bindGroups[0], [0]);
+    passEncoder.setPipeline(pipelines.accumulateTerminalRadiance);
+    passEncoder.dispatchWorkgroups(tileWorkgroups);
+    passEncoder.end();
+    device.queue.submit([encoder.finish()]);
+  }
+
+  function dispatchTile(tile, frameIndex) {
+    for (let sampleIndex = 0; sampleIndex < config.samplesPerPixel; sampleIndex += 1) {
+      dispatchTileSample(tile, frameIndex, sampleIndex);
+    }
+    dispatchTileOutput(tile, frameIndex);
+  }
+
+  function dispatchDenoise(frameIndex) {
+    if (!config.denoise) {
+      return;
+    }
+    device.queue.writeBuffer(
+      configBuffer,
+      0,
+      createConfigPayload(
+        config,
+        { x: 0, y: 0, width: config.width, height: config.height },
+        frameIndex,
+        { sampleIndex: 0, sampleWeight: 1 / config.samplesPerPixel }
+      )
+    );
+    const encoder = device.createCommandEncoder({
+      label: `plasius.wavefront.frame.${frameIndex}.denoise`,
+    });
+    const radiancePass = encoder.beginComputePass({
+      label: "plasius.wavefront.denoiseRadiancePass",
+    });
+    radiancePass.setBindGroup(0, denoiseRadianceBindGroup, [0]);
+    radiancePass.setPipeline(pipelines.denoiseLinearRadiance);
+    radiancePass.dispatchWorkgroups(Math.ceil(config.width / 8), Math.ceil(config.height / 8));
+    radiancePass.end();
+
+    const resolvePass = encoder.beginComputePass({
+      label: "plasius.wavefront.denoiseResolvePass",
+    });
+    resolvePass.setBindGroup(0, denoiseResolveBindGroup, [0]);
+    resolvePass.setPipeline(pipelines.resolveDenoisedOutputImage);
+    resolvePass.dispatchWorkgroups(Math.ceil(config.width / 8), Math.ceil(config.height / 8));
+    resolvePass.end();
+    device.queue.submit([encoder.finish()]);
+  }
+
+  function present() {
+    const texture = context.getCurrentTexture();
+    const encoder = device.createCommandEncoder({
+      label: `plasius.wavefront.present.${frame}`,
+    });
+    const passEncoder = encoder.beginRenderPass({
+      label: "plasius.wavefront.presentPass",
+      colorAttachments: [
+        {
+          view: texture.createView(),
+          clearValue: { r: 0, g: 0, b: 0, a: 1 },
+          loadOp: "clear",
+          storeOp: "store",
+        },
+      ],
+    });
+    passEncoder.setPipeline(presentPipeline);
+    passEncoder.setBindGroup(0, presentBindGroup);
+    passEncoder.draw(3);
+    passEncoder.end();
+    device.queue.submit([encoder.finish()]);
+  }
+
+  function renderOnce() {
+    frame += 1;
+    dispatchGpuAccelerationBuild(frame + config.frameIndex);
+    for (const tile of tiles) {
+      dispatchTile(tile, frame + config.frameIndex);
+    }
+    dispatchDenoise(frame + config.frameIndex);
+    present();
+    return Object.freeze({
+      frame,
+      width: config.width,
+      height: config.height,
+      maxDepth: config.maxDepth,
+      tiles: tiles.length,
+      tileSize: config.tileSize,
+      samplesPerPixel: config.samplesPerPixel,
+      screenRays: config.width * config.height,
+      primaryRays: config.width * config.height * config.samplesPerPixel,
+      sceneObjectCount: config.sceneObjectCount,
+      triangleCount: config.triangleCount,
+      emissiveTriangleCount: config.emissiveTriangleCount,
+      bvhNodeCount: config.bvhNodeCount,
+      displayQuality: config.displayQuality,
+      accelerationBuildMode: config.accelerationBuildMode,
+      gpuAccelerationBuildRequired: config.gpuAccelerationBuildRequired,
+      memory: config.memory,
+    });
+  }
+
+  async function readOutputProbe(optionsForProbe = {}) {
+    const mapMode = constants.map;
+    if (!mapMode) {
+      throw new Error("GPUMapMode.READ is unavailable in this environment.");
+    }
+    const x = clamp(readNonNegativeInteger("x", optionsForProbe.x, Math.floor(config.width / 2)), 0, config.width - 1);
+    const y = clamp(readNonNegativeInteger("y", optionsForProbe.y, Math.floor(config.height / 2)), 0, config.height - 1);
+    const readback = device.createBuffer({
+      label: "plasius.wavefront.outputProbe",
+      size: 256,
+      usage: constants.buffer.COPY_DST | constants.buffer.MAP_READ,
+    });
+    const encoder = device.createCommandEncoder({
+      label: "plasius.wavefront.outputProbe.copy",
+    });
+    encoder.copyTextureToBuffer(
+      { texture: outputTexture, origin: { x, y } },
+      { buffer: readback, bytesPerRow: 256, rowsPerImage: 1 },
+      { width: 1, height: 1, depthOrArrayLayers: 1 }
+    );
+    device.queue.submit([encoder.finish()]);
+    await readback.mapAsync(mapMode.READ);
+    const bytes = new Uint8Array(readback.getMappedRange()).slice(0, 4);
+    readback.unmap();
+    readback.destroy?.();
+    return Object.freeze({
+      x,
+      y,
+      rgba: Object.freeze(Array.from(bytes)),
+      luminance: (0.2126 * bytes[0] + 0.7152 * bytes[1] + 0.0722 * bytes[2]) / 255,
+    });
+  }
+
+  function updateSceneObjects(sceneObjects) {
+    const nextPackedScene = packWavefrontSceneObjects(sceneObjects, config.sceneObjectCapacity);
+    packedScene = nextPackedScene;
+    config = createWavefrontPathTracingComputeConfig({
+      ...options,
+      canvas,
+      width: config.width,
+      height: config.height,
+      maxDepth: config.maxDepth,
+      tileSize: config.tileSize,
+      samplesPerPixel: config.samplesPerPixel,
+      sceneObjectCapacity: config.sceneObjectCapacity,
+      sceneObjects: packedScene.objects,
+      frameIndex: config.frameIndex,
+    });
+    device.queue.writeBuffer(sceneObjectBuffer, 0, packedScene.buffer);
+    return config;
+  }
+
+  function getSnapshot() {
+    return Object.freeze({
+      frame,
+      width: config.width,
+      height: config.height,
+      maxDepth: config.maxDepth,
+      tiles: tiles.length,
+      tileSize: config.tileSize,
+      samplesPerPixel: config.samplesPerPixel,
+      sceneObjectCount: config.sceneObjectCount,
+      triangleCount: config.triangleCount,
+      emissiveTriangleCount: config.emissiveTriangleCount,
+      bvhNodeCount: config.bvhNodeCount,
+      displayQuality: config.displayQuality,
+      accelerationBuildMode: config.accelerationBuildMode,
+      gpuAccelerationBuildRequired: config.gpuAccelerationBuildRequired,
+      memory: config.memory,
+    });
+  }
+
+  function destroy() {
+    activeQueue.destroy?.();
+    nextQueue.destroy?.();
+    hitBuffer.destroy?.();
+    accumulationBuffer.destroy?.();
+    sceneObjectBuffer.destroy?.();
+    triangleBuffer.destroy?.();
+    bvhNodeBuffer.destroy?.();
+    meshVertexBuffer.destroy?.();
+    meshIndexBuffer.destroy?.();
+    meshRangeBuffer.destroy?.();
+    bvhLeafRefBuffer.destroy?.();
+    configBuffer.destroy?.();
+    bvhBuildConfigBuffer.destroy?.();
+    counterBuffer.destroy?.();
+    radianceTexture.destroy?.();
+    denoiseScratchTexture.destroy?.();
+    outputTexture.destroy?.();
+    context.unconfigure?.();
+  }
+
+  return Object.freeze({
+    canvas,
+    context,
+    device,
+    format,
+    config,
+    renderOnce,
+    readOutputProbe,
+    updateSceneObjects,
+    getSnapshot,
+    destroy,
+  });
+}

--- a/tests/demo-contract.test.js
+++ b/tests/demo-contract.test.js
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+const demoSource = readFileSync(
+  path.resolve("demo", "main.js"),
+  "utf8"
+);
+
+test("renderer demo mounts the wavefront compute renderer directly", () => {
+  assert.match(demoSource, /createWavefrontPathTracingComputeRenderer/);
+  assert.match(demoSource, /createWavefrontEnvironmentLightingOptions/);
+  assert.match(demoSource, /displayQuality: true/);
+  assert.match(demoSource, /meshes: createDemoMeshes\(\)/);
+  assert.match(demoSource, /surface: "gpu-renderer-wavefront-demo"/);
+  assert.match(demoSource, /geometryMode: "mesh-bvh-display-quality"/);
+  assert.match(demoSource, /requiresMeshBvhForDisplayQuality: true/);
+  assert.match(demoSource, /requiresTriangleMeshForProductStudio: true/);
+  assert.doesNotMatch(demoSource, /mountGpuShowcase/);
+  assert.doesNotMatch(demoSource, /createDefaultWavefrontSceneObjects/);
+});

--- a/tests/wavefront-compute.test.js
+++ b/tests/wavefront-compute.test.js
@@ -1,0 +1,968 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import {
+  createWavefrontPathTracingComputeRenderer,
+  createDefaultWavefrontSceneObjects,
+  createWavefrontBvhBuildLevels,
+  createWavefrontBvhSortStages,
+  createWavefrontEmissiveTriangleIndexSource,
+  createWavefrontGpuMeshSource,
+  createWavefrontMeshAcceleration,
+  createWavefrontPathTracingComputeConfig,
+  estimateWavefrontPathTracingMemory,
+  normalizeWavefrontMesh,
+  normalizeWavefrontSceneObject,
+  packWavefrontBvhNodes,
+  packWavefrontSceneObjects,
+  packWavefrontTriangles,
+  supportsWavefrontPathTracingCompute,
+  wavefrontMaterialKinds,
+  wavefrontPathTracingComputeLimits,
+  wavefrontSceneObjectKinds,
+} from "../src/index.js";
+
+const gpuConstants = Object.freeze({
+  buffer: Object.freeze({
+    MAP_READ: 1,
+    COPY_DST: 2,
+    COPY_SRC: 4,
+    STORAGE: 8,
+    UNIFORM: 16,
+  }),
+  texture: Object.freeze({
+    COPY_SRC: 1,
+    STORAGE_BINDING: 2,
+    TEXTURE_BINDING: 4,
+  }),
+  shader: Object.freeze({
+    COMPUTE: 1,
+    FRAGMENT: 2,
+  }),
+  map: Object.freeze({
+    READ: 1,
+  }),
+});
+
+function round(values) {
+  return Array.from(values, (value) => Number(value.toFixed(4)));
+}
+
+function readRendererSource() {
+  return readFileSync(new URL("../src/wavefront-compute.js", import.meta.url), "utf8");
+}
+
+async function withWebGpuConstants(callback) {
+  const previous = {
+    GPUBufferUsage: globalThis.GPUBufferUsage,
+    GPUTextureUsage: globalThis.GPUTextureUsage,
+    GPUShaderStage: globalThis.GPUShaderStage,
+    GPUMapMode: globalThis.GPUMapMode,
+  };
+
+  globalThis.GPUBufferUsage = gpuConstants.buffer;
+  globalThis.GPUTextureUsage = gpuConstants.texture;
+  globalThis.GPUShaderStage = gpuConstants.shader;
+  globalThis.GPUMapMode = gpuConstants.map;
+  try {
+    return await callback();
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) {
+        delete globalThis[key];
+      } else {
+        globalThis[key] = value;
+      }
+    }
+  }
+}
+
+class FakeWavefrontBuffer {
+  constructor(descriptor) {
+    this.descriptor = descriptor;
+    this.destroyed = false;
+    this.readback = new Uint8Array(256);
+    this.readback.set([32, 64, 128, 255]);
+  }
+
+  async mapAsync() {}
+
+  getMappedRange() {
+    return this.readback.buffer;
+  }
+
+  unmap() {
+    this.unmapped = true;
+  }
+
+  destroy() {
+    this.destroyed = true;
+  }
+}
+
+class FakeWavefrontTexture {
+  constructor(descriptor) {
+    this.descriptor = descriptor;
+    this.destroyed = false;
+  }
+
+  createView() {
+    return { textureLabel: this.descriptor.label };
+  }
+
+  destroy() {
+    this.destroyed = true;
+  }
+}
+
+class FakeWavefrontComputePass {
+  constructor(device, descriptor) {
+    this.device = device;
+    this.descriptor = descriptor;
+  }
+
+  setBindGroup() {
+    this.device.bindGroupSets += 1;
+  }
+
+  setPipeline() {
+    this.device.pipelineSets += 1;
+  }
+
+  dispatchWorkgroups(...groups) {
+    this.device.dispatches.push(groups);
+  }
+
+  end() {
+    this.device.computePassesEnded += 1;
+  }
+}
+
+class FakeWavefrontRenderPass {
+  constructor(device, descriptor) {
+    this.device = device;
+    this.descriptor = descriptor;
+  }
+
+  setPipeline() {
+    this.device.pipelineSets += 1;
+  }
+
+  setBindGroup() {
+    this.device.bindGroupSets += 1;
+  }
+
+  draw(vertexCount) {
+    this.device.drawCalls.push(vertexCount);
+  }
+
+  end() {
+    this.device.renderPassesEnded += 1;
+  }
+}
+
+class FakeWavefrontCommandEncoder {
+  constructor(device, descriptor) {
+    this.device = device;
+    this.descriptor = descriptor;
+  }
+
+  beginComputePass(descriptor) {
+    this.device.computePasses += 1;
+    return new FakeWavefrontComputePass(this.device, descriptor);
+  }
+
+  beginRenderPass(descriptor) {
+    this.device.renderPasses += 1;
+    return new FakeWavefrontRenderPass(this.device, descriptor);
+  }
+
+  copyTextureToBuffer(source, destination, size) {
+    this.device.copyTextureToBufferCalls.push({ source, destination, size });
+  }
+
+  finish() {
+    return { encoderLabel: this.descriptor.label };
+  }
+}
+
+class FakeWavefrontDevice {
+  constructor() {
+    this.limits = {
+      maxStorageBufferBindingSize: 134_217_728,
+      minUniformBufferOffsetAlignment: 256,
+    };
+    this.buffers = [];
+    this.textures = [];
+    this.dispatches = [];
+    this.copyTextureToBufferCalls = [];
+    this.drawCalls = [];
+    this.pipelineLabels = [];
+    this.bindGroupSets = 0;
+    this.pipelineSets = 0;
+    this.computePasses = 0;
+    this.computePassesEnded = 0;
+    this.renderPasses = 0;
+    this.renderPassesEnded = 0;
+    this.queue = {
+      submissions: [],
+      writes: [],
+      submit: (buffers) => {
+        this.queue.submissions.push(buffers);
+      },
+      writeBuffer: (buffer, offset, data) => {
+        this.queue.writes.push({ buffer, offset, byteLength: data.byteLength ?? data.length ?? 0 });
+      },
+    };
+  }
+
+  createBuffer(descriptor) {
+    const buffer = new FakeWavefrontBuffer(descriptor);
+    this.buffers.push(buffer);
+    return buffer;
+  }
+
+  createTexture(descriptor) {
+    const texture = new FakeWavefrontTexture(descriptor);
+    this.textures.push(texture);
+    return texture;
+  }
+
+  createSampler(descriptor) {
+    return { descriptor };
+  }
+
+  createBindGroupLayout(descriptor) {
+    return { descriptor };
+  }
+
+  createPipelineLayout(descriptor) {
+    return { descriptor };
+  }
+
+  createShaderModule(descriptor) {
+    return {
+      descriptor,
+      async compilationInfo() {
+        return { messages: [] };
+      },
+    };
+  }
+
+  createBindGroup(descriptor) {
+    return { descriptor };
+  }
+
+  createComputePipeline(descriptor) {
+    this.pipelineLabels.push(descriptor.label);
+    return { descriptor };
+  }
+
+  createRenderPipeline(descriptor) {
+    return { descriptor };
+  }
+
+  createCommandEncoder(descriptor) {
+    return new FakeWavefrontCommandEncoder(this, descriptor);
+  }
+}
+
+function createFakeWavefrontNavigator(device = new FakeWavefrontDevice()) {
+  return {
+    gpu: {
+      async requestAdapter() {
+        return {
+          async requestDevice() {
+            return device;
+          },
+        };
+      },
+      getPreferredCanvasFormat() {
+        return "bgra8unorm";
+      },
+    },
+  };
+}
+
+function createFakeWavefrontCanvas() {
+  const context = {
+    configured: null,
+    configure(config) {
+      this.configured = config;
+    },
+    getCurrentTexture() {
+      return new FakeWavefrontTexture({ label: "plasius.wavefront.currentTexture" });
+    },
+    unconfigure() {
+      this.configured = null;
+    },
+  };
+
+  return {
+    width: 0,
+    height: 0,
+    getContext(type) {
+      return type === "webgpu" ? context : null;
+    },
+    context,
+  };
+}
+
+test("wavefront compute config keeps 4K queues tile-bounded", () => {
+  const config = createWavefrontPathTracingComputeConfig({
+    width: 3840,
+    height: 2160,
+    tileSize: 128,
+    maxDepth: 8,
+  });
+
+  assert.equal(config.width, 3840);
+  assert.equal(config.height, 2160);
+  assert.equal(config.maxDepth, 8);
+  assert.equal(config.samplesPerPixel, 1);
+  assert.equal(config.displayQuality, false);
+  assert.equal(config.requiresMeshBvhForDisplayQuality, true);
+  assert.equal(config.tilePixelCapacity, 128 * 128);
+  assert.equal(wavefrontPathTracingComputeLimits.hitRecordBytes, 208);
+  assert.equal(config.memory.queueBytes, 128 * 128 * wavefrontPathTracingComputeLimits.rayRecordBytes);
+  assert.equal(config.memory.hitBytes, 128 * 128 * wavefrontPathTracingComputeLimits.hitRecordBytes);
+  assert.equal(config.memory.configBytes, 256);
+  assert.equal(config.memory.bvhLeafReferenceBytes, 0);
+  assert.equal(config.memory.emissiveTriangleMetadataBytes, 0);
+  assert.ok(config.memory.queueBytes < 134_217_728);
+  assert.ok(config.memory.hitBytes < 134_217_728);
+});
+
+test("wavefront compute config exposes bounded samples per pixel", () => {
+  const config = createWavefrontPathTracingComputeConfig({
+    width: 640,
+    height: 360,
+    samplesPerPixel: 8,
+  });
+  const clamped = createWavefrontPathTracingComputeConfig({
+    width: 640,
+    height: 360,
+    samplesPerPixel: 128,
+  });
+
+  assert.equal(config.samplesPerPixel, 8);
+  assert.equal(clamped.samplesPerPixel, 64);
+  assert.throws(
+    () =>
+      createWavefrontPathTracingComputeConfig({
+        width: 640,
+        height: 360,
+        samplesPerPixel: 0,
+      }),
+    /samplesPerPixel must be a positive integer/
+  );
+});
+
+test("wavefront compute denoise remains a two-pass GPU post process", () => {
+  const source = readRendererSource();
+
+  assert.match(source, /rgba16float/);
+  assert.match(source, /radianceTexture/);
+  assert.match(source, /denoiseScratchTexture/);
+  assert.match(source, /radianceToScratch/);
+  assert.match(source, /scratchToOutput/);
+  assert.match(source, /denoiseLinearRadiance/);
+  assert.match(source, /resolveDenoisedOutputImage/);
+  assert.match(source, /tone_map_radiance/);
+  assert.doesNotMatch(source, /getImageData|putImageData|Uint8ClampedArray/);
+});
+
+test("wavefront compute guides active continuation rays toward emissive triangles", () => {
+  const source = readRendererSource();
+
+  assert.match(source, /emissiveTriangleIndices/);
+  assert.match(source, /sample_emissive_triangle_direction/);
+  assert.match(source, /config\.emissiveTriangleCount/);
+  assert.match(source, /RAY_FLAG_GUIDED_EMISSIVE/);
+  assert.match(source, /guidedLightWeight/);
+  assert.match(source, /\(pixelId \* 747796405u\) \^/);
+  assert.match(source, /mix_seed\(sourcePixelId, sampleId, 0u, config\.frameIndex, 1u\)/);
+  assert.match(source, /mix_seed\(ray\.sourcePixelId, ray\.sampleId, ray\.bounce, config\.frameIndex, 11u\)/);
+  assert.match(source, /bvhNodes\[config\.bvhNodeCapacity \+ lightSlot\]/);
+  assert.match(source, /nextIndex >= config\.tilePixelCount/);
+  assert.doesNotMatch(source, /binding: 19/);
+  assert.doesNotMatch(source, /direct_key_lighting/);
+});
+
+test("analytic wavefront renderer rejects display-quality requests", () => {
+  assert.throws(
+    () =>
+      createWavefrontPathTracingComputeConfig({
+        width: 640,
+        height: 360,
+        displayQuality: true,
+      }),
+    /Display-quality path tracing requires mesh BVH triangle intersections/
+  );
+});
+
+test("display-quality wavefront config schedules GPU mesh BVH build input", () => {
+  const config = createWavefrontPathTracingComputeConfig({
+    width: 640,
+    height: 360,
+    displayQuality: true,
+    meshes: [
+      {
+        id: 9,
+        positions: [0, 0, 0, 1, 0, 0, 0, 1, 0],
+        indices: [0, 1, 2],
+        normals: [0, 0, 1, 0, 0, 1, 0, 0, 1],
+        color: [0.8, 0.7, 0.6, 1],
+      },
+    ],
+  });
+
+  assert.equal(config.displayQuality, true);
+  assert.equal(config.accelerationBuildMode, "gpu");
+  assert.equal(config.gpuAccelerationBuildRequired, true);
+  assert.equal(config.sceneObjectCount, 0);
+  assert.equal(config.triangleCount, 1);
+  assert.equal(config.bvhNodeCount, 1);
+  assert.equal(config.bvhNodeCapacity, 1);
+  assert.equal(config.bvhLeafSortCapacity, 1);
+  assert.deepEqual(config.bvhSortStages, []);
+  assert.deepEqual(config.bvhBuildLevels, []);
+  assert.equal(config.meshAcceleration.triangles.length, 0);
+  assert.equal(config.gpuMeshSource.vertices.count, 3);
+  assert.equal(config.gpuMeshSource.indices.count, 3);
+  assert.equal(config.gpuMeshSource.meshes.count, 1);
+  assert.equal(config.emissiveTriangleCount, 0);
+  assert.equal(config.memory.triangleBytes, wavefrontPathTracingComputeLimits.triangleRecordBytes);
+  assert.equal(config.memory.bvhNodeBytes, wavefrontPathTracingComputeLimits.bvhNodeRecordBytes);
+  assert.equal(config.memory.emissiveTriangleMetadataBytes, 0);
+});
+
+test("display-quality wavefront config rejects CPU-built acceleration mode", () => {
+  assert.throws(
+    () =>
+      createWavefrontPathTracingComputeConfig({
+        width: 640,
+        height: 360,
+        displayQuality: true,
+        accelerationBuildMode: "cpu-debug",
+        meshes: [
+          {
+            positions: [0, 0, 0, 1, 0, 0, 0, 1, 0],
+          },
+        ],
+      }),
+    /Display-quality path tracing requires GPU-built mesh acceleration/
+  );
+});
+
+test("wavefront BVH build levels schedule parent nodes concurrently bottom-up", () => {
+  const mesh = {
+    positions: [
+      -3, 0, 0,
+      -2.5, 0, 0,
+      -3, 0.5, 0,
+      -2, 0, 0,
+      -1.5, 0, 0,
+      -2, 0.5, 0,
+      -1, 0, 0,
+      -0.5, 0, 0,
+      -1, 0.5, 0,
+      0, 0, 0,
+      0.5, 0, 0,
+      0, 0.5, 0,
+      1, 0, 0,
+      1.5, 0, 0,
+      1, 0.5, 0,
+      2, 0, 0,
+      2.5, 0, 0,
+      2, 0.5, 0,
+      3, 0, 0,
+      3.5, 0, 0,
+      3, 0.5, 0,
+    ],
+  };
+  const expected = [
+    { start: 3, count: 3 },
+    { start: 1, count: 2 },
+    { start: 0, count: 1 },
+  ];
+  const expectedSortStages = [
+    { compareDistance: 1, sequenceSize: 2 },
+    { compareDistance: 2, sequenceSize: 4 },
+    { compareDistance: 1, sequenceSize: 4 },
+    { compareDistance: 4, sequenceSize: 8 },
+    { compareDistance: 2, sequenceSize: 8 },
+    { compareDistance: 1, sequenceSize: 8 },
+  ];
+  const config = createWavefrontPathTracingComputeConfig({
+    width: 640,
+    height: 360,
+    displayQuality: true,
+    meshes: [mesh],
+  });
+
+  assert.deepEqual(createWavefrontBvhBuildLevels(1), []);
+  assert.deepEqual(createWavefrontBvhBuildLevels(7), expected);
+  assert.deepEqual(createWavefrontBvhSortStages(1), []);
+  assert.deepEqual(createWavefrontBvhSortStages(7), expectedSortStages);
+  assert.equal(config.bvhLeafSortCapacity, 8);
+  assert.deepEqual(config.bvhSortStages, expectedSortStages);
+  assert.deepEqual(config.bvhBuildLevels, expected);
+  assert.equal(config.triangleCount, 7);
+  assert.equal(config.bvhNodeCount, 13);
+  assert.equal(
+    config.memory.bvhLeafReferenceBytes,
+    8 * wavefrontPathTracingComputeLimits.bvhLeafReferenceRecordBytes
+  );
+});
+
+test("wavefront mesh acceleration preserves triangle vertices and normals", () => {
+  const mesh = normalizeWavefrontMesh({
+    id: 12,
+    positions: [0, 0, 0, 2, 0, 0, 0, 2, 0],
+    indices: [0, 1, 2],
+    normals: [0, 0, 1, 0, 0, 1, 0, 0, 1],
+    uvs: [0, 0, 1, 0, 0, 1],
+    materialKind: "metal",
+    materialRefId: 98,
+    mediumRefId: 7,
+  });
+  const acceleration = createWavefrontMeshAcceleration([mesh]);
+  const triangle = acceleration.triangles[0];
+
+  assert.equal(mesh.id, 12);
+  assert.equal(acceleration.nodes.length, 1);
+  assert.equal(triangle.meshId, 12);
+  assert.deepEqual(triangle.v1, [2, 0, 0]);
+  assert.deepEqual(triangle.n2, [0, 0, 1]);
+  assert.deepEqual(triangle.uv2, [0, 1]);
+  assert.equal(triangle.materialRefId, 98);
+  assert.equal(triangle.mediumRefId, 7);
+  assert.deepEqual(acceleration.nodes[0].bounds.min, [0, 0, 0]);
+  assert.deepEqual(acceleration.nodes[0].bounds.max, [2, 2, 0]);
+});
+
+test("wavefront GPU mesh source packs raw mesh buffers without CPU BVH output", () => {
+  const source = createWavefrontGpuMeshSource([
+    {
+      id: 31,
+      positions: [0, 0, 0, 2, 0, 0, 0, 2, 0],
+      indices: [0, 1, 2],
+      normals: [0, 0, 1, 0, 0.6, 0.8, 0.6, 0, 0.8],
+      uvs: [0, 0, 1, 0, 0, 1],
+      materialKind: "dielectric",
+      materialRefId: 22,
+      mediumRefId: 3,
+      color: [0.25, 0.5, 0.75, 0.9],
+    },
+  ]);
+  const vertexFloats = new Float32Array(source.vertices.buffer);
+  const indexUints = new Uint32Array(source.indices.buffer);
+  const meshUints = new Uint32Array(source.meshes.buffer);
+  const meshFloats = new Float32Array(source.meshes.buffer);
+
+  assert.equal(source.vertices.buffer.byteLength, 3 * wavefrontPathTracingComputeLimits.meshVertexRecordBytes);
+  assert.equal(source.indices.buffer.byteLength, 3 * 4);
+  assert.equal(source.meshes.buffer.byteLength, wavefrontPathTracingComputeLimits.meshRangeRecordBytes);
+  assert.equal(source.triangleCount, 1);
+  assert.equal(source.bvhNodeCapacity, 1);
+  assert.deepEqual(round(vertexFloats.slice(0, 12)), [0, 0, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0]);
+  assert.deepEqual(Array.from(indexUints.slice(0, 3)), [0, 1, 2]);
+  assert.deepEqual(
+    Array.from(meshUints.slice(0, 11)),
+    [31, wavefrontMaterialKinds.dielectric, 0, 22, 3, 0, 3, 0, 1, 0, 3]
+  );
+  assert.deepEqual(round(meshFloats.slice(12, 16)), [0.25, 0.5, 0.75, 0.9]);
+});
+
+test("wavefront emissive triangle index source tracks light mesh triangle order", () => {
+  const source = createWavefrontEmissiveTriangleIndexSource([
+    {
+      positions: [0, 0, 0, 2, 0, 0, 0, 2, 0],
+      indices: [0, 1, 2],
+      materialKind: "diffuse",
+    },
+    {
+      positions: [
+        0, 1, 0,
+        1, 1, 0,
+        1, 2, 0,
+        0, 2, 0,
+      ],
+      indices: [0, 1, 2, 0, 2, 3],
+      materialKind: "emissive",
+      emission: [4, 3, 2, 1],
+    },
+  ]);
+  const uints = new Uint32Array(source.buffer);
+
+  assert.deepEqual(source.indices, [1, 2]);
+  assert.equal(source.count, 2);
+  assert.equal(source.capacity, 2);
+  assert.equal(source.recordBytes, wavefrontPathTracingComputeLimits.emissiveTriangleIndexBytes);
+  assert.deepEqual(Array.from(uints), [1, 2]);
+});
+
+test("wavefront config stores emissive guidance metadata in the BVH buffer tail", () => {
+  const config = createWavefrontPathTracingComputeConfig({
+    width: 640,
+    height: 360,
+    displayQuality: true,
+    meshes: [
+      {
+        positions: [
+          0, 1, 0,
+          1, 1, 0,
+          1, 2, 0,
+          0, 2, 0,
+        ],
+        indices: [0, 1, 2, 0, 2, 3],
+        materialKind: "emissive",
+        emission: [4, 3, 2, 1],
+      },
+    ],
+  });
+
+  assert.equal(config.emissiveTriangleCount, 2);
+  assert.equal(config.emissiveTriangleCapacity, 2);
+  assert.equal(
+    config.memory.emissiveTriangleMetadataBytes,
+    2 * wavefrontPathTracingComputeLimits.emissiveTriangleMetadataRecordBytes
+  );
+});
+
+test("wavefront mesh acceleration derives flat normals when vertex normals are absent", () => {
+  const acceleration = createWavefrontMeshAcceleration([
+    {
+      id: 15,
+      positions: [0, 0, 0, 1, 0, 0, 0, 1, 0],
+      indices: [0, 1, 2],
+    },
+  ]);
+  const triangle = acceleration.triangles[0];
+
+  assert.deepEqual(round(triangle.n0), [0, 0, 1]);
+  assert.deepEqual(round(triangle.n1), [0, 0, 1]);
+  assert.deepEqual(round(triangle.n2), [0, 0, 1]);
+});
+
+test("wavefront mesh acceleration keeps smooth normals for shader interpolation", () => {
+  const acceleration = createWavefrontMeshAcceleration([
+    {
+      id: 16,
+      positions: [0, 0, 0, 1, 0, 0, 0, 1, 0],
+      indices: [0, 1, 2],
+      normals: [0, 0, 1, 0, 0.6, 0.8, 0.6, 0, 0.8],
+    },
+  ]);
+  const triangle = acceleration.triangles[0];
+
+  assert.deepEqual(round(triangle.n0), [0, 0, 1]);
+  assert.deepEqual(round(triangle.n1), [0, 0.6, 0.8]);
+  assert.deepEqual(round(triangle.n2), [0.6, 0, 0.8]);
+});
+
+test("wavefront mesh acceleration builds BVH leaves with stable global triangle ids", () => {
+  const acceleration = createWavefrontMeshAcceleration([
+    {
+      id: 20,
+      positions: [
+        -3, 0, 0,
+        -2.5, 0, 0,
+        -3, 0.5, 0,
+        -2, 0, 0,
+        -1.5, 0, 0,
+        -2, 0.5, 0,
+        -1, 0, 0,
+        -0.5, 0, 0,
+        -1, 0.5, 0,
+        0, 0, 0,
+        0.5, 0, 0,
+        0, 0.5, 0,
+        1, 0, 0,
+        1.5, 0, 0,
+        1, 0.5, 0,
+        2, 0, 0,
+        2.5, 0, 0,
+        2, 0.5, 0,
+      ],
+    },
+    {
+      id: 21,
+      positions: [3, 0, 0, 3.5, 0, 0, 3, 0.5, 0],
+    },
+  ]);
+  const triangleIds = acceleration.triangles.map((triangle) => triangle.triangleId).sort((a, b) => a - b);
+  const leafNodes = acceleration.nodes.filter((node) => node.triangleCount > 0);
+  const root = acceleration.nodes[0];
+
+  assert.equal(acceleration.triangles.length, 7);
+  assert.ok(acceleration.nodes.length > 1);
+  assert.equal(root.triangleCount, 0);
+  assert.deepEqual(triangleIds, [0, 1, 2, 3, 4, 5, 6]);
+  assert.equal(leafNodes.every((node) => node.triangleCount <= 4), true);
+  assert.deepEqual(root.bounds.min, [-3, 0, 0]);
+  assert.deepEqual(root.bounds.max, [3.5, 0.5, 0]);
+});
+
+test("wavefront triangle and BVH packers use stable GPU record layouts", () => {
+  const acceleration = createWavefrontMeshAcceleration([
+    {
+      id: 4,
+      positions: [0, 0, 0, 1, 0, 0, 0, 1, 0],
+      indices: [0, 1, 2],
+      normals: [0, 0, 1, 0, 0, 1, 0, 0, 1],
+      emission: [2, 1, 0.5, 1],
+    },
+  ]);
+  const packedTriangles = packWavefrontTriangles(acceleration.triangles, 2);
+  const packedNodes = packWavefrontBvhNodes(acceleration.nodes, 2);
+  const triangleUints = new Uint32Array(packedTriangles.buffer);
+  const triangleFloats = new Float32Array(packedTriangles.buffer);
+  const nodeUints = new Uint32Array(packedNodes.buffer);
+
+  assert.equal(packedTriangles.buffer.byteLength, 2 * wavefrontPathTracingComputeLimits.triangleRecordBytes);
+  assert.equal(packedNodes.buffer.byteLength, 2 * wavefrontPathTracingComputeLimits.bvhNodeRecordBytes);
+  assert.equal(triangleUints[1], 4);
+  assert.equal(triangleUints[2], wavefrontMaterialKinds.emissive);
+  assert.equal(triangleUints[4], 0);
+  assert.equal(triangleUints[5], 0);
+  assert.deepEqual(round(triangleFloats.slice(8, 12)), [0, 0, 0, 0]);
+  assert.deepEqual(round(triangleFloats.slice(40, 44)), [0.72, 0.72, 0.68, 1]);
+  assert.deepEqual(round(triangleFloats.slice(44, 48)), [2, 1, 0.5, 1]);
+  assert.equal(nodeUints[9], 1);
+});
+
+test("wavefront compute config accepts lighting-owned environment payloads", () => {
+  const config = createWavefrontPathTracingComputeConfig({
+    width: 640,
+    height: 360,
+    environmentLighting: {
+      horizonColor: [0.5, 0.6, 0.7, 1],
+      zenithColor: [0.05, 0.08, 0.14, 1],
+      sunDirection: [0, 2, 0],
+      sunColor: [3, 2.8, 2.4, 1],
+      intensity: 1.25,
+      mode: 2,
+      exposure: 0.9,
+    },
+  });
+
+  assert.deepEqual(config.environmentLighting.horizonColor, [0.5, 0.6, 0.7, 1]);
+  assert.deepEqual(config.environmentLighting.zenithColor, [0.05, 0.08, 0.14, 1]);
+  assert.deepEqual(config.environmentLighting.sunDirection, [0, 1, 0]);
+  assert.deepEqual(config.environmentLighting.sunColor, [3, 2.8, 2.4, 1]);
+  assert.equal(config.environmentLighting.intensity, 1.25);
+  assert.equal(config.environmentLighting.mode, 2);
+  assert.equal(config.environmentLighting.exposure, 0.9);
+});
+
+test("wavefront scene object normalization derives boxes from bounds", () => {
+  const object = normalizeWavefrontSceneObject({
+    id: 42,
+    type: "bounds",
+    bounds: {
+      min: [-2, -1, 3],
+      max: [4, 5, 9],
+    },
+    material: {
+      kind: "metal",
+      baseColor: [0.7, 0.5, 0.25, 1],
+      roughness: 0.2,
+      metallic: 0.9,
+    },
+  });
+
+  assert.equal(object.id, 42);
+  assert.equal(object.kind, wavefrontSceneObjectKinds.box);
+  assert.equal(object.materialKind, wavefrontMaterialKinds.metal);
+  assert.deepEqual(object.center, [1, 2, 6]);
+  assert.deepEqual(object.halfExtent, [3, 3, 3]);
+  assert.equal(object.roughness, 0.2);
+  assert.equal(object.metallic, 0.9);
+});
+
+test("wavefront scene objects pack into stable GPU record layout", () => {
+  const packed = packWavefrontSceneObjects(
+    [
+      {
+        id: 7,
+        type: "sphere",
+        center: [1, 2, 3],
+        radius: 0.75,
+        color: [0.1, 0.2, 0.3, 0.4],
+        emission: [5, 4, 3, 1],
+      },
+    ],
+    2
+  );
+
+  assert.equal(packed.count, 1);
+  assert.equal(packed.capacity, 2);
+  assert.equal(packed.buffer.byteLength, 2 * wavefrontPathTracingComputeLimits.sceneObjectRecordBytes);
+
+  const uints = new Uint32Array(packed.buffer);
+  const floats = new Float32Array(packed.buffer);
+  assert.equal(uints[0], wavefrontSceneObjectKinds.sphere);
+  assert.equal(uints[1], 7);
+  assert.equal(uints[2], wavefrontMaterialKinds.emissive);
+  assert.deepEqual(round(floats.slice(4, 8)), [1, 2, 3, 0]);
+  assert.deepEqual(round(floats.slice(8, 12)), [0.75, 0.75, 0.75, 0]);
+  assert.deepEqual(round(floats.slice(16, 20)), [5, 4, 3, 1]);
+});
+
+test("wavefront scene objects pack opacity in material channel z", () => {
+  const packed = packWavefrontSceneObjects([
+    {
+      id: 8,
+      type: "sphere",
+      radius: 0.5,
+      color: [0.5, 0.6, 0.7, 0.35],
+      roughness: 0.91,
+      opacity: 0.35,
+      materialKind: "transparent",
+    },
+  ]);
+  const floats = new Float32Array(packed.buffer);
+
+  assert.deepEqual(round(floats.slice(20, 24)), [0.91, 0, 0.35, 1.45]);
+});
+
+test("wavefront compute helper reports unavailable WebGPU when navigator.gpu is missing", () => {
+  assert.equal(supportsWavefrontPathTracingCompute({ navigator: {} }), false);
+  assert.equal(
+    supportsWavefrontPathTracingCompute({
+      navigator: {
+        gpu: {
+          async requestAdapter() {
+            return null;
+          },
+        },
+      },
+    }),
+    true
+  );
+});
+
+test("wavefront compute renderer rejects unavailable WebGPU setup paths", async () => {
+  await withWebGpuConstants(async () => {
+    await assert.rejects(
+      createWavefrontPathTracingComputeRenderer({
+        canvas: createFakeWavefrontCanvas(),
+        navigator: {},
+        width: 8,
+        height: 8,
+      }),
+      /requires navigator\.gpu/
+    );
+
+    await assert.rejects(
+      createWavefrontPathTracingComputeRenderer({
+        canvas: createFakeWavefrontCanvas(),
+        navigator: {
+          gpu: {
+            async requestAdapter() {
+              return null;
+            },
+          },
+        },
+        width: 8,
+        height: 8,
+      }),
+      /Unable to acquire a WebGPU adapter/
+    );
+
+    await assert.rejects(
+      createWavefrontPathTracingComputeRenderer({
+        canvas: {
+          width: 0,
+          height: 0,
+          getContext() {
+            return null;
+          },
+        },
+        navigator: createFakeWavefrontNavigator(),
+        width: 8,
+        height: 8,
+      }),
+      /context does not support configure/
+    );
+  });
+});
+
+test("wavefront compute renderer drives GPU-only mesh BVH passes", async () => {
+  await withWebGpuConstants(async () => {
+    const device = new FakeWavefrontDevice();
+    const canvas = createFakeWavefrontCanvas();
+    const renderer = await createWavefrontPathTracingComputeRenderer({
+      canvas,
+      navigator: createFakeWavefrontNavigator(device),
+      width: 8,
+      height: 8,
+      tileSize: 8,
+      maxDepth: 2,
+      samplesPerPixel: 2,
+      denoise: true,
+      displayQuality: true,
+      meshes: [
+        {
+          id: 77,
+          positions: [
+            -1, 0, 0,
+            1, 0, 0,
+            0, 1, 0,
+          ],
+          indices: [0, 1, 2],
+          normals: [0, 0, 1, 0, 0.4, 0.9, 0.4, 0, 0.9],
+          materialKind: "emissive",
+          emission: [4, 3, 2, 1],
+        },
+      ],
+    });
+
+    const frame = renderer.renderOnce();
+    const probe = await renderer.readOutputProbe({ x: 2, y: 3 });
+    const nextConfig = renderer.updateSceneObjects([]);
+    const snapshot = renderer.getSnapshot();
+
+    assert.equal(canvas.width, 8);
+    assert.equal(canvas.height, 8);
+    assert.equal(canvas.context.configured.format, "bgra8unorm");
+    assert.equal(frame.frame, 1);
+    assert.equal(frame.displayQuality, true);
+    assert.equal(frame.gpuAccelerationBuildRequired, true);
+    assert.equal(frame.primaryRays, 128);
+    assert.equal(frame.tiles, 1);
+    assert.equal(probe.x, 2);
+    assert.equal(probe.y, 3);
+    assert.deepEqual(probe.rgba, [32, 64, 128, 255]);
+    assert.equal(nextConfig.displayQuality, true);
+    assert.equal(snapshot.frame, 1);
+    assert.equal(snapshot.triangleCount, 1);
+    assert.ok(device.pipelineLabels.includes("plasius.wavefront.prepareMeshTrianglesAndLeaves"));
+    assert.ok(device.pipelineLabels.includes("plasius.wavefront.generatePrimaryRays"));
+    assert.ok(device.pipelineLabels.includes("plasius.wavefront.denoiseLinearRadiance"));
+    assert.ok(device.computePasses >= 5);
+    assert.ok(device.renderPasses >= 1);
+    assert.equal(device.drawCalls.includes(3), true);
+    assert.ok(device.queue.submissions.length >= 1);
+    assert.equal(device.copyTextureToBufferCalls.length, 1);
+
+    renderer.destroy();
+    assert.equal(canvas.context.configured, null);
+    assert.equal(device.buffers.every((buffer) => buffer.destroyed), true);
+    assert.equal(device.textures.every((texture) => texture.destroyed), true);
+  });
+});
+
+test("default wavefront scene includes emissive termination geometry", () => {
+  const objects = createDefaultWavefrontSceneObjects();
+  assert.equal(objects.some((object) => object.materialKind === wavefrontMaterialKinds.emissive), true);
+
+  const estimate = estimateWavefrontPathTracingMemory({
+    tilePixelCapacity: 256 * 256,
+    sceneObjectCapacity: 128,
+  });
+  assert.ok(estimate.queueBytes < 134_217_728);
+  assert.ok(estimate.totalHotBufferBytes < 32_000_000);
+});


### PR DESCRIPTION
## Summary
- Adds the WebGPU wavefront path tracing renderer with tiled ray queues, GPU mesh BVH build/traversal, emissive termination, environment/ambient fallback, denoise, and presentation.
- Updates renderer public contracts, demo wiring, ADRs, README, and changelog for the mesh-BVH display-quality path.
- Bumps @plasius/gpu-renderer to 0.1.14 and hardens the CD workflow so bump=none creates the matching release tag before npm publish.

## Validation
- npm run test:coverage
- npm run lint
- npm run typecheck
- npm run build
- npm run audit:npm
- npm run pack:check

## Release note
After this PR merges to main, run the CD workflow with bump=none to publish the existing 0.1.14 package version.