### PR TITLE
[codex] Harden wavefront mesh renderer batching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,10 +57,15 @@ All notable changes to this project will be documented in this file.
     tail so active diffuse rays sample finite mesh light geometry more often
     without adding a ninth trace storage buffer or separate direct-light/shadow
     accumulation path.
+  - Added WebGPU environment-light portal records so rooms and studio interiors
+    can guide and gate sky/HDRI contribution through openings such as windows.
 
 - **Changed**
   - Wavefront environment misses now evaluate a direction-aware sky/key-light
     environment payload instead of only using a flat environment colour.
+  - Wavefront environment misses now respect `environmentPortalMode`; in
+    `guide-and-gate` mode, misses outside configured portals fall back to the
+    ambient residual instead of receiving full sky radiance.
   - Display-quality wavefront configuration now uses GPU-built mesh
     acceleration; CPU-built mesh acceleration is treated as debug-only.
   - Replaced the one-thread BVH internal-node build kernel with bottom-up
@@ -78,11 +83,17 @@ All notable changes to this project will be documented in this file.
     preview output.
   - Wavefront primary-ray jitter and bounce sampling now use mixed
     pixel/sample/bounce/frame seeds to reduce row-correlated low-sample noise.
+  - Wavefront frames now reuse a static GPU-built mesh BVH after the first
+    acceleration build and batch tile/sample tracing, tile output, optional
+    denoise, and presentation into one frame command submission.
 
 - **Fixed**
   - Fixed primary-ray jitter seeding to use absolute screen pixel ids instead
     of tile-local pixel ids, preventing repeated sampling patterns across
     tiles.
+  - Fixed environment portal WGSL reserved-word usage and now request the
+    required 9-storage-buffer trace limit from capable WebGPU adapters before
+    creating the mesh-BVH trace pipeline.
   - Fixed the WebGPU hit-buffer stride to match the WGSL `HitRecord` layout
     and added a continuation-queue capacity guard, preventing tile-row
     corruption in mesh BVH wavefront renders.

--- a/README.md
+++ b/README.md
@@ -200,6 +200,19 @@ weight so finite light guidance does not over-expose low-sample renders before
 full material PDFs/MIS are implemented. High-energy samples are clamped in
 linear radiance space to keep low-sample preview output stable while production
 sampling, temporal accumulation, and better material PDFs are hardened.
+For static mesh scenes, the GPU acceleration build is submitted once and then
+reused by subsequent frames. Per-frame tracing writes one dynamic uniform slot
+per tile/sample or post-process pass and batches tile tracing, tile output,
+optional denoise, and presentation into a single command submission. WebGPU
+still preserves ordering between dependent bounce passes, but the renderer no
+longer forces one CPU queue submission per tile/sample.
+Environment-light portals can additionally guide and gate sky/HDRI contribution
+through rectangular openings such as windows. `environmentPortalMode: "guide"`
+biases diffuse continuation rays toward configured openings, while
+`"guide-and-gate"` requires an environment miss to pass through a portal before
+it receives sky radiance; misses outside a portal fall back to the ambient
+residual. This keeps interior rooms from treating the whole sky as visible from
+every bounce.
 Texture sampling, dynamic TLAS updates, higher-grade LBVH/SAH construction,
 runtime execution behind the `@plasius/gpu-worker` lock-free queue, and broader
 material lookup remain follow-up work.

--- a/docs/adrs/adr-0007-triangle-mesh-wavefront-path-tracing.md
+++ b/docs/adrs/adr-0007-triangle-mesh-wavefront-path-tracing.md
@@ -109,9 +109,27 @@ bounded estimator weight until full material PDFs/MIS are implemented. Radiance
 clamping and damped diffuse throughput reduce fireflies while continuation rays
 still evaluate mesh BVH hits.
 
+Static mesh acceleration builds are amortized: the renderer submits GPU mesh
+triangle/BVH construction once for a static scene and reuses the built buffers
+across subsequent frames. Frame tracing is also batched into a single command
+submission with dynamic config offsets per tile/sample/post-process pass. This
+keeps dependent bounce passes ordered on the WebGPU queue while reducing
+browser-side submission overhead and avoiding accidental CPU-style serialization
+at tile/sample granularity.
+
+Interior scenes can additionally upload rectangular environment-light portals
+for windows, doors, or other openings. Portal records are a GPU trace-stage
+buffer, not CPU-side ray filtering. In `guide` mode, diffuse continuation rays
+are biased toward configured openings while environment misses remain
+unrestricted. In `guide-and-gate` mode, an environment miss receives sky/HDRI
+radiance only when the ray exits through a portal; misses outside the aperture
+fall back to the ambient residual. This keeps room lighting consistent with the
+single active-ray path-tracing model while reducing wasted diffuse samples that
+cannot plausibly reach external lighting.
+
 The remaining production-hardening work is not optional: material-id lookup
 tables, texture sampling, direct-light PDF/MIS correction, dynamic TLAS instance
-records, higher-grade LBVH/SAH construction, runtime execution behind the
-`@plasius/gpu-worker` lock-free queue, runtime GPU smoke coverage, and
-larger-scene traversal benchmarks still need to land before the mesh renderer is
-treated as final production-quality output.
+records, higher-grade LBVH/SAH construction, portal solid-angle/PDF correction,
+runtime execution behind the `@plasius/gpu-worker` lock-free queue, runtime GPU
+smoke coverage, and larger-scene traversal benchmarks still need to land before
+the mesh renderer is treated as final production-quality output.

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -209,6 +209,42 @@ export interface WavefrontEmissiveTriangleIndexSource {
   readonly recordBytes: 4;
 }
 
+export type WavefrontEnvironmentPortalMode =
+  | 0
+  | 1
+  | 2
+  | "disabled"
+  | "guide"
+  | "guide-and-gate"
+  | "gate";
+
+export interface WavefrontEnvironmentPortalInput {
+  readonly kind?: "rectangle";
+  readonly shape?: "rectangle";
+  readonly position?: readonly [number, number, number] | readonly number[];
+  readonly center?: readonly [number, number, number] | readonly number[];
+  readonly normal?: readonly [number, number, number] | readonly number[];
+  readonly tangent?: readonly [number, number, number] | readonly number[];
+  readonly width?: number;
+  readonly height?: number;
+  readonly halfWidth?: number;
+  readonly halfHeight?: number;
+  readonly radianceScale?: number;
+  readonly intensity?: number;
+  readonly color?: readonly [number, number, number, number?] | readonly number[];
+  readonly twoSided?: boolean;
+}
+
+export interface WavefrontEnvironmentPortalRecord {
+  readonly kind: 1;
+  readonly flags: number;
+  readonly position: readonly [number, number, number, number] | readonly number[];
+  readonly normal: readonly [number, number, number, number] | readonly number[];
+  readonly tangent: readonly [number, number, number, number] | readonly number[];
+  readonly bitangent: readonly [number, number, number, number] | readonly number[];
+  readonly color: readonly [number, number, number, number] | readonly number[];
+}
+
 export interface WavefrontPathTracingComputeConfig {
   readonly width: number;
   readonly height: number;
@@ -226,6 +262,10 @@ export interface WavefrontPathTracingComputeConfig {
   readonly emissiveTriangleIndices: WavefrontEmissiveTriangleIndexSource;
   readonly emissiveTriangleCount: number;
   readonly emissiveTriangleCapacity: number;
+  readonly environmentPortals: readonly WavefrontEnvironmentPortalRecord[];
+  readonly environmentPortalCount: number;
+  readonly environmentPortalCapacity: number;
+  readonly environmentPortalMode: 0 | 1 | 2;
   readonly triangleCount: number;
   readonly triangleCapacity: number;
   readonly bvhNodeCount: number;
@@ -262,6 +302,8 @@ export interface WavefrontEnvironmentLightingInput {
   readonly intensity?: number;
   readonly mode?: number;
   readonly exposure?: number;
+  readonly environmentPortals?: readonly WavefrontEnvironmentPortalInput[];
+  readonly environmentPortalMode?: WavefrontEnvironmentPortalMode;
 }
 
 export interface WavefrontEnvironmentLightingConfig {
@@ -286,6 +328,7 @@ export interface WavefrontPathTracingMemoryEstimate {
   readonly bvhNodeBytes: number;
   readonly bvhLeafReferenceBytes: number;
   readonly emissiveTriangleMetadataBytes: number;
+  readonly environmentPortalBytes: number;
   readonly configBytes: number;
   readonly counterBytes: number;
   readonly totalHotBufferBytes: number;
@@ -295,6 +338,8 @@ export interface CreateWavefrontPathTracingComputeRendererOptions {
   readonly canvas?: HTMLCanvasElement | string;
   readonly navigator?: Navigator | { gpu?: GPU };
   readonly document?: Document;
+  readonly deviceDescriptor?: GPUDeviceDescriptor;
+  readonly requiredLimits?: Partial<Record<string, number>>;
   readonly powerPreference?: GPUPowerPreference;
   readonly alpha?: boolean;
   readonly format?: GPUTextureFormat;
@@ -312,6 +357,11 @@ export interface CreateWavefrontPathTracingComputeRendererOptions {
   readonly bvhNodeCapacity?: number;
   readonly bvhLeafSortCapacity?: number;
   readonly emissiveTriangleCapacity?: number;
+  readonly environmentPortalCapacity?: number;
+  readonly environmentPortals?: readonly WavefrontEnvironmentPortalInput[];
+  readonly environmentLightPortals?: readonly WavefrontEnvironmentPortalInput[];
+  readonly environmentPortalMode?: WavefrontEnvironmentPortalMode;
+  readonly portalMode?: WavefrontEnvironmentPortalMode;
   readonly accelerationBuildMode?: WavefrontAccelerationBuildMode;
   readonly camera?: WavefrontCameraOptions;
   readonly environmentColor?: readonly [number, number, number, number?] | readonly number[];
@@ -341,10 +391,17 @@ export interface WavefrontPathTracingComputeRenderer {
     sceneObjectCount: number;
     triangleCount: number;
     emissiveTriangleCount: number;
+    environmentPortalCount: number;
+    environmentPortalMode: 0 | 1 | 2;
     bvhNodeCount: number;
     displayQuality: boolean;
     accelerationBuildMode: WavefrontAccelerationBuildMode;
     gpuAccelerationBuildRequired: boolean;
+    accelerationBuildSubmitted: boolean;
+    accelerationBuilt: boolean;
+    accelerationBuildCount: number;
+    commandSubmissions: number;
+    frameConfigSlots: number;
     memory: WavefrontPathTracingMemoryEstimate;
   }>;
   readOutputProbe(options?: { x?: number; y?: number }): Promise<
@@ -367,10 +424,15 @@ export interface WavefrontPathTracingComputeRenderer {
     sceneObjectCount: number;
     triangleCount: number;
     emissiveTriangleCount: number;
+    environmentPortalCount: number;
+    environmentPortalMode: 0 | 1 | 2;
     bvhNodeCount: number;
     displayQuality: boolean;
     accelerationBuildMode: WavefrontAccelerationBuildMode;
     gpuAccelerationBuildRequired: boolean;
+    accelerationBuilt: boolean;
+    accelerationBuildCount: number;
+    frameConfigSlots: number;
     memory: WavefrontPathTracingMemoryEstimate;
   }>;
   destroy(): void;
@@ -465,13 +527,16 @@ export function createWavefrontPathTracingComputeRenderer(
 export const wavefrontPathTracingComputeLimits: Readonly<{
   workgroupSize: 64;
   rayRecordBytes: 80;
-  hitRecordBytes: 192;
+  hitRecordBytes: 208;
   sceneObjectRecordBytes: 96;
   meshVertexRecordBytes: 48;
   meshRangeRecordBytes: 96;
   triangleRecordBytes: 208;
   bvhNodeRecordBytes: 48;
   bvhLeafReferenceRecordBytes: 16;
+  emissiveTriangleIndexBytes: 4;
+  emissiveTriangleMetadataRecordBytes: 48;
+  environmentPortalRecordBytes: 96;
   accumulationRecordBytes: 16;
 }>;
 export const wavefrontSceneObjectKinds: Readonly<{

--- a/src/wavefront-compute.js
+++ b/src/wavefront-compute.js
@@ -4,6 +4,7 @@ const DEFAULT_MAX_DEPTH = 6;
 const DEFAULT_TILE_SIZE = 128;
 const DEFAULT_SAMPLES_PER_PIXEL = 1;
 const DEFAULT_SCENE_OBJECT_CAPACITY = 128;
+const DEFAULT_ENVIRONMENT_PORTAL_CAPACITY = 32;
 const WORKGROUP_SIZE = 64;
 const RAY_RECORD_BYTES = 80;
 const HIT_RECORD_BYTES = 208;
@@ -14,9 +15,11 @@ const TRIANGLE_RECORD_BYTES = 208;
 const BVH_NODE_RECORD_BYTES = 48;
 const BVH_LEAF_REF_RECORD_BYTES = 16;
 const EMISSIVE_TRIANGLE_INDEX_BYTES = 4;
+const ENVIRONMENT_PORTAL_RECORD_BYTES = 96;
 const ACCUMULATION_RECORD_BYTES = 16;
-const CONFIG_BUFFER_BYTES = 256;
+const CONFIG_BUFFER_BYTES = 272;
 const COUNTER_BUFFER_BYTES = 16;
+const TRACE_STORAGE_BUFFER_BINDINGS = 9;
 const HIT_TYPE_SURFACE = 0;
 const HIT_TYPE_EMISSIVE = 1;
 const MATERIAL_DIFFUSE = 0;
@@ -48,6 +51,7 @@ const DEFAULT_ENVIRONMENT_LIGHTING = Object.freeze({
 
 export const wavefrontPathTracingComputeLimits = Object.freeze({
   workgroupSize: WORKGROUP_SIZE,
+  traceStorageBufferBindings: TRACE_STORAGE_BUFFER_BINDINGS,
   rayRecordBytes: RAY_RECORD_BYTES,
   hitRecordBytes: HIT_RECORD_BYTES,
   sceneObjectRecordBytes: SCENE_OBJECT_RECORD_BYTES,
@@ -58,6 +62,7 @@ export const wavefrontPathTracingComputeLimits = Object.freeze({
   bvhLeafReferenceRecordBytes: BVH_LEAF_REF_RECORD_BYTES,
   emissiveTriangleIndexBytes: EMISSIVE_TRIANGLE_INDEX_BYTES,
   emissiveTriangleMetadataRecordBytes: BVH_NODE_RECORD_BYTES,
+  environmentPortalRecordBytes: ENVIRONMENT_PORTAL_RECORD_BYTES,
   accumulationRecordBytes: ACCUMULATION_RECORD_BYTES,
 });
 
@@ -877,6 +882,135 @@ function resolveEnvironmentLighting(input, environmentColor, ambientColor) {
   });
 }
 
+function resolveEnvironmentPortalMode(value, hasPortals) {
+  if (value === undefined || value === null) {
+    return hasPortals ? 2 : 0;
+  }
+  if (Number.isInteger(value) && value >= 0 && value <= 2) {
+    return value;
+  }
+  if (value === "disabled") {
+    return 0;
+  }
+  if (value === "guide") {
+    return 1;
+  }
+  if (value === "guide-and-gate" || value === "gate") {
+    return 2;
+  }
+  throw new Error(
+    "environmentPortalMode must be disabled, guide, guide-and-gate, or an integer between 0 and 2."
+  );
+}
+
+function orthogonalPortalTangent(normal) {
+  if (Math.abs(normal[1]) < 0.92) {
+    return normalize(cross([0, 1, 0], normal), [1, 0, 0]);
+  }
+  return normalize(cross([1, 0, 0], normal), [0, 0, 1]);
+}
+
+function resolvePortalTangent(value, normal) {
+  const fallback = orthogonalPortalTangent(normal);
+  const tangent = asUnitVec3(value, fallback);
+  const projected = subtract(tangent, scale(normal, dot(tangent, normal)));
+  return normalize(projected, fallback);
+}
+
+function readPositiveFiniteNumber(name, value, fallback) {
+  const numeric = readFiniteNumber(name, value, fallback);
+  if (numeric <= 0) {
+    throw new Error(`${name} must be a positive finite number.`);
+  }
+  return numeric;
+}
+
+function readPortalExtent(name, value, halfName, halfValue) {
+  if (value !== undefined && value !== null) {
+    return readPositiveFiniteNumber(name, value, 1);
+  }
+  return readPositiveFiniteNumber(halfName, halfValue, 0.5) * 2;
+}
+
+function normalizeEnvironmentPortal(portal, index) {
+  if (!portal || typeof portal !== "object") {
+    throw new Error(`environmentPortals[${index}] must be an object.`);
+  }
+  const shape = portal.shape ?? portal.kind ?? "rectangle";
+  if (shape !== "rectangle") {
+    throw new Error(`environmentPortals[${index}].shape must be "rectangle".`);
+  }
+  const position = asVec3(portal.position ?? portal.center, [0, 0, 0]);
+  const normal = asUnitVec3(portal.normal, [0, 0, 1]);
+  const tangent = resolvePortalTangent(portal.tangent, normal);
+  const bitangent = normalize(cross(normal, tangent), [0, 1, 0]);
+  const width = readPortalExtent(
+    `environmentPortals[${index}].width`,
+    portal.width,
+    `environmentPortals[${index}].halfWidth`,
+    portal.halfWidth
+  );
+  const height = readPortalExtent(
+    `environmentPortals[${index}].height`,
+    portal.height,
+    `environmentPortals[${index}].halfHeight`,
+    portal.halfHeight
+  );
+  const radianceScale = Math.max(
+    0,
+    readFiniteNumber(
+      `environmentPortals[${index}].radianceScale`,
+      portal.radianceScale ?? portal.intensity,
+      1
+    )
+  );
+  return Object.freeze({
+    kind: 1,
+    flags: portal.twoSided === false ? 0 : 1,
+    position: Object.freeze([position[0], position[1], position[2], width * height]),
+    normal: Object.freeze([normal[0], normal[1], normal[2], radianceScale]),
+    tangent: Object.freeze([tangent[0], tangent[1], tangent[2], width * 0.5]),
+    bitangent: Object.freeze([bitangent[0], bitangent[1], bitangent[2], height * 0.5]),
+    color: Object.freeze(asColor(portal.color, [1, 1, 1, 1])),
+  });
+}
+
+function normalizeEnvironmentPortals(value) {
+  if (value === undefined || value === null) {
+    return Object.freeze([]);
+  }
+  if (!Array.isArray(value)) {
+    throw new Error("environmentPortals must be an array when provided.");
+  }
+  return Object.freeze(value.map(normalizeEnvironmentPortal));
+}
+
+function packEnvironmentPortals(portals, capacity) {
+  const bytes = new ArrayBuffer(capacity * ENVIRONMENT_PORTAL_RECORD_BYTES);
+  const data = new DataView(bytes);
+  const floatView = new Float32Array(bytes);
+  portals.forEach((portal, index) => {
+    const byteOffset = index * ENVIRONMENT_PORTAL_RECORD_BYTES;
+    const floatOffset = byteOffset / Float32Array.BYTES_PER_ELEMENT;
+    data.setUint32(byteOffset, portal.kind, true);
+    data.setUint32(byteOffset + 4, portal.flags, true);
+    data.setUint32(byteOffset + 8, 0, true);
+    data.setUint32(byteOffset + 12, 0, true);
+    writeVec4(floatView, floatOffset + 4, portal.position);
+    writeVec4(floatView, floatOffset + 8, portal.normal);
+    writeVec4(floatView, floatOffset + 12, portal.tangent);
+    writeVec4(floatView, floatOffset + 16, portal.bitangent);
+    writeVec4(floatView, floatOffset + 20, portal.color);
+  });
+  return Object.freeze({
+    buffer: bytes,
+    portals,
+    count: portals.length,
+    capacity,
+    recordBytes: ENVIRONMENT_PORTAL_RECORD_BYTES,
+  });
+}
+
 function getCanvasDimension(canvas, key, fallback) {
   const value = Number(canvas?.[key]);
   if (Number.isFinite(value) && value > 0) {
@@ -935,6 +1069,11 @@ export function estimateWavefrontPathTracingMemory(options = {}) {
     options.emissiveTriangleCapacity,
     0
   );
+  const environmentPortalCapacity = readNonNegativeInteger(
+    "environmentPortalCapacity",
+    options.environmentPortalCapacity,
+    0
+  );
   const queueBytes = tilePixelCapacity * RAY_RECORD_BYTES;
   const hitBytes = tilePixelCapacity * HIT_RECORD_BYTES;
   const accumulationBytes = tilePixelCapacity * ACCUMULATION_RECORD_BYTES;
@@ -944,6 +1083,8 @@ export function estimateWavefrontPathTracingMemory(options = {}) {
   const bvhLeafReferenceBytes = bvhLeafSortCapacity * BVH_LEAF_REF_RECORD_BYTES;
   const emissiveTriangleMetadataBytes =
     emissiveTriangleCapacity * BVH_NODE_RECORD_BYTES;
+  const environmentPortalBytes =
+    environmentPortalCapacity * ENVIRONMENT_PORTAL_RECORD_BYTES;
 
   return Object.freeze({
     queueBytes,
@@ -955,6 +1096,7 @@ export function estimateWavefrontPathTracingMemory(options = {}) {
     bvhNodeBytes,
     bvhLeafReferenceBytes,
     emissiveTriangleMetadataBytes,
+    environmentPortalBytes,
     configBytes: CONFIG_BUFFER_BYTES,
     counterBytes: COUNTER_BUFFER_BYTES,
     totalHotBufferBytes:
@@ -966,6 +1108,7 @@ export function estimateWavefrontPathTracingMemory(options = {}) {
       bvhNodeBytes +
       bvhLeafReferenceBytes +
       emissiveTriangleMetadataBytes +
+      environmentPortalBytes +
       CONFIG_BUFFER_BYTES +
       COUNTER_BUFFER_BYTES,
   });
@@ -1048,6 +1191,25 @@ export function createWavefrontPathTracingComputeConfig(options = {}) {
     environmentColor,
     ambientColor
   );
+  const environmentPortals = normalizeEnvironmentPortals(
+    options.environmentPortals ??
+      options.environmentLightPortals ??
+      options.environmentLighting?.environmentPortals
+  );
+  const environmentPortalCapacity = Math.max(
+    environmentPortals.length,
+    readNonNegativeInteger(
+      "environmentPortalCapacity",
+      options.environmentPortalCapacity,
+      DEFAULT_ENVIRONMENT_PORTAL_CAPACITY
+    )
+  );
+  const environmentPortalMode = resolveEnvironmentPortalMode(
+    options.environmentPortalMode ??
+      options.portalMode ??
+      options.environmentLighting?.environmentPortalMode,
+    environmentPortals.length > 0
+  );
 
   return Object.freeze({
     width,
@@ -1077,6 +1239,10 @@ export function createWavefrontPathTracingComputeConfig(options = {}) {
     environmentColor: environmentLighting.environmentColor,
     ambientColor: environmentLighting.ambientColor,
     environmentLighting,
+    environmentPortals,
+    environmentPortalCount: environmentPortals.length,
+    environmentPortalCapacity,
+    environmentPortalMode,
     displayQuality: options.displayQuality === true,
     requiresMeshBvhForDisplayQuality: true,
     denoise: options.denoise !== false,
@@ -1088,6 +1254,7 @@ export function createWavefrontPathTracingComputeConfig(options = {}) {
       bvhNodeCapacity,
       bvhLeafSortCapacity,
       emissiveTriangleCapacity: emissiveTriangleIndices.capacity,
+      environmentPortalCapacity,
     }),
   });
 }
@@ -1298,6 +1465,10 @@ function createConfigPayload(config, tile, frameIndex, buildRange = {}) {
   data.setUint32(244, buildRange.count ?? 0, true);
   data.setUint32(248, buildRange.sortItemCount ?? 0, true);
   data.setUint32(252, config.emissiveTriangleCount ?? 0, true);
+  data.setUint32(256, config.environmentPortalCount ?? 0, true);
+  data.setUint32(260, config.environmentPortalMode ?? 0, true);
+  data.setUint32(264, 0, true);
+  data.setUint32(268, 0, true);
   return bytes;
 }
 
@@ -1556,6 +1727,10 @@ struct FrameConfig {
   bvhBuildNodeCount: u32,
   bvhSortItemCount: u32,
   emissiveTriangleCount: u32,
+  environmentPortalCount: u32,
+  environmentPortalMode: u32,
+  _portalPad0: u32,
+  _portalPad1: u32,
 };
 
 struct Counters {
@@ -1579,6 +1754,18 @@ struct Candidate {
   mediumRefId: u32,
 };
 
+struct EnvironmentPortal {
+  kind: u32,
+  flags: u32,
+  _pad0: u32,
+  _pad1: u32,
+  position: vec4<f32>,
+  normal: vec4<f32>,
+  tangent: vec4<f32>,
+  bitangent: vec4<f32>,
+  color: vec4<f32>,
+};
+
 @group(0) @binding(0) var<storage, read_write> activeQueue: array<RayRecord>;
 @group(0) @binding(1) var<storage, read_write> nextQueue: array<RayRecord>;
 @group(0) @binding(2) var<storage, read_write> hits: array<HitRecord>;
@@ -1598,6 +1785,7 @@ struct Candidate {
 @group(0) @binding(16) var radianceImage: texture_storage_2d<rgba16float, write>;
 @group(0) @binding(17) var finalDenoiseInputRadiance: texture_2d<f32>;
 @group(0) @binding(18) var denoisedOutputImage: texture_storage_2d<rgba8unorm, write>;
+@group(0) @binding(19) var<storage, read> environmentPortals: array<EnvironmentPortal>;
 
 fn hash_u32(value: u32) -> u32 {
   var x = value;
@@ -1638,7 +1826,48 @@ fn saturate(value: f32) -> f32 {
   return clamp(value, 0.0, 1.0);
 }
 
-fn environment_radiance(direction: vec3<f32>) -> vec3<f32> {
+fn max_component(value: vec3<f32>) -> f32 {
+  return max(max(value.x, value.y), value.z);
+}
+
+fn environment_portal_radiance_scale(origin: vec3<f32>, direction: vec3<f32>) -> vec3<f32> {
+  if (config.environmentPortalCount == 0u || config.environmentPortalMode == 0u) {
+    return vec3<f32>(1.0);
+  }
+  var scale = vec3<f32>(0.0);
+  for (var portalIndex = 0u; portalIndex < config.environmentPortalCount; portalIndex = portalIndex + 1u) {
+    let portal = environmentPortals[portalIndex];
+    if (portal.kind == 1u) {
+      let portalNormal = safe_normalize(portal.normal.xyz, vec3<f32>(0.0, 0.0, 1.0));
+      let denominator = dot(direction, portalNormal);
+      let twoSided = (portal.flags & 1u) != 0u;
+      var facing = abs(denominator) > 0.0001;
+      if (!twoSided && denominator <= 0.0001) {
+        facing = false;
+      }
+      if (facing) {
+        let distance = dot(portal.position.xyz - origin, portalNormal) / denominator;
+        if (distance > 0.001) {
+          let hitPosition = origin + direction * distance;
+          let local = hitPosition - portal.position.xyz;
+          let tangent = safe_normalize(portal.tangent.xyz, vec3<f32>(1.0, 0.0, 0.0));
+          let bitangent = safe_normalize(portal.bitangent.xyz, vec3<f32>(0.0, 1.0, 0.0));
+          let u = dot(local, tangent);
+          let v = dot(local, bitangent);
+          if (abs(u) <= portal.tangent.w && abs(v) <= portal.bitangent.w) {
+            let areaWeight = clamp(sqrt(max(portal.position.w, 0.0001)), 0.25, 4.0);
+            let angleWeight = max(abs(denominator), 0.08);
+            let portalScale = portal.color.rgb * portal.normal.w * portal.color.a * areaWeight * angleWeight;
+            scale = max(scale, portalScale);
+          }
+        }
+      }
+    }
+  }
+  return scale;
+}
+
+fn environment_radiance(origin: vec3<f32>, direction: vec3<f32>) -> vec3<f32> {
   let rayDirection = safe_normalize(direction, vec3<f32>(0.0, 1.0, 0.0));
   let upFactor = saturate(rayDirection.y * 0.5 + 0.5);
   let sunDirection = safe_normalize(
@@ -1649,10 +1878,26 @@ fn environment_radiance(direction: vec3<f32>) -> vec3<f32> {
   let gradient =
     config.environmentHorizonColor.xyz * (1.0 - upFactor) +
     config.environmentZenithColor.xyz * upFactor;
+  let portalScale = environment_portal_radiance_scale(origin, rayDirection);
+  let portalHit = max_component(portalScale) > 0.0001;
   return (
     gradient +
     config.environmentSunColor.xyz * sunGlow
-  ) * max(config.environmentSunDirectionIntensity.w, 0.0001);
+  ) *
+    max(config.environmentSunDirectionIntensity.w, 0.0001) *
+    select(vec3<f32>(1.0), portalScale, portalHit);
+}
+
+fn gated_environment_radiance(origin: vec3<f32>, direction: vec3<f32>) -> vec3<f32> {
+  let portalScale = environment_portal_radiance_scale(origin, safe_normalize(direction, vec3<f32>(0.0, 1.0, 0.0)));
+  if (
+    config.environmentPortalCount > 0u &&
+    config.environmentPortalMode == 2u &&
+    max_component(portalScale) <= 0.0001
+  ) {
+    return config.ambientColor.xyz * 0.65;
+  }
+  return environment_radiance(origin, direction);
 }
 
 fn default_mesh_range() -> MeshRange {
@@ -1923,7 +2168,7 @@ fn make_ray(pixelIndex: u32) -> RayRecord {
 }
 
 fn make_miss(ray: RayRecord) -> HitRecord {
-  let radiance = environment_radiance(ray.direction.xyz);
+  let radiance = gated_environment_radiance(ray.origin.xyz, ray.direction.xyz);
   return HitRecord(
     ray.rayId,
     ray.sourcePixelId,
@@ -2409,6 +2654,21 @@ fn sample_emissive_triangle_direction(hit: HitRecord, seed: u32, fallback: vec3<
   return safe_normalize(lightPoint - hit.position.xyz, fallback);
 }
 
+fn sample_environment_portal_direction(hit: HitRecord, seed: u32, fallback: vec3<f32>) -> vec3<f32> {
+  if (config.environmentPortalCount == 0u || config.environmentPortalMode == 0u) {
+    return fallback;
+  }
+  let portalSlot = min(
+    u32(random01(seed + 211u) * f32(config.environmentPortalCount)),
+    config.environmentPortalCount - 1u
+  );
+  let portal = environmentPortals[portalSlot];
+  let u = (random01(seed + 223u) * 2.0 - 1.0) * portal.tangent.w;
+  let v = (random01(seed + 227u) * 2.0 - 1.0) * portal.bitangent.w;
+  let portalTarget = portal.position.xyz + portal.tangent.xyz * u + portal.bitangent.xyz * v;
+  return safe_normalize(portalTarget - hit.position.xyz, fallback);
+}
+
 fn scatter_direction(ray: RayRecord, hit: HitRecord, seed: u32) -> ScatterResult {
   let roughness = clamp(hit.material.x, 0.0, 1.0);
   if (hit.materialKind == 1u) {
@@ -2448,8 +2708,17 @@ fn scatter_direction(ray: RayRecord, hit: HitRecord, seed: u32) -> ScatterResult
   let canSampleLight = dot(hit.shadingNormal.xyz, guidedLight) > -0.04;
   let guideProbability = select(0.38, 0.72, ray.bounce == 0u);
   let useGuidedLight = canSampleLight && random01(seed + 37u) < guideProbability;
+  let guidedPortal = sample_environment_portal_direction(hit, seed, randomDiffuse);
+  let canSamplePortal = dot(hit.shadingNormal.xyz, guidedPortal) > -0.04;
+  let useGuidedPortal =
+    !useGuidedLight &&
+    canSamplePortal &&
+    config.environmentPortalCount > 0u &&
+    config.environmentPortalMode > 0u &&
+    random01(seed + 89u) < 0.58;
+  let guidedDirection = select(randomDiffuse, guidedPortal, useGuidedPortal);
   return ScatterResult(
-    vec4<f32>(select(randomDiffuse, guidedLight, useGuidedLight), 0.0),
+    vec4<f32>(select(guidedDirection, guidedLight, useGuidedLight), 0.0),
     select(0u, RAY_FLAG_GUIDED_EMISSIVE, useGuidedLight),
     0u,
     0u,
@@ -2658,6 +2927,32 @@ fn fragmentMain(in: VertexOut) -> @location(0) vec4<f32> {
 }
 `;
 
+function createWavefrontDeviceDescriptor(adapter, options = {}) {
+  const requiredLimits = { ...(options.requiredLimits ?? {}) };
+  const exposedStorageBufferLimit = Number(adapter?.limits?.maxStorageBuffersPerShaderStage);
+  if (Number.isFinite(exposedStorageBufferLimit)) {
+    if (exposedStorageBufferLimit < TRACE_STORAGE_BUFFER_BINDINGS) {
+      throw new Error(
+        `Wavefront mesh tracing requires maxStorageBuffersPerShaderStage>=${TRACE_STORAGE_BUFFER_BINDINGS}, ` +
+          `but this adapter exposes ${exposedStorageBufferLimit}.`
+      );
+    }
+    requiredLimits.maxStorageBuffersPerShaderStage = Math.max(
+      Number(requiredLimits.maxStorageBuffersPerShaderStage ?? 0),
+      TRACE_STORAGE_BUFFER_BINDINGS
+    );
+  }
+
+  const descriptor = { ...(options.deviceDescriptor ?? {}) };
+  if (Object.keys(requiredLimits).length > 0) {
+    descriptor.requiredLimits = {
+      ...(descriptor.requiredLimits ?? {}),
+      ...requiredLimits,
+    };
+  }
+  return Object.keys(descriptor).length > 0 ? descriptor : undefined;
+}
+
 export async function createWavefrontPathTracingComputeRenderer(options = {}) {
   assertAnalyticDisplayQualityPolicy(options);
   const constants = getGpuUsageConstants();
@@ -2678,7 +2973,7 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
     throw new Error("Unable to acquire a WebGPU adapter for wavefront path tracing.");
   }
 
-  const device = await adapter.requestDevice();
+  const device = await adapter.requestDevice(createWavefrontDeviceDescriptor(adapter, options));
   const context = canvas.getContext("webgpu");
   if (!context || typeof context.configure !== "function") {
     throw new Error("Canvas WebGPU context does not support configure().");
@@ -2758,24 +3053,35 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
     Math.max(1, config.gpuMeshSource.meshes.count) * MESH_RANGE_RECORD_BYTES,
     "plasius.wavefront.meshRanges"
   );
+  const environmentPortalBuffer = createBuffer(
+    device,
+    constants.buffer.STORAGE | constants.buffer.COPY_DST,
+    Math.max(1, config.environmentPortalCapacity) * ENVIRONMENT_PORTAL_RECORD_BYTES,
+    "plasius.wavefront.environmentPortals"
+  );
   const bvhLeafRefBuffer = createBuffer(
     device,
     constants.buffer.STORAGE | constants.buffer.COPY_DST,
     Math.max(1, config.bvhLeafSortCapacity) * BVH_LEAF_REF_RECORD_BYTES,
     "plasius.wavefront.bvhLeafRefs"
   );
-  const configBuffer = createBuffer(
-    device,
-    constants.buffer.UNIFORM | constants.buffer.COPY_DST,
-    CONFIG_BUFFER_BYTES,
-    "plasius.wavefront.frameConfig"
-  );
+  const tiles = createTiles(config.width, config.height, config.tileSize);
   const uniformOffsetAlignment = Number(device?.limits?.minUniformBufferOffsetAlignment);
   const configBufferStride = alignTo(
     CONFIG_BUFFER_BYTES,
     Number.isFinite(uniformOffsetAlignment) && uniformOffsetAlignment > 0
       ? uniformOffsetAlignment
       : CONFIG_BUFFER_BYTES
+  );
+  const frameConfigSlotCount = Math.max(
+    1,
+    tiles.length * config.samplesPerPixel + tiles.length + (config.denoise ? 1 : 0)
+  );
+  const configBuffer = createBuffer(
+    device,
+    constants.buffer.UNIFORM | constants.buffer.COPY_DST,
+    frameConfigSlotCount * configBufferStride,
+    "plasius.wavefront.frameConfig"
   );
   const bvhBuildConfigSlots =
     1 + config.bvhSortStages.length + config.bvhBuildLevels.length;
@@ -2812,6 +3118,11 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
   device.queue.writeBuffer(meshVertexBuffer, 0, config.gpuMeshSource.vertices.buffer);
   device.queue.writeBuffer(meshIndexBuffer, 0, config.gpuMeshSource.indices.buffer);
   device.queue.writeBuffer(meshRangeBuffer, 0, config.gpuMeshSource.meshes.buffer);
+  const packedEnvironmentPortals = packEnvironmentPortals(
+    config.environmentPortals,
+    Math.max(1, config.environmentPortalCapacity)
+  );
+  device.queue.writeBuffer(environmentPortalBuffer, 0, packedEnvironmentPortals.buffer);
 
   const radianceTexture = device.createTexture({
     label: "plasius.wavefront.radiance",
@@ -2873,6 +3184,7 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
         visibility: constants.shader.COMPUTE,
         storageTexture: { access: "write-only", format: "rgba16float" },
       },
+      { binding: 19, visibility: constants.shader.COMPUTE, buffer: { type: "read-only-storage" } },
     ],
   });
   const accelerationBindGroupLayout = device.createBindGroupLayout({
@@ -3048,6 +3360,7 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
         { binding: 8, resource: { buffer: triangleBuffer } },
         { binding: 9, resource: { buffer: bvhNodeBuffer } },
         { binding: 16, resource: radianceView },
+        { binding: 19, resource: { buffer: environmentPortalBuffer } },
       ],
     });
   }
@@ -3139,11 +3452,29 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
   });
 
   let frame = 0;
-  const tiles = createTiles(config.width, config.height, config.tileSize);
+  let accelerationBuilt = !config.gpuAccelerationBuildRequired;
+  let accelerationBuildCount = 0;
+
+  function createFrameConfigWriter(frameIndex) {
+    let slot = 0;
+    return (tile, buildRange = {}) => {
+      if (slot >= frameConfigSlotCount) {
+        throw new Error("Wavefront frame config slot capacity exceeded.");
+      }
+      const offset = slot * configBufferStride;
+      slot += 1;
+      device.queue.writeBuffer(
+        configBuffer,
+        offset,
+        createConfigPayload(config, tile, frameIndex, buildRange)
+      );
+      return offset;
+    };
+  }
 
   function dispatchGpuAccelerationBuild(frameIndex) {
-    if (!config.gpuAccelerationBuildRequired) {
-      return;
+    if (!config.gpuAccelerationBuildRequired || accelerationBuilt) {
+      return false;
     }
     const buildTile = tiles[0] ?? { x: 0, y: 0, width: 1, height: 1 };
     const encoder = device.createCommandEncoder({
@@ -3201,30 +3532,24 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
     }
     passEncoder.end();
     device.queue.submit([encoder.finish()]);
+    accelerationBuilt = true;
+    accelerationBuildCount += 1;
+    return true;
   }
 
-  function dispatchTileSample(tile, frameIndex, sampleIndex) {
-    const sampleWeight = 1 / config.samplesPerPixel;
-    const configPayload = createConfigPayload(config, tile, frameIndex, {
-      sampleIndex,
-      sampleWeight,
-    });
-    device.queue.writeBuffer(configBuffer, 0, configPayload);
-    const encoder = device.createCommandEncoder({
-      label: `plasius.wavefront.frame.${frameIndex}.tile.${tile.x}.${tile.y}.sample.${sampleIndex}`,
-    });
+  function encodeTileSample(encoder, tile, configOffset) {
     const passEncoder = encoder.beginComputePass({
       label: "plasius.wavefront.computePass",
     });
     const tileWorkgroups = Math.ceil((tile.width * tile.height) / WORKGROUP_SIZE);
     const capacityWorkgroups = Math.ceil(config.tilePixelCapacity / WORKGROUP_SIZE);
 
-    passEncoder.setBindGroup(0, bindGroups[0], [0]);
+    passEncoder.setBindGroup(0, bindGroups[0], [configOffset]);
     passEncoder.setPipeline(pipelines.generatePrimaryRays);
     passEncoder.dispatchWorkgroups(tileWorkgroups);
 
     for (let bounceIndex = 0; bounceIndex < config.maxDepth; bounceIndex += 1) {
-      passEncoder.setBindGroup(0, bindGroups[bounceIndex % 2], [0]);
+      passEncoder.setBindGroup(0, bindGroups[bounceIndex % 2], [configOffset]);
       passEncoder.setPipeline(pipelines.intersectActiveQueue);
       passEncoder.dispatchWorkgroups(capacityWorkgroups);
       passEncoder.setPipeline(pipelines.resolveSurfaceRecords);
@@ -3234,58 +3559,28 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
     }
 
     passEncoder.end();
-    device.queue.submit([encoder.finish()]);
   }
 
-  function dispatchTileOutput(tile, frameIndex) {
-    const configPayload = createConfigPayload(config, tile, frameIndex, {
-      sampleIndex: 0,
-      sampleWeight: 1 / config.samplesPerPixel,
-    });
-    device.queue.writeBuffer(configBuffer, 0, configPayload);
-    const encoder = device.createCommandEncoder({
-      label: `plasius.wavefront.frame.${frameIndex}.tile.${tile.x}.${tile.y}.output`,
-    });
+  function encodeTileOutput(encoder, tile, configOffset) {
     const passEncoder = encoder.beginComputePass({
       label: "plasius.wavefront.outputPass",
     });
     const tileWorkgroups = Math.ceil((tile.width * tile.height) / WORKGROUP_SIZE);
 
-    passEncoder.setBindGroup(0, bindGroups[0], [0]);
+    passEncoder.setBindGroup(0, bindGroups[0], [configOffset]);
     passEncoder.setPipeline(pipelines.accumulateTerminalRadiance);
     passEncoder.dispatchWorkgroups(tileWorkgroups);
     passEncoder.end();
-    device.queue.submit([encoder.finish()]);
   }
 
-  function dispatchTile(tile, frameIndex) {
-    for (let sampleIndex = 0; sampleIndex < config.samplesPerPixel; sampleIndex += 1) {
-      dispatchTileSample(tile, frameIndex, sampleIndex);
-    }
-    dispatchTileOutput(tile, frameIndex);
-  }
-
-  function dispatchDenoise(frameIndex) {
+  function encodeDenoise(encoder, configOffset) {
     if (!config.denoise) {
       return;
     }
-    device.queue.writeBuffer(
-      configBuffer,
-      0,
-      createConfigPayload(
-        config,
-        { x: 0, y: 0, width: config.width, height: config.height },
-        frameIndex,
-        { sampleIndex: 0, sampleWeight: 1 / config.samplesPerPixel }
-      )
-    );
-    const encoder = device.createCommandEncoder({
-      label: `plasius.wavefront.frame.${frameIndex}.denoise`,
-    });
     const radiancePass = encoder.beginComputePass({
       label: "plasius.wavefront.denoiseRadiancePass",
     });
-    radiancePass.setBindGroup(0, denoiseRadianceBindGroup, [0]);
+    radiancePass.setBindGroup(0, denoiseRadianceBindGroup, [configOffset]);
     radiancePass.setPipeline(pipelines.denoiseLinearRadiance);
     radiancePass.dispatchWorkgroups(Math.ceil(config.width / 8), Math.ceil(config.height / 8));
     radiancePass.end();
@@ -3293,18 +3588,14 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
     const resolvePass = encoder.beginComputePass({
       label: "plasius.wavefront.denoiseResolvePass",
     });
-    resolvePass.setBindGroup(0, denoiseResolveBindGroup, [0]);
+    resolvePass.setBindGroup(0, denoiseResolveBindGroup, [configOffset]);
     resolvePass.setPipeline(pipelines.resolveDenoisedOutputImage);
     resolvePass.dispatchWorkgroups(Math.ceil(config.width / 8), Math.ceil(config.height / 8));
     resolvePass.end();
-    device.queue.submit([encoder.finish()]);
   }
 
-  function present() {
+  function encodePresent(encoder) {
     const texture = context.getCurrentTexture();
-    const encoder = device.createCommandEncoder({
-      label: `plasius.wavefront.present.${frame}`,
-    });
     const passEncoder = encoder.beginRenderPass({
       label: "plasius.wavefront.presentPass",
       colorAttachments: [
@@ -3320,17 +3611,44 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
     passEncoder.setBindGroup(0, presentBindGroup);
     passEncoder.draw(3);
     passEncoder.end();
+  }
+
+  function dispatchFrame(frameIndex) {
+    const writeFrameConfig = createFrameConfigWriter(frameIndex);
+    const encoder = device.createCommandEncoder({
+      label: `plasius.wavefront.frame.${frameIndex}.batched`,
+    });
+    for (const tile of tiles) {
+      for (let sampleIndex = 0; sampleIndex < config.samplesPerPixel; sampleIndex += 1) {
+        const configOffset = writeFrameConfig(tile, {
+          sampleIndex,
+          sampleWeight: 1 / config.samplesPerPixel,
+        });
+        encodeTileSample(encoder, tile, configOffset);
+      }
+      const outputConfigOffset = writeFrameConfig(tile, {
+        sampleIndex: 0,
+        sampleWeight: 1 / config.samplesPerPixel,
+      });
+      encodeTileOutput(encoder, tile, outputConfigOffset);
+    }
+    if (config.denoise) {
+      const denoiseConfigOffset = writeFrameConfig(
+        { x: 0, y: 0, width: config.width, height: config.height },
+        { sampleIndex: 0, sampleWeight: 1 / config.samplesPerPixel }
+      );
+      encodeDenoise(encoder, denoiseConfigOffset);
+    }
+    encodePresent(encoder);
     device.queue.submit([encoder.finish()]);
+    return 1;
   }
 
   function renderOnce() {
     frame += 1;
-    dispatchGpuAccelerationBuild(frame + config.frameIndex);
-    for (const tile of tiles) {
-      dispatchTile(tile, frame + config.frameIndex);
-    }
-    dispatchDenoise(frame + config.frameIndex);
-    present();
+    const frameIndex = frame + config.frameIndex;
+    const accelerationBuildSubmitted = dispatchGpuAccelerationBuild(frameIndex);
+    const frameSubmissionCount = dispatchFrame(frameIndex);
     return Object.freeze({
       frame,
       width: config.width,
@@ -3344,10 +3662,17 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
       sceneObjectCount: config.sceneObjectCount,
       triangleCount: config.triangleCount,
       emissiveTriangleCount: config.emissiveTriangleCount,
+      environmentPortalCount: config.environmentPortalCount,
+      environmentPortalMode: config.environmentPortalMode,
       bvhNodeCount: config.bvhNodeCount,
       displayQuality: config.displayQuality,
       accelerationBuildMode: config.accelerationBuildMode,
       gpuAccelerationBuildRequired: config.gpuAccelerationBuildRequired,
+      accelerationBuildSubmitted,
+      accelerationBuilt,
+      accelerationBuildCount,
+      commandSubmissions: frameSubmissionCount + (accelerationBuildSubmitted ? 1 : 0),
+      frameConfigSlots: frameConfigSlotCount,
       memory: config.memory,
     });
   }
@@ -3416,10 +3741,15 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
       sceneObjectCount: config.sceneObjectCount,
       triangleCount: config.triangleCount,
       emissiveTriangleCount: config.emissiveTriangleCount,
+      environmentPortalCount: config.environmentPortalCount,
+      environmentPortalMode: config.environmentPortalMode,
       bvhNodeCount: config.bvhNodeCount,
       displayQuality: config.displayQuality,
       accelerationBuildMode: config.accelerationBuildMode,
       gpuAccelerationBuildRequired: config.gpuAccelerationBuildRequired,
+      accelerationBuilt,
+      accelerationBuildCount,
+      frameConfigSlots: frameConfigSlotCount,
       memory: config.memory,
     });
   }
@@ -3435,6 +3765,7 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
     meshVertexBuffer.destroy?.();
     meshIndexBuffer.destroy?.();
     meshRangeBuffer.destroy?.();
+    environmentPortalBuffer.destroy?.();
     bvhLeafRefBuffer.destroy?.();
     configBuffer.destroy?.();
     bvhBuildConfigBuffer.destroy?.();

--- a/tests/wavefront-compute.test.js
+++ b/tests/wavefront-compute.test.js
@@ -267,12 +267,14 @@ class FakeWavefrontDevice {
   }
 }
 
-function createFakeWavefrontNavigator(device = new FakeWavefrontDevice()) {
+function createFakeWavefrontNavigator(device = new FakeWavefrontDevice(), adapterOptions = {}) {
   return {
     gpu: {
       async requestAdapter() {
         return {
-          async requestDevice() {
+          limits: adapterOptions.limits,
+          async requestDevice(descriptor) {
+            adapterOptions.onRequestDevice?.(descriptor);
             return device;
           },
         };
@@ -326,9 +328,10 @@ test("wavefront compute config keeps 4K queues tile-bounded", () => {
   assert.equal(wavefrontPathTracingComputeLimits.hitRecordBytes, 208);
   assert.equal(config.memory.queueBytes, 128 * 128 * wavefrontPathTracingComputeLimits.rayRecordBytes);
   assert.equal(config.memory.hitBytes, 128 * 128 * wavefrontPathTracingComputeLimits.hitRecordBytes);
-  assert.equal(config.memory.configBytes, 256);
+  assert.equal(config.memory.configBytes, 272);
   assert.equal(config.memory.bvhLeafReferenceBytes, 0);
   assert.equal(config.memory.emissiveTriangleMetadataBytes, 0);
+  assert.equal(config.memory.environmentPortalBytes, 32 * wavefrontPathTracingComputeLimits.environmentPortalRecordBytes);
   assert.ok(config.memory.queueBytes < 134_217_728);
   assert.ok(config.memory.hitBytes < 134_217_728);
 });
@@ -385,8 +388,19 @@ test("wavefront compute guides active continuation rays toward emissive triangle
   assert.match(source, /mix_seed\(ray\.sourcePixelId, ray\.sampleId, ray\.bounce, config\.frameIndex, 11u\)/);
   assert.match(source, /bvhNodes\[config\.bvhNodeCapacity \+ lightSlot\]/);
   assert.match(source, /nextIndex >= config\.tilePixelCount/);
-  assert.doesNotMatch(source, /binding: 19/);
   assert.doesNotMatch(source, /direct_key_lighting/);
+});
+
+test("wavefront compute guides and gates environment lighting through portals", () => {
+  const source = readRendererSource();
+
+  assert.match(source, /ENVIRONMENT_PORTAL_RECORD_BYTES = 96/);
+  assert.match(source, /environmentPortalRecordBytes/);
+  assert.match(source, /@group\(0\) @binding\(19\) var<storage, read> environmentPortals/);
+  assert.match(source, /fn environment_portal_radiance_scale/);
+  assert.match(source, /fn gated_environment_radiance/);
+  assert.match(source, /fn sample_environment_portal_direction/);
+  assert.match(source, /gated_environment_radiance\(ray\.origin\.xyz, ray\.direction\.xyz\)/);
 });
 
 test("analytic wavefront renderer rejects display-quality requests", () => {
@@ -757,6 +771,80 @@ test("wavefront compute config accepts lighting-owned environment payloads", () 
   assert.equal(config.environmentLighting.exposure, 0.9);
 });
 
+test("wavefront compute config normalizes environment portal apertures", () => {
+  const config = createWavefrontPathTracingComputeConfig({
+    width: 640,
+    height: 360,
+    environmentPortalMode: "guide-and-gate",
+    environmentPortals: [
+      {
+        position: [0, 1.2, -2.4],
+        normal: [0, 0, 1],
+        tangent: [1, 0, 0],
+        width: 1.8,
+        height: 1.1,
+        intensity: 1.35,
+        color: [0.8, 0.92, 1, 0.7],
+      },
+    ],
+  });
+
+  assert.equal(config.environmentPortalMode, 2);
+  assert.equal(config.environmentPortalCount, 1);
+  assert.equal(config.environmentPortalCapacity, 32);
+  assert.deepEqual(config.environmentPortals[0].position.slice(0, 3), [0, 1.2, -2.4]);
+  assert.equal(Math.abs(config.environmentPortals[0].position[3] - 1.98) < 0.000001, true);
+  assert.deepEqual(config.environmentPortals[0].normal, [0, 0, 1, 1.35]);
+  assert.deepEqual(config.environmentPortals[0].tangent, [1, 0, 0, 0.9]);
+  assert.deepEqual(config.environmentPortals[0].bitangent, [0, 1, 0, 0.55]);
+  assert.deepEqual(config.environmentPortals[0].color, [0.8, 0.92, 1, 0.7]);
+  assert.equal(config.memory.environmentPortalBytes, 32 * wavefrontPathTracingComputeLimits.environmentPortalRecordBytes);
+});
+
+test("wavefront compute config accepts lighting-owned portal payloads", () => {
+  const config = createWavefrontPathTracingComputeConfig({
+    width: 640,
+    height: 360,
+    environmentLighting: {
+      environmentPortalMode: "guide",
+      environmentPortals: [
+        {
+          center: [1, 1.4, -3],
+          normal: [0, 0, 1],
+          halfWidth: 0.5,
+          halfHeight: 0.25,
+        },
+      ],
+    },
+  });
+
+  assert.equal(config.environmentPortalMode, 1);
+  assert.equal(config.environmentPortalCount, 1);
+  assert.equal(config.environmentPortals[0].tangent[3], 0.5);
+  assert.equal(config.environmentPortals[0].bitangent[3], 0.25);
+});
+
+test("wavefront compute config validates environment portal inputs", () => {
+  assert.throws(
+    () =>
+      createWavefrontPathTracingComputeConfig({
+        width: 640,
+        height: 360,
+        environmentPortalMode: "bad-mode",
+      }),
+    /environmentPortalMode must be disabled, guide, guide-and-gate/
+  );
+  assert.throws(
+    () =>
+      createWavefrontPathTracingComputeConfig({
+        width: 640,
+        height: 360,
+        environmentPortals: [{ shape: "circle" }],
+      }),
+    /environmentPortals\[0\]\.shape must be "rectangle"/
+  );
+});
+
 test("wavefront scene object normalization derives boxes from bounds", () => {
   const object = normalizeWavefrontSceneObject({
     id: 42,
@@ -887,16 +975,34 @@ test("wavefront compute renderer rejects unavailable WebGPU setup paths", async 
       }),
       /context does not support configure/
     );
+
+    await assert.rejects(
+      createWavefrontPathTracingComputeRenderer({
+        canvas: createFakeWavefrontCanvas(),
+        navigator: createFakeWavefrontNavigator(new FakeWavefrontDevice(), {
+          limits: { maxStorageBuffersPerShaderStage: 8 },
+        }),
+        width: 8,
+        height: 8,
+      }),
+      /requires maxStorageBuffersPerShaderStage>=9/
+    );
   });
 });
 
 test("wavefront compute renderer drives GPU-only mesh BVH passes", async () => {
   await withWebGpuConstants(async () => {
     const device = new FakeWavefrontDevice();
+    let requestedDeviceDescriptor = null;
     const canvas = createFakeWavefrontCanvas();
     const renderer = await createWavefrontPathTracingComputeRenderer({
       canvas,
-      navigator: createFakeWavefrontNavigator(device),
+      navigator: createFakeWavefrontNavigator(device, {
+        limits: { maxStorageBuffersPerShaderStage: 10 },
+        onRequestDevice(descriptor) {
+          requestedDeviceDescriptor = descriptor;
+        },
+      }),
       width: 8,
       height: 8,
       tileSize: 8,
@@ -921,6 +1027,7 @@ test("wavefront compute renderer drives GPU-only mesh BVH passes", async () => {
     });
 
     const frame = renderer.renderOnce();
+    const secondFrame = renderer.renderOnce();
     const probe = await renderer.readOutputProbe({ x: 2, y: 3 });
     const nextConfig = renderer.updateSceneObjects([]);
     const snapshot = renderer.getSnapshot();
@@ -928,17 +1035,34 @@ test("wavefront compute renderer drives GPU-only mesh BVH passes", async () => {
     assert.equal(canvas.width, 8);
     assert.equal(canvas.height, 8);
     assert.equal(canvas.context.configured.format, "bgra8unorm");
+    assert.equal(
+      requestedDeviceDescriptor.requiredLimits.maxStorageBuffersPerShaderStage,
+      9
+    );
     assert.equal(frame.frame, 1);
     assert.equal(frame.displayQuality, true);
     assert.equal(frame.gpuAccelerationBuildRequired, true);
+    assert.equal(frame.accelerationBuildSubmitted, true);
+    assert.equal(frame.accelerationBuilt, true);
+    assert.equal(frame.accelerationBuildCount, 1);
+    assert.equal(frame.commandSubmissions, 2);
+    assert.equal(secondFrame.frame, 2);
+    assert.equal(secondFrame.accelerationBuildSubmitted, false);
+    assert.equal(secondFrame.accelerationBuilt, true);
+    assert.equal(secondFrame.accelerationBuildCount, 1);
+    assert.equal(secondFrame.commandSubmissions, 1);
     assert.equal(frame.primaryRays, 128);
     assert.equal(frame.tiles, 1);
+    assert.equal(frame.frameConfigSlots, 4);
     assert.equal(probe.x, 2);
     assert.equal(probe.y, 3);
     assert.deepEqual(probe.rgba, [32, 64, 128, 255]);
     assert.equal(nextConfig.displayQuality, true);
-    assert.equal(snapshot.frame, 1);
+    assert.equal(snapshot.frame, 2);
     assert.equal(snapshot.triangleCount, 1);
+    assert.equal(snapshot.accelerationBuilt, true);
+    assert.equal(snapshot.accelerationBuildCount, 1);
+    assert.equal(snapshot.frameConfigSlots, 4);
     assert.ok(device.pipelineLabels.includes("plasius.wavefront.prepareMeshTrianglesAndLeaves"));
     assert.ok(device.pipelineLabels.includes("plasius.wavefront.generatePrimaryRays"));
     assert.ok(device.pipelineLabels.includes("plasius.wavefront.denoiseLinearRadiance"));
@@ -946,6 +1070,9 @@ test("wavefront compute renderer drives GPU-only mesh BVH passes", async () => {
     assert.ok(device.renderPasses >= 1);
     assert.equal(device.drawCalls.includes(3), true);
     assert.ok(device.queue.submissions.length >= 1);
+    const submittedLabels = device.queue.submissions.flat().map((submission) => submission.encoderLabel);
+    assert.equal(submittedLabels.filter((label) => label.includes("buildAcceleration")).length, 1);
+    assert.equal(submittedLabels.filter((label) => label.includes(".batched")).length, 2);
     assert.equal(device.copyTextureToBufferCalls.length, 1);
 
     renderer.destroy();


### PR DESCRIPTION
## Summary
- batch wavefront tile/sample tracing, tile output, denoise, and present into one frame command submission
- reuse static GPU-built mesh BVH after the first acceleration build
- request the required 9-storage-buffer WebGPU limit and fix the environment portal WGSL reserved word

## Validation
- npm test
- npm run test:coverage
- npm run typecheck
- npm run lint
- npm run build
- npm run pack:check
- npm run audit:npm
- Playwright MCP Eames benchmark smoke rendered 265,476 triangles with non-black probe [151,119,88,255]

## Release
After merge to main, run .github/workflows/cd.yml with bump=patch to publish the next npm patch version. Do not refresh downstream consumers until npm shows the new @plasius/gpu-renderer version.