### PR TITLE
chore: prepare renderer release 0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@plasius/gpu-renderer",
-  "version": "0.1.15",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@plasius/gpu-renderer",
-      "version": "0.1.15",
+      "version": "0.2.0",
       "funding": [
         {
           "type": "patreon",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plasius/gpu-renderer",
-  "version": "0.1.15",
+  "version": "0.2.0",
   "description": "Framework-agnostic WebGPU renderer runtime for Plasius projects.",
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
Prepares `@plasius/gpu-renderer` `0.2.0` for the protected-branch CD path after task #12 merged to `main`.

The prior `cd.yml` dispatch with `bump=minor` failed because the workflow still attempts to push the version bump commit back to protected `main`. This prep PR follows the existing repo pattern from #29: land the version bump via PR first, then rerun `cd.yml` with `bump=none` so publication can proceed without mutating `main`.

Validation run locally:
- npm run typecheck
- npm run pack:check