### PR TITLE
fix: estimate direct environment light at surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,14 +12,20 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 - **Added**
-  - (placeholder)
+  - Added `updateCamera(...)` support for wavefront renderers so validation
+    views can animate camera movement without rebuilding mesh buffers.
 
 - **Changed**
-  - (placeholder)
+  - Changed wavefront frame dispatch to split large tile/sample workloads into
+    bounded command submissions instead of encoding an entire high-resolution
+    frame into one command buffer.
 
 - **Fixed**
   - Fixed low-sample wavefront renders so non-emissive surface hits receive a
     deterministic sky, sun, and portal-light estimate before random continuation.
+  - Reduced deterministic environment fill on direct surface hits so ambient
+    rescue lighting no longer washes dark materials toward the full scene
+    ambient colour.
 
 - **Security**
   - (placeholder)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ All notable changes to this project will be documented in this file.
   - (placeholder)
 
 - **Fixed**
-  - (placeholder)
+  - Fixed low-sample wavefront renders so non-emissive surface hits receive a
+    deterministic sky, sun, and portal-light estimate before random continuation.
 
 - **Security**
   - (placeholder)

--- a/README.md
+++ b/README.md
@@ -207,14 +207,18 @@ sampling, temporal accumulation, and better material PDFs are hardened.
 For static mesh scenes, the GPU acceleration build is submitted once and then
 reused by subsequent frames. Per-frame tracing writes one dynamic uniform slot
 per tile/sample or post-process pass and batches tile tracing, tile output,
-optional denoise, and presentation into a single command submission. After each
+optional denoise, and presentation into bounded command submissions controlled
+by `maxFramePassesPerSubmission` to keep 4K/high-spp command buffers from
+becoming oversized. `updateCamera(...)` can update the per-frame camera uniforms
+between renders without rebuilding mesh buffers. After each
 primary-ray or compaction pass, the GPU writes the active-ray workgroup count
 into the counter buffer and the encoder copies it into an indirect-dispatch
 argument buffer. Intersection and surface-resolution passes therefore scale
 with active continuation rays instead of the maximum tile capacity, while still
 avoiding CPU readback between bounces. WebGPU
-still preserves ordering between dependent bounce passes, but the renderer no
-longer forces one CPU queue submission per tile/sample.
+still preserves ordering between dependent bounce passes, but the renderer
+keeps CPU queue submissions bounded rather than forcing one submission per
+tile/sample.
 Environment-light portals can additionally guide and gate sky/HDRI contribution
 through rectangular openings such as windows. `environmentPortalMode: "guide"`
 biases diffuse continuation rays toward configured openings, while

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -315,6 +315,7 @@ export interface WavefrontPathTracingComputeConfig {
   readonly maxDepth: number;
   readonly tileSize: number;
   readonly samplesPerPixel: number;
+  readonly maxFramePassesPerSubmission: number;
   readonly tilePixelCapacity: number;
   readonly sceneObjects: readonly WavefrontSceneObject[];
   readonly sceneObjectCount: number;
@@ -413,6 +414,7 @@ export interface CreateWavefrontPathTracingComputeRendererOptions {
   readonly maxDepth?: number;
   readonly tileSize?: number;
   readonly samplesPerPixel?: number;
+  readonly maxFramePassesPerSubmission?: number;
   readonly tilePixelCapacity?: number;
   readonly sceneObjectCapacity?: number;
   readonly sceneObjects?: readonly WavefrontSceneObjectInput[];
@@ -458,6 +460,7 @@ export interface WavefrontPathTracingComputeRenderer {
     }>
   >;
   updateSceneObjects(sceneObjects: readonly WavefrontSceneObjectInput[]): WavefrontPathTracingComputeConfig;
+  updateCamera(camera: WavefrontCameraOptions): WavefrontPathTracingComputeConfig;
   getSnapshot(): Readonly<{
     frame: number;
     width: number;
@@ -466,6 +469,7 @@ export interface WavefrontPathTracingComputeRenderer {
     tiles: number;
     tileSize: number;
     samplesPerPixel: number;
+    maxFramePassesPerSubmission: number;
     sceneObjectCount: number;
     triangleCount: number;
     emissiveTriangleCount: number;
@@ -491,6 +495,7 @@ export interface WavefrontPathTracingComputeFrameStats {
   readonly tiles: number;
   readonly tileSize: number;
   readonly samplesPerPixel: number;
+  readonly maxFramePassesPerSubmission: number;
   readonly screenRays: number;
   readonly primaryRays: number;
   readonly sceneObjectCount: number;

--- a/src/wavefront-compute.js
+++ b/src/wavefront-compute.js
@@ -3163,9 +3163,13 @@ fn resolveSurfaceRecords(@builtin(global_invocation_id) globalId: vec3<u32>) {
     return;
   }
 
-  let directEnvironment = surface_direct_environment_contribution(ray, hit);
-  accumulation[ray.rayId] =
-    accumulation[ray.rayId] + vec4<f32>(directEnvironment * sample_weight(), 0.0);
+  let shouldEstimateDirectEnvironment =
+    (hit.materialKind == 0u || hit.materialKind == 1u) && hit.material.z >= 0.95;
+  if (shouldEstimateDirectEnvironment) {
+    let directEnvironment = surface_direct_environment_contribution(ray, hit);
+    accumulation[ray.rayId] =
+      accumulation[ray.rayId] + vec4<f32>(directEnvironment * sample_weight(), 0.0);
+  }
 
   if (ray.bounce + 1u >= config.maxDepth) {
     let terminalEnvironment = terminal_surface_environment_contribution(ray, hit);

--- a/src/wavefront-compute.js
+++ b/src/wavefront-compute.js
@@ -3,6 +3,7 @@ const DEFAULT_HEIGHT = 720;
 const DEFAULT_MAX_DEPTH = 6;
 const DEFAULT_TILE_SIZE = 128;
 const DEFAULT_SAMPLES_PER_PIXEL = 1;
+const DEFAULT_MAX_FRAME_PASSES_PER_SUBMISSION = 256;
 const DEFAULT_SCENE_OBJECT_CAPACITY = 128;
 const DEFAULT_ENVIRONMENT_PORTAL_CAPACITY = 32;
 const WORKGROUP_SIZE = 64;
@@ -1193,6 +1194,15 @@ export function createWavefrontPathTracingComputeConfig(options = {}) {
     1,
     64
   );
+  const maxFramePassesPerSubmission = clamp(
+    readPositiveInteger(
+      "maxFramePassesPerSubmission",
+      options.maxFramePassesPerSubmission,
+      DEFAULT_MAX_FRAME_PASSES_PER_SUBMISSION
+    ),
+    1,
+    4096
+  );
   const tilePixelCapacity = readPositiveInteger(
     "tilePixelCapacity",
     options.tilePixelCapacity,
@@ -1284,6 +1294,7 @@ export function createWavefrontPathTracingComputeConfig(options = {}) {
     maxDepth,
     tileSize,
     samplesPerPixel,
+    maxFramePassesPerSubmission,
     tilePixelCapacity,
     sceneObjects,
     sceneObjectCount: sceneObjects.length,
@@ -2253,13 +2264,13 @@ fn surface_direct_environment_contribution(ray: RayRecord, hit: HitRecord) -> ve
   let normal = safe_normalize(hit.shadingNormal.xyz, vec3<f32>(0.0, 1.0, 0.0));
   let origin = hit.position.xyz + normal * 0.003;
   let viewDirection = safe_normalize(-ray.direction.xyz, normal);
-  let surfaceColor = clamp(max(hit.color.xyz, config.ambientColor.xyz), vec3<f32>(0.0), vec3<f32>(1.0));
+  let surfaceColor = clamp(max(hit.color.xyz, config.ambientColor.xyz * 0.35), vec3<f32>(0.0), vec3<f32>(1.0));
   let roughness = clamp(hit.material.x, 0.0, 1.0);
   let metallic = clamp(hit.material.y, 0.0, 1.0);
 
   let normalEnvironment = gated_environment_radiance(origin, normal);
   let skyVisibility = 0.35 + saturate(normal.y * 0.5 + 0.5) * 0.45;
-  let skyIrradiance = max(config.ambientColor.xyz, normalEnvironment * skyVisibility * 0.22);
+  let skyIrradiance = max(config.ambientColor.xyz * 0.72, normalEnvironment * skyVisibility * 0.16);
 
   let sunDirection = safe_normalize(
     config.environmentSunDirectionIntensity.xyz,
@@ -2267,7 +2278,7 @@ fn surface_direct_environment_contribution(ray: RayRecord, hit: HitRecord) -> ve
   );
   let sunFacing = saturate(dot(normal, sunDirection));
   let sunRadiance = gated_environment_radiance(origin, sunDirection);
-  let sunIrradiance = sunRadiance * sunFacing * 0.24;
+  let sunIrradiance = sunRadiance * sunFacing * 0.2;
   let portalIrradiance = direct_environment_portal_irradiance(origin, normal);
 
   let diffuseWeight = select(1.0 - metallic * 0.65, 0.22, hit.materialKind == 1u);
@@ -3865,6 +3876,7 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
   let frame = 0;
   let accelerationBuilt = !config.gpuAccelerationBuildRequired;
   let accelerationBuildCount = 0;
+  let activeCameraOptions = options.camera ?? DEFAULT_CAMERA;
 
   function createFrameConfigWriter(frameIndex) {
     let slot = 0;
@@ -4035,33 +4047,59 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
 
   function dispatchFrame(frameIndex) {
     const writeFrameConfig = createFrameConfigWriter(frameIndex);
-    const encoder = device.createCommandEncoder({
-      label: `plasius.wavefront.frame.${frameIndex}.batched`,
+    let submissionCount = 0;
+    let encodedFramePasses = 0;
+    let encoder = device.createCommandEncoder({
+      label: `plasius.wavefront.frame.${frameIndex}.batched.${submissionCount + 1}`,
     });
+
+    function submitCurrentEncoder() {
+      if (encodedFramePasses <= 0) {
+        return;
+      }
+      device.queue.submit([encoder.finish()]);
+      submissionCount += 1;
+      encodedFramePasses = 0;
+      encoder = device.createCommandEncoder({
+        label: `plasius.wavefront.frame.${frameIndex}.batched.${submissionCount + 1}`,
+      });
+    }
+
+    function reserveEncoder(passCount = 1) {
+      if (
+        encodedFramePasses > 0 &&
+        encodedFramePasses + passCount > config.maxFramePassesPerSubmission
+      ) {
+        submitCurrentEncoder();
+      }
+      encodedFramePasses += passCount;
+      return encoder;
+    }
+
     for (const tile of tiles) {
       for (let sampleIndex = 0; sampleIndex < config.samplesPerPixel; sampleIndex += 1) {
         const configOffset = writeFrameConfig(tile, {
           sampleIndex,
           sampleWeight: 1 / config.samplesPerPixel,
         });
-        encodeTileSample(encoder, tile, configOffset);
+        encodeTileSample(reserveEncoder(), tile, configOffset);
       }
       const outputConfigOffset = writeFrameConfig(tile, {
         sampleIndex: 0,
         sampleWeight: 1 / config.samplesPerPixel,
       });
-      encodeTileOutput(encoder, tile, outputConfigOffset);
+      encodeTileOutput(reserveEncoder(), tile, outputConfigOffset);
     }
     if (config.denoise) {
       const denoiseConfigOffset = writeFrameConfig(
         { x: 0, y: 0, width: config.width, height: config.height },
         { sampleIndex: 0, sampleWeight: 1 / config.samplesPerPixel }
       );
-      encodeDenoise(encoder, denoiseConfigOffset);
+      encodeDenoise(reserveEncoder(), denoiseConfigOffset);
     }
-    encodePresent(encoder);
-    device.queue.submit([encoder.finish()]);
-    return 1;
+    encodePresent(reserveEncoder());
+    submitCurrentEncoder();
+    return submissionCount;
   }
 
   function renderOnce() {
@@ -4077,6 +4115,7 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
       tiles: tiles.length,
       tileSize: config.tileSize,
       samplesPerPixel: config.samplesPerPixel,
+      maxFramePassesPerSubmission: config.maxFramePassesPerSubmission,
       screenRays: config.width * config.height,
       primaryRays: config.width * config.height * config.samplesPerPixel,
       sceneObjectCount: config.sceneObjectCount,
@@ -4169,9 +4208,28 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
       samplesPerPixel: config.samplesPerPixel,
       sceneObjectCapacity: config.sceneObjectCapacity,
       sceneObjects: packedScene.objects,
+      camera: activeCameraOptions,
       frameIndex: config.frameIndex,
     });
     device.queue.writeBuffer(sceneObjectBuffer, 0, packedScene.buffer);
+    return config;
+  }
+
+  function updateCamera(cameraOptions = {}) {
+    activeCameraOptions = cameraOptions;
+    config = createWavefrontPathTracingComputeConfig({
+      ...options,
+      canvas,
+      width: config.width,
+      height: config.height,
+      maxDepth: config.maxDepth,
+      tileSize: config.tileSize,
+      samplesPerPixel: config.samplesPerPixel,
+      sceneObjectCapacity: config.sceneObjectCapacity,
+      sceneObjects: packedScene.objects,
+      camera: activeCameraOptions,
+      frameIndex: config.frameIndex,
+    });
     return config;
   }
 
@@ -4184,6 +4242,7 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
       tiles: tiles.length,
       tileSize: config.tileSize,
       samplesPerPixel: config.samplesPerPixel,
+      maxFramePassesPerSubmission: config.maxFramePassesPerSubmission,
       sceneObjectCount: config.sceneObjectCount,
       triangleCount: config.triangleCount,
       emissiveTriangleCount: config.emissiveTriangleCount,
@@ -4233,6 +4292,7 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
     renderFrame,
     readOutputProbe,
     updateSceneObjects,
+    updateCamera,
     getSnapshot,
     destroy,
   });

--- a/src/wavefront-compute.js
+++ b/src/wavefront-compute.js
@@ -2209,6 +2209,80 @@ fn terminal_surface_environment_contribution(ray: RayRecord, hit: HitRecord) -> 
   return clamp_sample_radiance(ray.throughput.xyz * surfaceColor * environmentFloor * materialFloor);
 }
 
+fn direct_environment_portal_irradiance(origin: vec3<f32>, normal: vec3<f32>) -> vec3<f32> {
+  if (config.environmentPortalCount == 0u || config.environmentPortalMode == 0u) {
+    return vec3<f32>(0.0);
+  }
+
+  var irradiance = vec3<f32>(0.0);
+  for (var portalIndex = 0u; portalIndex < config.environmentPortalCount; portalIndex = portalIndex + 1u) {
+    let portal = environmentPortals[portalIndex];
+    if (portal.kind != 1u) {
+      continue;
+    }
+
+    let toPortal = portal.position.xyz - origin;
+    let distanceSquared = max(dot(toPortal, toPortal), 0.01);
+    let direction = safe_normalize(toPortal, normal);
+    let surfaceFacing = saturate(dot(normal, direction));
+    if (surfaceFacing <= 0.0001) {
+      continue;
+    }
+
+    let portalNormal = safe_normalize(portal.normal.xyz, vec3<f32>(0.0, 0.0, 1.0));
+    let twoSided = (portal.flags & 1u) != 0u;
+    let portalFacing = select(
+      saturate(dot(-direction, portalNormal)),
+      max(abs(dot(direction, portalNormal)), 0.15),
+      twoSided
+    );
+    let area = max(portal.position.w, 0.0001);
+    let distanceFalloff = clamp(area / max(distanceSquared, area * 0.25), 0.0, 2.5);
+    irradiance = irradiance +
+      portal.color.rgb *
+      portal.normal.w *
+      portal.color.a *
+      surfaceFacing *
+      portalFacing *
+      distanceFalloff;
+  }
+  return irradiance;
+}
+
+fn surface_direct_environment_contribution(ray: RayRecord, hit: HitRecord) -> vec3<f32> {
+  let normal = safe_normalize(hit.shadingNormal.xyz, vec3<f32>(0.0, 1.0, 0.0));
+  let origin = hit.position.xyz + normal * 0.003;
+  let viewDirection = safe_normalize(-ray.direction.xyz, normal);
+  let surfaceColor = clamp(max(hit.color.xyz, config.ambientColor.xyz), vec3<f32>(0.0), vec3<f32>(1.0));
+  let roughness = clamp(hit.material.x, 0.0, 1.0);
+  let metallic = clamp(hit.material.y, 0.0, 1.0);
+
+  let normalEnvironment = gated_environment_radiance(origin, normal);
+  let skyVisibility = 0.35 + saturate(normal.y * 0.5 + 0.5) * 0.45;
+  let skyIrradiance = max(config.ambientColor.xyz, normalEnvironment * skyVisibility * 0.22);
+
+  let sunDirection = safe_normalize(
+    config.environmentSunDirectionIntensity.xyz,
+    vec3<f32>(0.0, 1.0, 0.0)
+  );
+  let sunFacing = saturate(dot(normal, sunDirection));
+  let sunRadiance = gated_environment_radiance(origin, sunDirection);
+  let sunIrradiance = sunRadiance * sunFacing * 0.24;
+  let portalIrradiance = direct_environment_portal_irradiance(origin, normal);
+
+  let diffuseWeight = select(1.0 - metallic * 0.65, 0.22, hit.materialKind == 1u);
+  let diffuse = surfaceColor * (skyIrradiance + sunIrradiance + portalIrradiance) * diffuseWeight;
+
+  let halfVector = safe_normalize(sunDirection + viewDirection, normal);
+  let specularPower = 8.0 + (1.0 - roughness) * 96.0;
+  let specularFacing = pow(saturate(dot(normal, halfVector)), specularPower) * sunFacing;
+  let specularTint = mix(vec3<f32>(0.04), surfaceColor, metallic);
+  let specular = specularTint * sunRadiance * specularFacing * select(0.16, 0.48, hit.materialKind == 1u || hit.materialKind == 2u);
+
+  let bounceWeight = select(1.0, 0.38, ray.bounce > 0u);
+  return clamp_sample_radiance(ray.throughput.xyz * (diffuse + specular) * bounceWeight);
+}
+
 fn default_mesh_range() -> MeshRange {
   return MeshRange(
     0u,
@@ -3077,6 +3151,10 @@ fn resolveSurfaceRecords(@builtin(global_invocation_id) globalId: vec3<u32>) {
     atomicAdd(&counters.terminatedCount, 1u);
     return;
   }
+
+  let directEnvironment = surface_direct_environment_contribution(ray, hit);
+  accumulation[ray.rayId] =
+    accumulation[ray.rayId] + vec4<f32>(directEnvironment * sample_weight(), 0.0);
 
   if (ray.bounce + 1u >= config.maxDepth) {
     let terminalEnvironment = terminal_surface_environment_contribution(ray, hit);

--- a/tests/wavefront-compute.test.js
+++ b/tests/wavefront-compute.test.js
@@ -624,6 +624,28 @@ test("wavefront compute applies environment ambient on terminal surface collisio
   );
 });
 
+test("wavefront compute estimates direct environment light before random continuation", () => {
+  const source = readRendererSource();
+
+  assert.match(source, /fn surface_direct_environment_contribution/);
+  assert.match(source, /fn direct_environment_portal_irradiance/);
+  assert.match(source, /let skyIrradiance = max\(config\.ambientColor\.xyz, normalEnvironment \* skyVisibility \* 0\.22\);/);
+  assert.match(source, /let sunIrradiance = sunRadiance \* sunFacing \* 0\.24;/);
+  assert.match(source, /let portalIrradiance = direct_environment_portal_irradiance\(origin, normal\);/);
+  assert.match(
+    source,
+    /let directEnvironment = surface_direct_environment_contribution\(ray, hit\);/
+  );
+  assert.match(
+    source,
+    /accumulation\[ray\.rayId\] =\s+accumulation\[ray\.rayId\] \+\s+vec4<f32>\(directEnvironment \* sample_weight\(\), 0\.0\);/
+  );
+  assert.ok(
+    source.indexOf("let directEnvironment = surface_direct_environment_contribution(ray, hit);") <
+      source.indexOf("if (ray.bounce + 1u >= config.maxDepth)")
+  );
+});
+
 test("analytic wavefront renderer rejects display-quality requests", () => {
   assert.throws(
     () =>

--- a/tests/wavefront-compute.test.js
+++ b/tests/wavefront-compute.test.js
@@ -348,6 +348,7 @@ test("wavefront compute config keeps 4K queues tile-bounded", () => {
   assert.equal(config.height, 2160);
   assert.equal(config.maxDepth, 8);
   assert.equal(config.samplesPerPixel, 1);
+  assert.equal(config.maxFramePassesPerSubmission, 256);
   assert.equal(config.displayQuality, false);
   assert.equal(config.requiresMeshBvhForDisplayQuality, true);
   assert.equal(config.tilePixelCapacity, 128 * 128);
@@ -388,6 +389,7 @@ test("wavefront compute config exposes bounded samples per pixel", () => {
     width: 640,
     height: 360,
     samplesPerPixel: 8,
+    maxFramePassesPerSubmission: 32,
   });
   const clamped = createWavefrontPathTracingComputeConfig({
     width: 640,
@@ -396,6 +398,7 @@ test("wavefront compute config exposes bounded samples per pixel", () => {
   });
 
   assert.equal(config.samplesPerPixel, 8);
+  assert.equal(config.maxFramePassesPerSubmission, 32);
   assert.equal(clamped.samplesPerPixel, 64);
   assert.throws(
     () =>
@@ -405,6 +408,15 @@ test("wavefront compute config exposes bounded samples per pixel", () => {
         samplesPerPixel: 0,
       }),
     /samplesPerPixel must be a positive integer/
+  );
+  assert.throws(
+    () =>
+      createWavefrontPathTracingComputeConfig({
+        width: 640,
+        height: 360,
+        maxFramePassesPerSubmission: 0,
+      }),
+    /maxFramePassesPerSubmission must be a positive integer/
   );
 });
 
@@ -629,8 +641,9 @@ test("wavefront compute estimates direct environment light before random continu
 
   assert.match(source, /fn surface_direct_environment_contribution/);
   assert.match(source, /fn direct_environment_portal_irradiance/);
-  assert.match(source, /let skyIrradiance = max\(config\.ambientColor\.xyz, normalEnvironment \* skyVisibility \* 0\.22\);/);
-  assert.match(source, /let sunIrradiance = sunRadiance \* sunFacing \* 0\.24;/);
+  assert.match(source, /let surfaceColor = clamp\(max\(hit\.color\.xyz, config\.ambientColor\.xyz \* 0\.35\)/);
+  assert.match(source, /let skyIrradiance = max\(config\.ambientColor\.xyz \* 0\.72, normalEnvironment \* skyVisibility \* 0\.16\);/);
+  assert.match(source, /let sunIrradiance = sunRadiance \* sunFacing \* 0\.2;/);
   assert.match(source, /let portalIrradiance = direct_environment_portal_irradiance\(origin, normal\);/);
   assert.match(
     source,
@@ -1273,6 +1286,11 @@ test("wavefront compute renderer drives GPU-only mesh BVH passes", async () => {
     const secondFrame = renderer.renderOnce();
     const probe = await renderer.readOutputProbe({ x: 2, y: 3 });
     const compatibilityFrame = await renderer.renderFrame({ probe: { x: 2, y: 3 } });
+    const movedConfig = renderer.updateCamera({
+      position: [0.8, 1.3, 5.2],
+      target: [0, 0.55, 0],
+      fovYDegrees: 42,
+    });
     const nextConfig = renderer.updateSceneObjects([]);
     const snapshot = renderer.getSnapshot();
 
@@ -1311,6 +1329,9 @@ test("wavefront compute renderer drives GPU-only mesh BVH passes", async () => {
     assert.equal(probe.x, 2);
     assert.equal(probe.y, 3);
     assert.deepEqual(probe.rgba, [32, 64, 128, 255]);
+    assert.deepEqual(round(movedConfig.camera.position), [0.8, 1.3, 5.2]);
+    assert.deepEqual(round(nextConfig.camera.position), [0.8, 1.3, 5.2]);
+    assert.equal(nextConfig.camera.fovYDegrees, 42);
     assert.equal(nextConfig.displayQuality, true);
     assert.equal(snapshot.frame, 3);
     assert.equal(snapshot.triangleCount, 1);
@@ -1345,6 +1366,37 @@ test("wavefront compute renderer drives GPU-only mesh BVH passes", async () => {
     assert.equal(canvas.context.configured, null);
     assert.equal(device.buffers.every((buffer) => buffer.destroyed), true);
     assert.equal(device.textures.every((texture) => texture.destroyed), true);
+  });
+});
+
+test("wavefront compute renderer splits large frames into bounded command submissions", async () => {
+  await withWebGpuConstants(async () => {
+    const device = new FakeWavefrontDevice();
+    const renderer = await createWavefrontPathTracingComputeRenderer({
+      canvas: createFakeWavefrontCanvas(),
+      navigator: createFakeWavefrontNavigator(device),
+      width: 512,
+      height: 512,
+      tileSize: 128,
+      maxDepth: 1,
+      samplesPerPixel: 2,
+      maxFramePassesPerSubmission: 5,
+      denoise: true,
+    });
+
+    const frame = renderer.renderOnce();
+    const submittedLabels = device.queue.submissions
+      .flat()
+      .map((submission) => submission.encoderLabel);
+
+    assert.equal(frame.tiles, 16);
+    assert.equal(frame.maxFramePassesPerSubmission, 5);
+    assert.equal(frame.commandSubmissions, 10);
+    assert.equal(frame.frameConfigSlots, 49);
+    assert.equal(device.queue.submissions.length, 10);
+    assert.equal(submittedLabels.every((label) => label.includes(".batched.")), true);
+
+    renderer.destroy();
   });
 });
 

--- a/tests/wavefront-compute.test.js
+++ b/tests/wavefront-compute.test.js
@@ -647,11 +647,19 @@ test("wavefront compute estimates direct environment light before random continu
   assert.match(source, /let portalIrradiance = direct_environment_portal_irradiance\(origin, normal\);/);
   assert.match(
     source,
+    /let shouldEstimateDirectEnvironment =\s+\(hit\.materialKind == 0u \|\| hit\.materialKind == 1u\) && hit\.material\.z >= 0\.95;/
+  );
+  assert.match(
+    source,
     /let directEnvironment = surface_direct_environment_contribution\(ray, hit\);/
   );
   assert.match(
     source,
     /accumulation\[ray\.rayId\] =\s+accumulation\[ray\.rayId\] \+\s+vec4<f32>\(directEnvironment \* sample_weight\(\), 0\.0\);/
+  );
+  assert.ok(
+    source.indexOf("let shouldEstimateDirectEnvironment =") <
+      source.indexOf("let directEnvironment = surface_direct_environment_contribution(ray, hit);")
   );
   assert.ok(
     source.indexOf("let directEnvironment = surface_direct_environment_contribution(ray, hit);") <


### PR DESCRIPTION
## Summary
- add deterministic sky, sun, and environment portal lighting at non-emissive wavefront surface hits
- apply that direct estimate before random continuation and before max-depth termination so 1-2 spp renders do not depend on lucky light hits
- add regression coverage and changelog entry

## Validation
- npm run typecheck
- npm run lint
- npm run test:unit -- tests/wavefront-compute.test.js
- npm run test:unit
- npm run test:coverage
- npm run build
- npm run audit:npm