### PR TITLE
docs(changelog): release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 - **Added**
+  - (placeholder)
+
+- **Changed**
+  - (placeholder)
+
+- **Fixed**
+  - (placeholder)
+
+- **Security**
+  - (placeholder)
+
+## [0.2.1] - 2026-06-06
+
+- **Added**
   - Added deterministic wavefront reference helpers for primary-ray creation,
     triangle-hit evaluation, nearest-hit selection, and environment-miss
     fallback alongside regression tests for task-level acceptance coverage.
@@ -297,3 +311,4 @@ All notable changes to this project will be documented in this file.
 [0.1.11]: https://github.com/Plasius-LTD/gpu-renderer/releases/tag/v0.1.11
 [0.1.12]: https://github.com/Plasius-LTD/gpu-renderer/releases/tag/v0.1.12
 [0.1.14]: https://github.com/Plasius-LTD/gpu-renderer/releases/tag/v0.1.14
+[0.2.1]: https://github.com/Plasius-LTD/gpu-renderer/releases/tag/v0.2.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@plasius/gpu-renderer",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@plasius/gpu-renderer",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "funding": [
         {
           "type": "patreon",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plasius/gpu-renderer",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Framework-agnostic WebGPU renderer runtime for Plasius projects.",
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
Generated by the CD workflow for v0.2.1. The package has already been published and the GitHub release is published; this PR persists package.json, package-lock.json, and CHANGELOG.md release metadata on the protected main branch after the workflow pushed the automation branch.