### PR TITLE
chore: prepare renderer release 0.1.15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@plasius/gpu-renderer",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@plasius/gpu-renderer",
-      "version": "0.1.14",
+      "version": "0.1.15",
       "funding": [
         {
           "type": "patreon",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plasius/gpu-renderer",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Framework-agnostic WebGPU renderer runtime for Plasius projects.",
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
Prepares @plasius/gpu-renderer 0.1.15 for the protected-branch CD path. The previous workflow_dispatch bump failed because branch protection rejects direct writes to main; after this PR merges, run cd.yml with bump=none so the workflow can publish the package without mutating main.\n\nValidation run locally:\n- npm run typecheck\n- npm run pack:check