### PR TITLE
docs(changelog): release v0.1.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 - **Added**
+  - (placeholder)
+
+- **Changed**
+  - (placeholder)
+
+- **Fixed**
+  - (placeholder)
+
+- **Security**
+  - (placeholder)
+
+## [0.1.14] - 2026-06-04
+
+- **Added**
   - Added wavefront path-tracing queue/buffer contracts and bounce-schedule
     metadata beneath `createRayTracingRenderPlan(...)`.
   - Added a tiled WebGPU wavefront compute renderer with scene-object buffers,
@@ -247,3 +261,4 @@ All notable changes to this project will be documented in this file.
 [0.1.10]: https://github.com/Plasius-LTD/gpu-renderer/releases/tag/v0.1.10
 [0.1.11]: https://github.com/Plasius-LTD/gpu-renderer/releases/tag/v0.1.11
 [0.1.12]: https://github.com/Plasius-LTD/gpu-renderer/releases/tag/v0.1.12
+[0.1.14]: https://github.com/Plasius-LTD/gpu-renderer/releases/tag/v0.1.14


### PR DESCRIPTION
Generated by the successful CD workflow run 26954715960 for v0.1.14. The npm package and GitHub release are already published; this PR persists the release-entry changelog update on protected main.