### PR TITLE
feat: improve low-sample environment path resolve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,27 @@ All notable changes to this project will be documented in this file.
 - **Added**
   - Added `updateCamera(...)` support for wavefront renderers so validation
     views can animate camera movement without rebuilding mesh buffers.
+  - Added `gpuParallelism` diagnostics to wavefront frame stats and snapshots so
+    consumers can inspect adapter compute limits, direct workgroups,
+    indirect-dispatch estimates, and whether a frame exposes multi-workgroup GPU
+    parallelism.
+  - Added optional equirectangular `environmentMap` sampling for wavefront
+    tracing so environment misses and surface environment estimates can use a
+    bound radiance texture before falling back to procedural sky/ambient values.
+  - Added default-on `deferredPathResolve` support for wavefront tracing so
+    surface traversal records material responses and terminal source radiance
+    before the output pass resolves the path backward into pixel accumulation.
 
 - **Changed**
   - Changed wavefront frame dispatch to split large tile/sample workloads into
     bounded command submissions instead of encoding an entire high-resolution
     frame into one command buffer.
+  - Changed display-quality wavefront tracing to require one additional
+    path-vertex storage buffer, raising the trace-stage storage-buffer request
+    from 9 to 10.
+  - Changed wavefront terminal/direct environment estimates to consume
+    `environmentLighting.sunlitBaseline` as a time-of-day daylight floor instead
+    of relying only on restrained ambient colour.
 
 - **Fixed**
   - Fixed low-sample wavefront renders so non-emissive surface hits receive a

--- a/README.md
+++ b/README.md
@@ -196,21 +196,42 @@ tone mapping into the presented `rgba8unorm` output. Filtering in linear
 radiance space lets the denoise pass cross tile boundaries without compressing
 energy/detail before the final resolve. The renderer also stores compact
 emissive-triangle metadata in the existing BVH buffer tail and uses it to guide
-diffuse continuation rays toward finite mesh light geometry without adding a
-ninth trace storage buffer. This is not a separate shadow/direct-light pass: the
-active ray still has to hit emissive geometry or miss into the environment
-before radiance is accumulated. Guided emissive hits carry a bounded estimator
-weight so finite light guidance does not over-expose low-sample renders before
-full material PDFs/MIS are implemented. High-energy samples are clamped in
-linear radiance space to keep low-sample preview output stable while production
-sampling, temporal accumulation, and better material PDFs are hardened.
+diffuse continuation rays toward finite mesh light geometry. This is not a
+separate shadow/direct-light pass: the active ray still has to hit emissive
+geometry or miss into the environment before radiance is committed. Guided
+emissive hits carry a bounded estimator weight so finite light guidance does not
+over-expose low-sample renders before full material PDFs/MIS are implemented.
+High-energy samples are clamped in linear radiance space to keep low-sample
+preview output stable while production sampling, temporal accumulation, and
+better material PDFs are hardened. By default, `deferredPathResolve` records
+per-bounce material responses in a tile-bounded path buffer and records the
+terminal emissive/HDRI/environment source in the final path slot. The output
+pass then resolves that recorded path backward and adds the weighted sample to
+the pixel accumulation, so surface traversal no longer injects broad visible
+ambient/direct environment light before a terminal source is known. Set
+`deferredPathResolve: false` only for legacy forward-accumulation comparison.
+When an `environmentMap` is provided, the wavefront trace shader samples it as
+an equirectangular radiance source for environment misses and uses the same
+mapped radiance for terminal residuals before falling back to static ambient.
+The procedural horizon/zenith/sun model remains the fallback for callers that
+have not supplied an HDRI/radiance texture. `environmentLighting.sunlitBaseline`
+adds a time-of-day daylight floor to terminal and direct environment estimates,
+so bright presets retain colour at the last collision without returning to a
+whitewashed global ambient term.
 For static mesh scenes, the GPU acceleration build is submitted once and then
 reused by subsequent frames. Per-frame tracing writes one dynamic uniform slot
 per tile/sample or post-process pass and batches tile tracing, tile output,
 optional denoise, and presentation into bounded command submissions controlled
 by `maxFramePassesPerSubmission` to keep 4K/high-spp command buffers from
 becoming oversized. `updateCamera(...)` can update the per-frame camera uniforms
-between renders without rebuilding mesh buffers. After each
+between renders without rebuilding mesh buffers. Frame stats and snapshots expose
+`gpuParallelism` diagnostics with adapter compute limits, configured workgroup
+size, direct compute dispatches, known workgroups/invocations, indirect dispatch
+counts, and upper-bound indirect work estimates. WebGPU does not expose physical
+GPU core counts, so `physicalCoreCount` remains `null`; use
+`exposesMultiWorkgroupParallelism`, `largestDirectWorkgroupsPerDispatch`, and
+`largestEstimatedIndirectWorkgroupsPerDispatch` to confirm the renderer is
+submitting work that can occupy more than one GPU execution unit. After each
 primary-ray or compaction pass, the GPU writes the active-ray workgroup count
 into the counter buffer and the encoder copies it into an indirect-dispatch
 argument buffer. Intersection and surface-resolution passes therefore scale

--- a/docs/adrs/adr-0008-deferred-terminal-path-resolve.md
+++ b/docs/adrs/adr-0008-deferred-terminal-path-resolve.md
@@ -1,0 +1,77 @@
+# ADR 0008: Deferred Terminal Path Resolve For Wavefront Path Tracing
+
+## Status
+
+Accepted
+
+## Context
+
+The first wavefront path tracer accumulated some visible radiance while a path
+was still traversing the scene. Surface resolution could add broad direct
+environment estimates, terminal ambient floors could multiply material colour
+immediately, and continuation rays carried an already-tinted throughput. That
+made low-sample renders brighter and more stable, but it also made lighting
+levels difficult to reason about because sun, HDRI, ambient residual, and
+material response were mixed before the path had reached a real terminal light
+source.
+
+The renderer needs a path model where a camera sample first reaches an
+emissive surface, an HDRI/environment miss, or an explicit residual termination
+before visible colour is committed. This gives better control over exposure and
+ambient residuals, and it makes path diagnostics easier because every sample has
+a clear terminal source and a bounded list of material responses.
+
+## Decision
+
+`@plasius/gpu-renderer` will support deferred terminal path resolution for the
+wavefront path tracer. In deferred mode the trace pass:
+
+- records one compact material response per ray bounce;
+- records the terminal source radiance in the final path slot when the path hits
+  emissive geometry, misses into the HDRI/environment, reaches max depth, or
+  overflows the active queue;
+- uses the lighting-owned `sunlitBaseline` scalar as a time-of-day terminal
+  daylight floor instead of raising the global ambient colour;
+- avoids adding direct environment or ambient contribution to the visible
+  accumulation buffer during surface traversal;
+- resolves the path in the terminal pass by walking recorded responses from the
+  last bounce back to the first camera hit and then adding the weighted sample
+  to the pixel accumulation.
+
+The first implementation remains a single stochastic continuation path per
+sample. Reflective or refractive materials do not branch into separate reflected
+and transmitted paths yet.
+
+## Consequences
+
+- Display-quality lighting becomes less dependent on fake per-bounce brightening
+  and more dependent on the terminal emissive/HDRI source discovered by the
+  active path.
+- Low-sample images can become darker when paths fail to find strong light
+  sources. Bright time-of-day presets still retain a bounded terminal daylight
+  floor through `environmentLighting.sunlitBaseline`; further noise and light
+  reach issues should be addressed with better light/HDRI sampling, PDFs, MIS,
+  and denoising rather than by restoring broad ambient floors.
+- The trace stage requires one additional storage buffer for path vertices. The
+  renderer therefore requests `maxStorageBuffersPerShaderStage >= 10`.
+- The path response record intentionally stores the current approximate material
+  response, not a final physical BSDF. Future material-table, texture, medium,
+  Beer-Lambert absorption, Fresnel PDF, and spectral-dispersion work should
+  replace the response calculation without changing the terminal-source model.
+- A legacy forward accumulation switch remains available for before/after
+  comparison and regression isolation.
+
+## Current Implementation Boundary
+
+Deferred resolution stores path data in a tile-bounded `pathVertices` buffer
+with `(maxDepth + 1)` `vec4<f32>` slots per tile pixel. Slots `0..maxDepth-1`
+store per-bounce RGB response and a validity flag. Slot `maxDepth` stores the
+terminal source RGB and validity flag. The output pass resolves the current
+sample immediately after its bounce loop so the next sample can clear and reuse
+the same path slots while the pixel accumulation buffer preserves the weighted
+result.
+
+The implementation does not yet include texture-material sampling, material
+lookup tables, medium entry/exit distance tracking, Beer-Lambert absorption,
+Russian roulette, PDF-correct throughput, MIS, or spectral prism dispersion.
+Those are follow-up renderer material-system features.

--- a/docs/adrs/index.md
+++ b/docs/adrs/index.md
@@ -7,3 +7,4 @@
 - [ADR 0005: Ray-Tracing-First Hybrid Render Graph](./adr-0005-ray-tracing-first-hybrid-render-graph.md)
 - [ADR 0006: WebGPU Wavefront Compute Path Tracing](./adr-0006-webgpu-wavefront-compute-path-tracing.md)
 - [ADR 0007: Mesh BVH Wavefront Path Tracing As Display Quality Baseline](./adr-0007-triangle-mesh-wavefront-path-tracing.md)
+- [ADR 0008: Deferred Terminal Path Resolve For Wavefront Path Tracing](./adr-0008-deferred-terminal-path-resolve.md)

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -308,6 +308,33 @@ export interface WavefrontEnvironmentPortalRecord {
   readonly color: readonly [number, number, number, number] | readonly number[];
 }
 
+export interface WavefrontEnvironmentMapInput {
+  readonly enabled?: boolean;
+  readonly width?: number;
+  readonly height?: number;
+  readonly projection?: "equirectangular" | string;
+  readonly format?: GPUTextureFormat | "rgba16float";
+  readonly texture?: GPUTexture;
+  readonly view?: GPUTextureView;
+  readonly sampler?: GPUSampler;
+  readonly data?: readonly number[] | Float32Array | Uint16Array | Uint8Array;
+  readonly intensity?: number;
+  readonly radianceScale?: number;
+  readonly rotationRadians?: number;
+  readonly rotation?: number;
+  readonly ambientStrength?: number;
+}
+
+export interface WavefrontEnvironmentMapSnapshot {
+  readonly enabled: boolean;
+  readonly width: number;
+  readonly height: number;
+  readonly projection: string;
+  readonly intensity: number;
+  readonly rotationRadians: number;
+  readonly ambientStrength: number;
+}
+
 export interface WavefrontPathTracingComputeConfig {
   readonly mode: typeof rendererWavefrontComputeMode;
   readonly width: number;
@@ -331,6 +358,8 @@ export interface WavefrontPathTracingComputeConfig {
   readonly environmentPortalCount: number;
   readonly environmentPortalCapacity: number;
   readonly environmentPortalMode: 0 | 1 | 2;
+  readonly environmentMap: WavefrontEnvironmentMapInput;
+  readonly deferredPathResolve: boolean;
   readonly triangleCount: number;
   readonly triangleCapacity: number;
   readonly bvhNodeCount: number;
@@ -367,8 +396,11 @@ export interface WavefrontEnvironmentLightingInput {
   readonly intensity?: number;
   readonly mode?: number;
   readonly exposure?: number;
+  readonly sunlitBaseline?: number;
+  readonly daylightBaseline?: number;
   readonly environmentPortals?: readonly WavefrontEnvironmentPortalInput[];
   readonly environmentPortalMode?: WavefrontEnvironmentPortalMode;
+  readonly environmentMap?: WavefrontEnvironmentMapInput;
 }
 
 export interface WavefrontEnvironmentLightingConfig {
@@ -381,6 +413,7 @@ export interface WavefrontEnvironmentLightingConfig {
   readonly intensity: number;
   readonly mode: number;
   readonly exposure: number;
+  readonly sunlitBaseline: number;
 }
 
 export interface WavefrontPathTracingMemoryEstimate {
@@ -388,6 +421,7 @@ export interface WavefrontPathTracingMemoryEstimate {
   readonly queuePairBytes: number;
   readonly hitBytes: number;
   readonly accumulationBytes: number;
+  readonly pathVertexBytes: number;
   readonly sceneObjectBytes: number;
   readonly triangleBytes: number;
   readonly bvhNodeBytes: number;
@@ -398,6 +432,43 @@ export interface WavefrontPathTracingMemoryEstimate {
   readonly counterBytes: number;
   readonly indirectDispatchBytes: number;
   readonly totalHotBufferBytes: number;
+}
+
+export interface WavefrontGpuParallelismDiagnostics {
+  readonly physicalCoreCount: number | null;
+  readonly physicalCoreCountAvailable: boolean;
+  readonly physicalCoreCountUnavailableReason: string;
+  readonly adapterInfo: Readonly<{
+    readonly vendor: string;
+    readonly architecture: string;
+    readonly device: string;
+    readonly description: string;
+  }> | null;
+  readonly adapterLimits: Readonly<{
+    readonly maxComputeInvocationsPerWorkgroup: number | null;
+    readonly maxComputeWorkgroupSizeX: number | null;
+    readonly maxComputeWorkgroupSizeY: number | null;
+    readonly maxComputeWorkgroupSizeZ: number | null;
+    readonly maxComputeWorkgroupsPerDimension: number | null;
+    readonly maxStorageBuffersPerShaderStage: number | null;
+    readonly maxStorageBufferBindingSize: number | null;
+  }>;
+  readonly configuredWorkgroupSize: number;
+  readonly directDispatches: number;
+  readonly directWorkgroups: number;
+  readonly directShaderInvocations: number;
+  readonly multiWorkgroupDispatches: number;
+  readonly largestDirectWorkgroupsPerDispatch: number;
+  readonly indirectDispatches: number;
+  readonly estimatedIndirectWorkgroupsUpperBound: number;
+  readonly estimatedIndirectShaderInvocationsUpperBound: number;
+  readonly indirectDispatchesWithMultiWorkgroupCapacity: number;
+  readonly largestEstimatedIndirectWorkgroupsPerDispatch: number;
+  readonly totalEstimatedWorkgroupsUpperBound: number;
+  readonly totalEstimatedShaderInvocationsUpperBound: number;
+  readonly exposesMultiWorkgroupParallelism: boolean;
+  readonly likelyUsesMoreThanOnePhysicalGpuCore: boolean | null;
+  readonly coreUtilizationStatus: "not-exposed-by-webgpu";
 }
 
 export interface CreateWavefrontPathTracingComputeRendererOptions {
@@ -429,6 +500,11 @@ export interface CreateWavefrontPathTracingComputeRendererOptions {
   readonly environmentLightPortals?: readonly WavefrontEnvironmentPortalInput[];
   readonly environmentPortalMode?: WavefrontEnvironmentPortalMode;
   readonly portalMode?: WavefrontEnvironmentPortalMode;
+  readonly environmentMap?: WavefrontEnvironmentMapInput;
+  readonly environmentTexture?: WavefrontEnvironmentMapInput;
+  readonly deferredPathResolve?: boolean;
+  readonly deferredResolve?: boolean;
+  readonly pathResolve?: { readonly deferred?: boolean };
   readonly accelerationBuildMode?: WavefrontAccelerationBuildMode;
   readonly camera?: WavefrontCameraOptions;
   readonly environmentColor?: readonly [number, number, number, number?] | readonly number[];
@@ -475,6 +551,8 @@ export interface WavefrontPathTracingComputeRenderer {
     emissiveTriangleCount: number;
     environmentPortalCount: number;
     environmentPortalMode: 0 | 1 | 2;
+    environmentMap: WavefrontEnvironmentMapSnapshot;
+    deferredPathResolve: boolean;
     bvhNodeCount: number;
     displayQuality: boolean;
     accelerationBuildMode: WavefrontAccelerationBuildMode;
@@ -482,6 +560,7 @@ export interface WavefrontPathTracingComputeRenderer {
     accelerationBuilt: boolean;
     accelerationBuildCount: number;
     frameConfigSlots: number;
+    gpuParallelism: WavefrontGpuParallelismDiagnostics;
     memory: WavefrontPathTracingMemoryEstimate;
   }>;
   destroy(): void;
@@ -503,6 +582,8 @@ export interface WavefrontPathTracingComputeFrameStats {
   readonly emissiveTriangleCount: number;
   readonly environmentPortalCount: number;
   readonly environmentPortalMode: 0 | 1 | 2;
+  readonly environmentMap: WavefrontEnvironmentMapSnapshot;
+  readonly deferredPathResolve: boolean;
   readonly bvhNodeCount: number;
   readonly displayQuality: boolean;
   readonly accelerationBuildMode: WavefrontAccelerationBuildMode;
@@ -512,6 +593,7 @@ export interface WavefrontPathTracingComputeFrameStats {
   readonly accelerationBuildCount: number;
   readonly commandSubmissions: number;
   readonly frameConfigSlots: number;
+  readonly gpuParallelism: WavefrontGpuParallelismDiagnostics;
   readonly memory: WavefrontPathTracingMemoryEstimate;
   readonly outputProbe?: Readonly<{
     x: number;
@@ -661,6 +743,7 @@ export const wavefrontPathTracingComputeLimits: Readonly<{
   emissiveTriangleMetadataRecordBytes: 48;
   environmentPortalRecordBytes: 96;
   accumulationRecordBytes: 16;
+  pathVertexRecordBytes: 16;
   counterRecordBytes: 32;
   indirectDispatchRecordBytes: 12;
 }>;

--- a/src/wavefront-compute.js
+++ b/src/wavefront-compute.js
@@ -21,11 +21,12 @@ const BVH_LEAF_REF_RECORD_BYTES = 16;
 const EMISSIVE_TRIANGLE_INDEX_BYTES = 4;
 const ENVIRONMENT_PORTAL_RECORD_BYTES = 96;
 const ACCUMULATION_RECORD_BYTES = 16;
-const CONFIG_BUFFER_BYTES = 272;
+const PATH_VERTEX_RECORD_BYTES = 16;
+const CONFIG_BUFFER_BYTES = 304;
 const COUNTER_DISPATCH_ARGS_OFFSET = 16;
 const INDIRECT_DISPATCH_ARGS_BYTES = 12;
 const COUNTER_BUFFER_BYTES = 32;
-const TRACE_STORAGE_BUFFER_BINDINGS = 9;
+const TRACE_STORAGE_BUFFER_BINDINGS = 10;
 const HIT_TYPE_SURFACE = 0;
 const HIT_TYPE_EMISSIVE = 1;
 const MATERIAL_DIFFUSE = 0;
@@ -53,6 +54,7 @@ const DEFAULT_ENVIRONMENT_LIGHTING = Object.freeze({
   intensity: 1,
   mode: 0,
   exposure: 1,
+  sunlitBaseline: 0.16,
 });
 
 export const wavefrontPathTracingComputeLimits = Object.freeze({
@@ -70,6 +72,7 @@ export const wavefrontPathTracingComputeLimits = Object.freeze({
   emissiveTriangleMetadataRecordBytes: BVH_NODE_RECORD_BYTES,
   environmentPortalRecordBytes: ENVIRONMENT_PORTAL_RECORD_BYTES,
   accumulationRecordBytes: ACCUMULATION_RECORD_BYTES,
+  pathVertexRecordBytes: PATH_VERTEX_RECORD_BYTES,
   counterRecordBytes: COUNTER_BUFFER_BYTES,
   indirectDispatchRecordBytes: INDIRECT_DISPATCH_ARGS_BYTES,
 });
@@ -159,6 +162,39 @@ function asColor(value, fallback = [1, 1, 1, 1]) {
     clamp(readFiniteNumber("color[2]", value[2], fallback[2]), 0, 64),
     clamp(readFiniteNumber("color[3]", value[3], fallback[3] ?? 1), 0, 1),
   ];
+}
+
+function resolveEnvironmentMap(input = null) {
+  const source = input && typeof input === "object" ? input : null;
+  const hasTexture = Boolean(source?.view || source?.texture || source?.data);
+  const width = readPositiveInteger("environmentMap.width", source?.width, 1);
+  const height = readPositiveInteger("environmentMap.height", source?.height, 1);
+  return Object.freeze({
+    enabled: hasTexture && source?.enabled !== false,
+    width,
+    height,
+    format: typeof source?.format === "string" ? source.format : "rgba16float",
+    projection: typeof source?.projection === "string" ? source.projection : "equirectangular",
+    texture: source?.texture ?? null,
+    view: source?.view ?? null,
+    sampler: source?.sampler ?? null,
+    data: source?.data ?? null,
+    intensity: Math.max(0, readFiniteNumber("environmentMap.intensity", source?.intensity ?? source?.radianceScale, 1)),
+    rotationRadians: readFiniteNumber("environmentMap.rotationRadians", source?.rotationRadians ?? source?.rotation, 0),
+    ambientStrength: Math.max(
+      0,
+      readFiniteNumber("environmentMap.ambientStrength", source?.ambientStrength, 0.32)
+    ),
+  });
+}
+
+function resolveDeferredPathResolve(options = {}) {
+  const value =
+    options.deferredPathResolve ??
+    options.deferredResolve ??
+    options.pathResolve?.deferred ??
+    true;
+  return value !== false;
 }
 
 function emissionPower(emission) {
@@ -914,6 +950,14 @@ function resolveEnvironmentLighting(input, environmentColor, ambientColor) {
     intensity: Math.max(0.0001, readFiniteNumber("environmentLighting.intensity", source.intensity, DEFAULT_ENVIRONMENT_LIGHTING.intensity)),
     mode: readNonNegativeInteger("environmentLighting.mode", source.mode, DEFAULT_ENVIRONMENT_LIGHTING.mode),
     exposure: Math.max(0.0001, readFiniteNumber("environmentLighting.exposure", source.exposure, DEFAULT_ENVIRONMENT_LIGHTING.exposure)),
+    sunlitBaseline: Math.max(
+      0,
+      readFiniteNumber(
+        "environmentLighting.sunlitBaseline",
+        source.sunlitBaseline ?? source.daylightBaseline,
+        DEFAULT_ENVIRONMENT_LIGHTING.sunlitBaseline
+      )
+    ),
   });
 }
 
@@ -1117,6 +1161,11 @@ export function estimateWavefrontPathTracingMemory(options = {}) {
     options.tilePixelCapacity,
     DEFAULT_TILE_SIZE * DEFAULT_TILE_SIZE
   );
+  const maxDepth = clamp(
+    readPositiveInteger("maxDepth", options.maxDepth, DEFAULT_MAX_DEPTH),
+    1,
+    16
+  );
   const sceneObjectCapacity = readPositiveInteger(
     "sceneObjectCapacity",
     options.sceneObjectCapacity,
@@ -1142,6 +1191,7 @@ export function estimateWavefrontPathTracingMemory(options = {}) {
   const queueBytes = tilePixelCapacity * RAY_RECORD_BYTES;
   const hitBytes = tilePixelCapacity * HIT_RECORD_BYTES;
   const accumulationBytes = tilePixelCapacity * ACCUMULATION_RECORD_BYTES;
+  const pathVertexBytes = tilePixelCapacity * (maxDepth + 1) * PATH_VERTEX_RECORD_BYTES;
   const sceneObjectBytes = sceneObjectCapacity * SCENE_OBJECT_RECORD_BYTES;
   const triangleBytes = triangleCapacity * TRIANGLE_RECORD_BYTES;
   const bvhNodeBytes = bvhNodeCapacity * BVH_NODE_RECORD_BYTES;
@@ -1156,6 +1206,7 @@ export function estimateWavefrontPathTracingMemory(options = {}) {
     queuePairBytes: queueBytes * 2,
     hitBytes,
     accumulationBytes,
+    pathVertexBytes,
     sceneObjectBytes,
     triangleBytes,
     bvhNodeBytes,
@@ -1169,6 +1220,7 @@ export function estimateWavefrontPathTracingMemory(options = {}) {
       queueBytes * 2 +
       hitBytes +
       accumulationBytes +
+      pathVertexBytes +
       sceneObjectBytes +
       triangleBytes +
       bvhNodeBytes +
@@ -1286,6 +1338,12 @@ export function createWavefrontPathTracingComputeConfig(options = {}) {
       options.environmentLighting?.environmentPortalMode,
     environmentPortals.length > 0
   );
+  const environmentMap = resolveEnvironmentMap(
+    options.environmentMap ??
+      options.environmentTexture ??
+      options.environmentLighting?.environmentMap
+  );
+  const deferredPathResolve = resolveDeferredPathResolve(options);
 
   return Object.freeze({
     mode: rendererWavefrontComputeMode,
@@ -1321,12 +1379,15 @@ export function createWavefrontPathTracingComputeConfig(options = {}) {
     environmentPortalCount: environmentPortals.length,
     environmentPortalCapacity,
     environmentPortalMode,
+    environmentMap,
+    deferredPathResolve,
     displayQuality: options.displayQuality === true,
     requiresMeshBvhForDisplayQuality: true,
     denoise: options.denoise !== false,
     frameIndex: readNonNegativeInteger("frameIndex", options.frameIndex, 0),
     memory: estimateWavefrontPathTracingMemory({
       tilePixelCapacity,
+      maxDepth,
       sceneObjectCapacity,
       triangleCapacity,
       bvhNodeCapacity,
@@ -1550,6 +1611,18 @@ function createConfigPayload(config, tile, frameIndex, buildRange = {}) {
   data.setUint32(260, config.environmentPortalMode ?? 0, true);
   data.setUint32(264, 0, true);
   data.setUint32(268, 0, true);
+  writeVec4(floatView, 272, [
+    config.environmentMap.enabled ? 1 : 0,
+    config.environmentMap.intensity,
+    config.environmentMap.rotationRadians,
+    config.environmentMap.ambientStrength,
+  ]);
+  writeVec4(floatView, 288, [
+    config.deferredPathResolve ? 1 : 0,
+    config.environmentLighting.sunlitBaseline,
+    0,
+    0,
+  ]);
   return bytes;
 }
 
@@ -1822,6 +1895,129 @@ function alignTo(value, alignment) {
   return Math.ceil(value / resolvedAlignment) * resolvedAlignment;
 }
 
+function float32ToFloat16Bits(value) {
+  const floatView = new Float32Array(1);
+  const intView = new Uint32Array(floatView.buffer);
+  floatView[0] = Number.isFinite(value) ? value : 0;
+  const x = intView[0];
+  const sign = (x >> 16) & 0x8000;
+  let mantissa = x & 0x7fffff;
+  let exponent = (x >> 23) & 0xff;
+
+  if (exponent === 0xff) {
+    return sign | (mantissa ? 0x7e00 : 0x7c00);
+  }
+
+  exponent = exponent - 127 + 15;
+  if (exponent >= 0x1f) {
+    return sign | 0x7c00;
+  }
+  if (exponent <= 0) {
+    if (exponent < -10) {
+      return sign;
+    }
+    mantissa = (mantissa | 0x800000) >> (1 - exponent);
+    return sign | ((mantissa + 0x1000) >> 13);
+  }
+  return sign | (exponent << 10) | ((mantissa + 0x1000) >> 13);
+}
+
+function readEnvironmentMapComponent(data, index, fallback) {
+  if (!data || index >= data.length) {
+    return fallback;
+  }
+  const value = Number(data[index]);
+  return Number.isFinite(value) ? Math.max(0, value) : fallback;
+}
+
+function createEnvironmentMapUploadBytes(environmentMap, fallbackColor) {
+  const width = Math.max(1, environmentMap.width);
+  const height = Math.max(1, environmentMap.height);
+  const rowBytes = width * 8;
+  const bytesPerRow = alignTo(rowBytes, 256);
+  const bytes = new Uint8Array(bytesPerRow * height);
+  const data = environmentMap.data;
+  const view = new DataView(bytes.buffer);
+
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      const sourceOffset = (y * width + x) * 4;
+      const targetOffset = y * bytesPerRow + x * 8;
+      view.setUint16(targetOffset, float32ToFloat16Bits(readEnvironmentMapComponent(data, sourceOffset, fallbackColor[0])), true);
+      view.setUint16(targetOffset + 2, float32ToFloat16Bits(readEnvironmentMapComponent(data, sourceOffset + 1, fallbackColor[1])), true);
+      view.setUint16(targetOffset + 4, float32ToFloat16Bits(readEnvironmentMapComponent(data, sourceOffset + 2, fallbackColor[2])), true);
+      view.setUint16(targetOffset + 6, float32ToFloat16Bits(readEnvironmentMapComponent(data, sourceOffset + 3, fallbackColor[3] ?? 1)), true);
+    }
+  }
+
+  return Object.freeze({
+    bytes,
+    bytesPerRow,
+    width,
+    height,
+  });
+}
+
+function createEnvironmentMapResource(device, constants, environmentMap, fallbackColor) {
+  if (environmentMap.view) {
+    return Object.freeze({
+      view: environmentMap.view,
+      sampler: environmentMap.sampler ?? device.createSampler({
+        label: "plasius.wavefront.environmentMapSampler",
+        addressModeU: "repeat",
+        addressModeV: "clamp-to-edge",
+        magFilter: "linear",
+        minFilter: "linear",
+      }),
+      texture: null,
+      ownsTexture: false,
+    });
+  }
+
+  if (environmentMap.texture && typeof environmentMap.texture.createView === "function") {
+    return Object.freeze({
+      view: environmentMap.texture.createView(),
+      sampler: environmentMap.sampler ?? device.createSampler({
+        label: "plasius.wavefront.environmentMapSampler",
+        addressModeU: "repeat",
+        addressModeV: "clamp-to-edge",
+        magFilter: "linear",
+        minFilter: "linear",
+      }),
+      texture: environmentMap.texture,
+      ownsTexture: false,
+    });
+  }
+
+  const upload = createEnvironmentMapUploadBytes(environmentMap, fallbackColor);
+  const texture = device.createTexture({
+    label: environmentMap.enabled
+      ? "plasius.wavefront.environmentMap"
+      : "plasius.wavefront.environmentMapFallback",
+    size: { width: upload.width, height: upload.height },
+    format: "rgba16float",
+    usage: constants.texture.TEXTURE_BINDING | constants.texture.COPY_DST,
+  });
+  device.queue.writeTexture(
+    { texture },
+    upload.bytes,
+    { bytesPerRow: upload.bytesPerRow, rowsPerImage: upload.height },
+    { width: upload.width, height: upload.height, depthOrArrayLayers: 1 }
+  );
+  return Object.freeze({
+    view: texture.createView(),
+    sampler: environmentMap.sampler ?? device.createSampler({
+      label: "plasius.wavefront.environmentMapSampler",
+      addressModeU: "repeat",
+      addressModeV: "clamp-to-edge",
+      magFilter: "linear",
+      minFilter: "linear",
+    }),
+    texture,
+    ownsTexture: true,
+  });
+}
+
 async function getPipelineDiagnostics(shaderModule) {
   if (typeof shaderModule?.compilationInfo !== "function") {
     return "";
@@ -2035,6 +2231,8 @@ struct FrameConfig {
   environmentPortalMode: u32,
   _portalPad0: u32,
   _portalPad1: u32,
+  environmentMapSettings: vec4<f32>,
+  pathResolveSettings: vec4<f32>,
 };
 
 struct Counters {
@@ -2094,6 +2292,9 @@ struct EnvironmentPortal {
 @group(0) @binding(17) var finalDenoiseInputRadiance: texture_2d<f32>;
 @group(0) @binding(18) var denoisedOutputImage: texture_storage_2d<rgba8unorm, write>;
 @group(0) @binding(19) var<storage, read> environmentPortals: array<EnvironmentPortal>;
+@group(0) @binding(20) var environmentMapTexture: texture_2d<f32>;
+@group(0) @binding(21) var environmentMapSampler: sampler;
+@group(0) @binding(22) var<storage, read_write> pathVertices: array<vec4<f32>>;
 
 fn hash_u32(value: u32) -> u32 {
   var x = value;
@@ -2138,6 +2339,89 @@ fn max_component(value: vec3<f32>) -> f32 {
   return max(max(value.x, value.y), value.z);
 }
 
+fn environment_map_enabled() -> bool {
+  return config.environmentMapSettings.x > 0.5;
+}
+
+fn deferred_path_resolve_enabled() -> bool {
+  return config.pathResolveSettings.x > 0.5;
+}
+
+fn path_vertex_count_per_ray() -> u32 {
+  return config.maxDepth + 1u;
+}
+
+fn path_vertex_index(rayId: u32, depth: u32) -> u32 {
+  return rayId * path_vertex_count_per_ray() + min(depth, config.maxDepth);
+}
+
+fn clear_deferred_path(rayId: u32) {
+  if (!deferred_path_resolve_enabled()) {
+    return;
+  }
+
+  for (var depth = 0u; depth <= config.maxDepth; depth = depth + 1u) {
+    pathVertices[path_vertex_index(rayId, depth)] = vec4<f32>(0.0);
+    if (depth == config.maxDepth) {
+      break;
+    }
+  }
+}
+
+fn record_deferred_path_response(ray: RayRecord, response: vec3<f32>) {
+  if (!deferred_path_resolve_enabled() || ray.rayId >= config.tilePixelCount || ray.bounce >= config.maxDepth) {
+    return;
+  }
+  pathVertices[path_vertex_index(ray.rayId, ray.bounce)] =
+    vec4<f32>(max(response, vec3<f32>(0.0)), 1.0);
+}
+
+fn record_deferred_terminal_source(ray: RayRecord, sourceRadiance: vec3<f32>) {
+  if (!deferred_path_resolve_enabled() || ray.rayId >= config.tilePixelCount) {
+    return;
+  }
+  pathVertices[path_vertex_index(ray.rayId, config.maxDepth)] =
+    vec4<f32>(clamp_sample_radiance(sourceRadiance), 1.0);
+}
+
+fn environment_map_uv(direction: vec3<f32>) -> vec2<f32> {
+  let rayDirection = safe_normalize(direction, vec3<f32>(0.0, 1.0, 0.0));
+  let rotationTurns = config.environmentMapSettings.z / 6.28318530718;
+  let u = fract(atan2(rayDirection.z, rayDirection.x) / 6.28318530718 + 0.5 + rotationTurns);
+  let v = acos(clamp(rayDirection.y, -1.0, 1.0)) / 3.14159265359;
+  return vec2<f32>(u, clamp(v, 0.0, 1.0));
+}
+
+fn environment_map_radiance(direction: vec3<f32>) -> vec3<f32> {
+  let uv = environment_map_uv(direction);
+  let texel = max(textureSampleLevel(environmentMapTexture, environmentMapSampler, uv, 0.0).rgb, vec3<f32>(0.0));
+  return texel * max(config.environmentMapSettings.y, 0.0);
+}
+
+fn procedural_environment_radiance(direction: vec3<f32>) -> vec3<f32> {
+  let rayDirection = safe_normalize(direction, vec3<f32>(0.0, 1.0, 0.0));
+  let upFactor = saturate(rayDirection.y * 0.5 + 0.5);
+  let sunDirection = safe_normalize(
+    config.environmentSunDirectionIntensity.xyz,
+    vec3<f32>(0.0, 1.0, 0.0)
+  );
+  let sunGlow = pow(saturate(dot(rayDirection, sunDirection)), 192.0);
+  let gradient =
+    config.environmentHorizonColor.xyz * (1.0 - upFactor) +
+    config.environmentZenithColor.xyz * upFactor;
+  return (
+    gradient +
+    config.environmentSunColor.xyz * sunGlow
+  ) * max(config.environmentSunDirectionIntensity.w, 0.0001);
+}
+
+fn base_environment_radiance(direction: vec3<f32>) -> vec3<f32> {
+  if (environment_map_enabled()) {
+    return environment_map_radiance(direction);
+  }
+  return procedural_environment_radiance(direction);
+}
+
 fn environment_portal_radiance_scale(origin: vec3<f32>, direction: vec3<f32>) -> vec3<f32> {
   if (config.environmentPortalCount == 0u || config.environmentPortalMode == 0u) {
     return vec3<f32>(1.0);
@@ -2177,22 +2461,9 @@ fn environment_portal_radiance_scale(origin: vec3<f32>, direction: vec3<f32>) ->
 
 fn environment_radiance(origin: vec3<f32>, direction: vec3<f32>) -> vec3<f32> {
   let rayDirection = safe_normalize(direction, vec3<f32>(0.0, 1.0, 0.0));
-  let upFactor = saturate(rayDirection.y * 0.5 + 0.5);
-  let sunDirection = safe_normalize(
-    config.environmentSunDirectionIntensity.xyz,
-    vec3<f32>(0.0, 1.0, 0.0)
-  );
-  let sunGlow = pow(saturate(dot(rayDirection, sunDirection)), 192.0);
-  let gradient =
-    config.environmentHorizonColor.xyz * (1.0 - upFactor) +
-    config.environmentZenithColor.xyz * upFactor;
   let portalScale = environment_portal_radiance_scale(origin, rayDirection);
   let portalHit = max_component(portalScale) > 0.0001;
-  return (
-    gradient +
-    config.environmentSunColor.xyz * sunGlow
-  ) *
-    max(config.environmentSunDirectionIntensity.w, 0.0001) *
+  return base_environment_radiance(rayDirection) *
     select(vec3<f32>(1.0), portalScale, portalHit);
 }
 
@@ -2208,16 +2479,59 @@ fn gated_environment_radiance(origin: vec3<f32>, direction: vec3<f32>) -> vec3<f
   return environment_radiance(origin, direction);
 }
 
-fn terminal_surface_environment_contribution(ray: RayRecord, hit: HitRecord) -> vec3<f32> {
+fn surface_path_response(hit: HitRecord) -> vec3<f32> {
+  let color = clamp(hit.color.xyz, vec3<f32>(0.0), vec3<f32>(1.0));
+  let opacity = clamp(hit.material.z, 0.0, 1.0);
+  let materialEnergy = select(0.68, 0.92, hit.materialKind == 1u || hit.materialKind == 2u);
+  let transparentEnergy = select(materialEnergy, 0.9, hit.hitType == 3u);
+  return mix(vec3<f32>(1.0), color, max(opacity, 0.18)) * transparentEnergy;
+}
+
+fn sunlit_baseline_radiance(normal: vec3<f32>) -> vec3<f32> {
+  let baseline = max(config.pathResolveSettings.y, 0.0);
+  if (baseline <= 0.000001) {
+    return vec3<f32>(0.0);
+  }
+  let sunDirection = safe_normalize(
+    config.environmentSunDirectionIntensity.xyz,
+    vec3<f32>(0.0, 1.0, 0.0)
+  );
+  let sunFacing = saturate(dot(normal, sunDirection));
+  let skyFacing = 0.35 + saturate(normal.y * 0.5 + 0.5) * 0.65;
+  let directionalWeight = 0.38 + sunFacing * 0.62;
+  let sunTint = max(config.environmentSunColor.xyz, vec3<f32>(0.0));
+  return clamp_sample_radiance(sunTint * baseline * skyFacing * directionalWeight * 0.04);
+}
+
+fn terminal_surface_environment_source(hit: HitRecord) -> vec3<f32> {
   let normal = safe_normalize(hit.shadingNormal.xyz, vec3<f32>(0.0, 1.0, 0.0));
-  let surfaceColor = max(hit.color.xyz, config.ambientColor.xyz);
   let normalEnvironment = gated_environment_radiance(
     hit.position.xyz + normal * 0.003,
     normal
   );
-  let environmentFloor = max(config.ambientColor.xyz, normalEnvironment * 0.12);
+  let sunlitFloor = sunlit_baseline_radiance(normal);
+  let ambientFloor = select(
+    max(config.ambientColor.xyz, sunlitFloor * 0.82),
+    max(config.ambientColor.xyz * 0.35, sunlitFloor * 0.58),
+    environment_map_enabled()
+  );
+  let environmentInfluence = select(
+    max(0.12, config.pathResolveSettings.y * 0.42),
+    max(config.environmentMapSettings.w, max(0.12, config.pathResolveSettings.y * 0.42)),
+    environment_map_enabled()
+  );
+  let environmentFloor = max(ambientFloor, max(sunlitFloor, normalEnvironment * environmentInfluence));
   let materialFloor = select(0.7, 1.0, hit.materialKind == 0u || hit.materialKind == 3u);
-  return clamp_sample_radiance(ray.throughput.xyz * surfaceColor * environmentFloor * materialFloor);
+  return clamp_sample_radiance(environmentFloor * materialFloor);
+}
+
+fn terminal_surface_environment_contribution(ray: RayRecord, hit: HitRecord) -> vec3<f32> {
+  let surfaceColor = max(hit.color.xyz, config.ambientColor.xyz);
+  return clamp_sample_radiance(
+    ray.throughput.xyz *
+    surfaceColor *
+    terminal_surface_environment_source(hit)
+  );
 }
 
 fn direct_environment_portal_irradiance(origin: vec3<f32>, normal: vec3<f32>) -> vec3<f32> {
@@ -2270,7 +2584,17 @@ fn surface_direct_environment_contribution(ray: RayRecord, hit: HitRecord) -> ve
 
   let normalEnvironment = gated_environment_radiance(origin, normal);
   let skyVisibility = 0.35 + saturate(normal.y * 0.5 + 0.5) * 0.45;
-  let skyIrradiance = max(config.ambientColor.xyz * 0.72, normalEnvironment * skyVisibility * 0.16);
+  let sunlitFloor = sunlit_baseline_radiance(normal);
+  let ambientIrradiance = max(
+    select(config.ambientColor.xyz * 0.72, config.ambientColor.xyz * 0.28, environment_map_enabled()),
+    sunlitFloor * select(0.72, 0.45, environment_map_enabled())
+  );
+  let environmentIrradianceScale = select(
+    max(0.16, config.pathResolveSettings.y * 0.45),
+    max(config.environmentMapSettings.w, max(0.16, config.pathResolveSettings.y * 0.45)),
+    environment_map_enabled()
+  );
+  let skyIrradiance = max(ambientIrradiance, normalEnvironment * skyVisibility * environmentIrradianceScale);
 
   let sunDirection = safe_normalize(
     config.environmentSunDirectionIntensity.xyz,
@@ -2894,6 +3218,7 @@ fn generatePrimaryRays(@builtin(global_invocation_id) globalId: vec3<u32>) {
     return;
   }
   activeQueue[index] = make_ray(index);
+  clear_deferred_path(index);
   if (u32(config.projectionAndSampling.w) == 0u) {
     accumulation[index] = vec4<f32>(0.0);
   }
@@ -3146,25 +3471,37 @@ fn resolveSurfaceRecords(@builtin(global_invocation_id) globalId: vec3<u32>) {
 
   if (hit.hitType == 1u) {
     let guidedLightWeight = select(1.0, 0.24, (ray.flags & RAY_FLAG_GUIDED_EMISSIVE) != 0u);
-    contribution = clamp_sample_radiance(
-      ray.throughput.xyz * max(hit.emission.xyz, hit.color.xyz) * guidedLightWeight
-    );
-    accumulation[ray.rayId] =
-      accumulation[ray.rayId] + vec4<f32>(contribution * sample_weight(), 1.0);
+    let sourceRadiance = max(hit.emission.xyz, hit.color.xyz) * guidedLightWeight;
+    if (deferred_path_resolve_enabled()) {
+      record_deferred_terminal_source(ray, sourceRadiance);
+    } else {
+      contribution = clamp_sample_radiance(ray.throughput.xyz * sourceRadiance);
+      accumulation[ray.rayId] =
+        accumulation[ray.rayId] + vec4<f32>(contribution * sample_weight(), 1.0);
+    }
     atomicAdd(&counters.terminatedCount, 1u);
     return;
   }
 
   if (hit.hitType == 2u) {
-    contribution = clamp_sample_radiance(ray.throughput.xyz * max(hit.color.xyz, config.ambientColor.xyz));
-    accumulation[ray.rayId] =
-      accumulation[ray.rayId] + vec4<f32>(contribution * sample_weight(), 1.0);
+    if (deferred_path_resolve_enabled()) {
+      record_deferred_terminal_source(ray, hit.color.xyz);
+    } else {
+      contribution = clamp_sample_radiance(ray.throughput.xyz * max(hit.color.xyz, config.ambientColor.xyz));
+      accumulation[ray.rayId] =
+        accumulation[ray.rayId] + vec4<f32>(contribution * sample_weight(), 1.0);
+    }
     atomicAdd(&counters.terminatedCount, 1u);
     return;
   }
 
+  let response = surface_path_response(hit);
+  record_deferred_path_response(ray, response);
+
   let shouldEstimateDirectEnvironment =
-    (hit.materialKind == 0u || hit.materialKind == 1u) && hit.material.z >= 0.95;
+    !deferred_path_resolve_enabled() &&
+    (hit.materialKind == 0u || hit.materialKind == 1u) &&
+    hit.material.z >= 0.95;
   if (shouldEstimateDirectEnvironment) {
     let directEnvironment = surface_direct_environment_contribution(ray, hit);
     accumulation[ray.rayId] =
@@ -3172,9 +3509,13 @@ fn resolveSurfaceRecords(@builtin(global_invocation_id) globalId: vec3<u32>) {
   }
 
   if (ray.bounce + 1u >= config.maxDepth) {
-    let terminalEnvironment = terminal_surface_environment_contribution(ray, hit);
-    accumulation[ray.rayId] =
-      accumulation[ray.rayId] + vec4<f32>(terminalEnvironment * sample_weight(), 1.0);
+    if (deferred_path_resolve_enabled()) {
+      record_deferred_terminal_source(ray, terminal_surface_environment_source(hit));
+    } else {
+      let terminalEnvironment = terminal_surface_environment_contribution(ray, hit);
+      accumulation[ray.rayId] =
+        accumulation[ray.rayId] + vec4<f32>(terminalEnvironment * sample_weight(), 1.0);
+    }
     atomicAdd(&counters.terminatedCount, 1u);
     return;
   }
@@ -3183,17 +3524,17 @@ fn resolveSurfaceRecords(@builtin(global_invocation_id) globalId: vec3<u32>) {
   let scatter = scatter_direction(ray, hit, seed);
   let nextIndex = atomicAdd(&counters.nextCount, 1u);
   if (nextIndex >= config.tilePixelCount) {
-    let overflowEnvironment = terminal_surface_environment_contribution(ray, hit);
-    accumulation[ray.rayId] =
-      accumulation[ray.rayId] + vec4<f32>(overflowEnvironment * sample_weight(), 1.0);
+    if (deferred_path_resolve_enabled()) {
+      record_deferred_terminal_source(ray, terminal_surface_environment_source(hit));
+    } else {
+      let overflowEnvironment = terminal_surface_environment_contribution(ray, hit);
+      accumulation[ray.rayId] =
+        accumulation[ray.rayId] + vec4<f32>(overflowEnvironment * sample_weight(), 1.0);
+    }
     atomicAdd(&counters.terminatedCount, 1u);
     return;
   }
-  let color = clamp(hit.color.xyz, vec3<f32>(0.0), vec3<f32>(1.0));
-  let opacity = clamp(hit.material.z, 0.0, 1.0);
-  let materialEnergy = select(0.68, 0.92, hit.materialKind == 1u || hit.materialKind == 2u);
-  let transparentEnergy = select(materialEnergy, 0.9, hit.hitType == 3u);
-  let throughput = ray.throughput.xyz * mix(vec3<f32>(1.0), color, max(opacity, 0.18)) * transparentEnergy;
+  let throughput = ray.throughput.xyz * response;
   nextQueue[nextIndex] = RayRecord(
     ray.rayId,
     ray.rayId,
@@ -3221,6 +3562,27 @@ fn compactAndSwapQueues(@builtin(global_invocation_id) globalId: vec3<u32>) {
   write_active_dispatch_args(activeCount);
 }
 
+fn resolve_deferred_path_radiance(rayId: u32) -> vec3<f32> {
+  let terminal = pathVertices[path_vertex_index(rayId, config.maxDepth)];
+  if (terminal.w <= 0.0) {
+    return vec3<f32>(0.0);
+  }
+
+  var radiance = terminal.xyz;
+  var depth = config.maxDepth;
+  loop {
+    if (depth == 0u) {
+      break;
+    }
+    depth = depth - 1u;
+    let response = pathVertices[path_vertex_index(rayId, depth)];
+    if (response.w > 0.0) {
+      radiance = radiance * response.xyz;
+    }
+  }
+  return clamp_sample_radiance(radiance);
+}
+
 @compute @workgroup_size(64)
 fn accumulateTerminalRadiance(@builtin(global_invocation_id) globalId: vec3<u32>) {
   let index = globalId.x;
@@ -3230,7 +3592,12 @@ fn accumulateTerminalRadiance(@builtin(global_invocation_id) globalId: vec3<u32>
   let localX = index % config.tileWidth;
   let localY = index / config.tileWidth;
   let pixel = vec2<i32>(i32(config.tileX + localX), i32(config.tileY + localY));
-  let radiance = max(accumulation[index].xyz, vec3<f32>(0.0));
+  var radiance = max(accumulation[index].xyz, vec3<f32>(0.0));
+  if (deferred_path_resolve_enabled()) {
+    let resolved = resolve_deferred_path_radiance(index) * sample_weight();
+    radiance = clamp_sample_radiance(radiance + resolved);
+    accumulation[index] = vec4<f32>(radiance, 1.0);
+  }
 
   textureStore(radianceImage, pixel, vec4<f32>(radiance, 1.0));
   if (config.denoise == 0u) {
@@ -3373,6 +3740,137 @@ function createWavefrontDeviceDescriptor(adapter, options = {}) {
   return Object.keys(descriptor).length > 0 ? descriptor : undefined;
 }
 
+function readGpuLimit(adapter, device, name) {
+  const adapterValue = Number(adapter?.limits?.[name]);
+  if (Number.isFinite(adapterValue)) {
+    return adapterValue;
+  }
+  const deviceValue = Number(device?.limits?.[name]);
+  return Number.isFinite(deviceValue) ? deviceValue : null;
+}
+
+function createAdapterInfoSnapshot(adapter) {
+  const info = adapter?.info;
+  if (!info || typeof info !== "object") {
+    return null;
+  }
+  return Object.freeze({
+    vendor: typeof info.vendor === "string" ? info.vendor : "",
+    architecture: typeof info.architecture === "string" ? info.architecture : "",
+    device: typeof info.device === "string" ? info.device : "",
+    description: typeof info.description === "string" ? info.description : "",
+  });
+}
+
+function createGpuAdapterParallelismDiagnostics(adapter, device) {
+  return Object.freeze({
+    physicalCoreCount: null,
+    physicalCoreCountAvailable: false,
+    physicalCoreCountUnavailableReason: "WebGPU does not expose physical GPU core counts.",
+    adapterInfo: createAdapterInfoSnapshot(adapter),
+    adapterLimits: Object.freeze({
+      maxComputeInvocationsPerWorkgroup: readGpuLimit(adapter, device, "maxComputeInvocationsPerWorkgroup"),
+      maxComputeWorkgroupSizeX: readGpuLimit(adapter, device, "maxComputeWorkgroupSizeX"),
+      maxComputeWorkgroupSizeY: readGpuLimit(adapter, device, "maxComputeWorkgroupSizeY"),
+      maxComputeWorkgroupSizeZ: readGpuLimit(adapter, device, "maxComputeWorkgroupSizeZ"),
+      maxComputeWorkgroupsPerDimension: readGpuLimit(adapter, device, "maxComputeWorkgroupsPerDimension"),
+      maxStorageBuffersPerShaderStage: readGpuLimit(adapter, device, "maxStorageBuffersPerShaderStage"),
+      maxStorageBufferBindingSize: readGpuLimit(adapter, device, "maxStorageBufferBindingSize"),
+    }),
+    configuredWorkgroupSize: WORKGROUP_SIZE,
+  });
+}
+
+function createGpuParallelismCounters() {
+  return {
+    directDispatches: 0,
+    directWorkgroups: 0,
+    directShaderInvocations: 0,
+    multiWorkgroupDispatches: 0,
+    largestDirectWorkgroupsPerDispatch: 0,
+    indirectDispatches: 0,
+    estimatedIndirectWorkgroupsUpperBound: 0,
+    estimatedIndirectShaderInvocationsUpperBound: 0,
+    indirectDispatchesWithMultiWorkgroupCapacity: 0,
+    largestEstimatedIndirectWorkgroupsPerDispatch: 0,
+  };
+}
+
+function countDispatchWorkgroups(groups) {
+  return groups.reduce((product, value) => {
+    const numeric = Number(value ?? 1);
+    const count = Number.isFinite(numeric) ? Math.max(1, Math.trunc(numeric)) : 1;
+    return product * count;
+  }, 1);
+}
+
+function recordDirectDispatch(parallelism, groups, invocationsPerWorkgroup = WORKGROUP_SIZE) {
+  const workgroups = countDispatchWorkgroups(groups);
+  parallelism.directDispatches += 1;
+  parallelism.directWorkgroups += workgroups;
+  parallelism.directShaderInvocations += workgroups * invocationsPerWorkgroup;
+  parallelism.largestDirectWorkgroupsPerDispatch = Math.max(
+    parallelism.largestDirectWorkgroupsPerDispatch,
+    workgroups
+  );
+  if (workgroups > 1) {
+    parallelism.multiWorkgroupDispatches += 1;
+  }
+}
+
+function recordIndirectDispatch(parallelism, estimatedWorkgroupsUpperBound, invocationsPerWorkgroup = WORKGROUP_SIZE) {
+  const workgroups = Math.max(1, Math.trunc(Number(estimatedWorkgroupsUpperBound) || 1));
+  parallelism.indirectDispatches += 1;
+  parallelism.estimatedIndirectWorkgroupsUpperBound += workgroups;
+  parallelism.estimatedIndirectShaderInvocationsUpperBound += workgroups * invocationsPerWorkgroup;
+  parallelism.largestEstimatedIndirectWorkgroupsPerDispatch = Math.max(
+    parallelism.largestEstimatedIndirectWorkgroupsPerDispatch,
+    workgroups
+  );
+  if (workgroups > 1) {
+    parallelism.indirectDispatchesWithMultiWorkgroupCapacity += 1;
+  }
+}
+
+function createGpuParallelismDiagnostics(adapterDiagnostics, counters) {
+  const totalEstimatedWorkgroupsUpperBound =
+    counters.directWorkgroups + counters.estimatedIndirectWorkgroupsUpperBound;
+  const totalEstimatedShaderInvocationsUpperBound =
+    counters.directShaderInvocations + counters.estimatedIndirectShaderInvocationsUpperBound;
+  const exposesMultiWorkgroupParallelism =
+    counters.multiWorkgroupDispatches > 0 || counters.indirectDispatchesWithMultiWorkgroupCapacity > 0;
+  return Object.freeze({
+    ...adapterDiagnostics,
+    directDispatches: counters.directDispatches,
+    directWorkgroups: counters.directWorkgroups,
+    directShaderInvocations: counters.directShaderInvocations,
+    multiWorkgroupDispatches: counters.multiWorkgroupDispatches,
+    largestDirectWorkgroupsPerDispatch: counters.largestDirectWorkgroupsPerDispatch,
+    indirectDispatches: counters.indirectDispatches,
+    estimatedIndirectWorkgroupsUpperBound: counters.estimatedIndirectWorkgroupsUpperBound,
+    estimatedIndirectShaderInvocationsUpperBound: counters.estimatedIndirectShaderInvocationsUpperBound,
+    indirectDispatchesWithMultiWorkgroupCapacity: counters.indirectDispatchesWithMultiWorkgroupCapacity,
+    largestEstimatedIndirectWorkgroupsPerDispatch: counters.largestEstimatedIndirectWorkgroupsPerDispatch,
+    totalEstimatedWorkgroupsUpperBound,
+    totalEstimatedShaderInvocationsUpperBound,
+    exposesMultiWorkgroupParallelism,
+    likelyUsesMoreThanOnePhysicalGpuCore: null,
+    coreUtilizationStatus: "not-exposed-by-webgpu",
+  });
+}
+
+function createEnvironmentMapSnapshot(environmentMap) {
+  return Object.freeze({
+    enabled: environmentMap.enabled,
+    width: environmentMap.width,
+    height: environmentMap.height,
+    projection: environmentMap.projection,
+    intensity: environmentMap.intensity,
+    rotationRadians: environmentMap.rotationRadians,
+    ambientStrength: environmentMap.ambientStrength,
+  });
+}
+
 export async function createWavefrontPathTracingComputeRenderer(options = {}) {
   assertAnalyticDisplayQualityPolicy(options);
   const constants = getGpuUsageConstants();
@@ -3394,6 +3892,7 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
   }
 
   const device = await adapter.requestDevice(createWavefrontDeviceDescriptor(adapter, options));
+  const gpuAdapterParallelism = createGpuAdapterParallelismDiagnostics(adapter, device);
   const context = canvas.getContext("webgpu");
   if (!context || typeof context.configure !== "function") {
     throw new Error("Canvas WebGPU context does not support configure().");
@@ -3427,6 +3926,7 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
   const rayQueueBytes = config.tilePixelCapacity * RAY_RECORD_BYTES;
   const hitBytes = config.tilePixelCapacity * HIT_RECORD_BYTES;
   const accumulationBytes = config.tilePixelCapacity * ACCUMULATION_RECORD_BYTES;
+  const pathVertexBytes = config.tilePixelCapacity * (config.maxDepth + 1) * PATH_VERTEX_RECORD_BYTES;
   const activeQueue = createBuffer(device, bufferUsage, rayQueueBytes, "plasius.wavefront.activeQueue");
   const nextQueue = createBuffer(device, bufferUsage, rayQueueBytes, "plasius.wavefront.nextQueue");
   const hitBuffer = createBuffer(device, bufferUsage, hitBytes, "plasius.wavefront.hitBuffer");
@@ -3435,6 +3935,12 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
     bufferUsage,
     accumulationBytes,
     "plasius.wavefront.accumulation"
+  );
+  const pathVertexBuffer = createBuffer(
+    device,
+    bufferUsage,
+    pathVertexBytes,
+    "plasius.wavefront.pathVertices"
   );
   const sceneObjectBuffer = createBuffer(
     device,
@@ -3493,9 +3999,10 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
       ? uniformOffsetAlignment
       : CONFIG_BUFFER_BYTES
   );
+  const outputConfigSlotCount = config.deferredPathResolve ? 0 : tiles.length;
   const frameConfigSlotCount = Math.max(
     1,
-    tiles.length * config.samplesPerPixel + tiles.length + (config.denoise ? 1 : 0)
+    tiles.length * config.samplesPerPixel + outputConfigSlotCount + (config.denoise ? 1 : 0)
   );
   const configBuffer = createBuffer(
     device,
@@ -3583,6 +4090,12 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
     magFilter: "nearest",
     minFilter: "nearest",
   });
+  const environmentMapResource = createEnvironmentMapResource(
+    device,
+    constants,
+    config.environmentMap,
+    config.environmentColor
+  );
 
   const traceBindGroupLayout = device.createBindGroupLayout({
     label: "plasius.wavefront.traceBindGroupLayout",
@@ -3611,6 +4124,9 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
         storageTexture: { access: "write-only", format: "rgba16float" },
       },
       { binding: 19, visibility: constants.shader.COMPUTE, buffer: { type: "read-only-storage" } },
+      { binding: 20, visibility: constants.shader.COMPUTE, texture: { sampleType: "float" } },
+      { binding: 21, visibility: constants.shader.COMPUTE, sampler: { type: "filtering" } },
+      { binding: 22, visibility: constants.shader.COMPUTE, buffer: { type: "storage" } },
     ],
   });
   const accelerationBindGroupLayout = device.createBindGroupLayout({
@@ -3787,6 +4303,9 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
         { binding: 9, resource: { buffer: bvhNodeBuffer } },
         { binding: 16, resource: radianceView },
         { binding: 19, resource: { buffer: environmentPortalBuffer } },
+        { binding: 20, resource: environmentMapResource.view },
+        { binding: 21, resource: environmentMapResource.sampler },
+        { binding: 22, resource: { buffer: pathVertexBuffer } },
       ],
     });
   }
@@ -3881,6 +4400,10 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
   let accelerationBuilt = !config.gpuAccelerationBuildRequired;
   let accelerationBuildCount = 0;
   let activeCameraOptions = options.camera ?? DEFAULT_CAMERA;
+  let lastGpuParallelism = createGpuParallelismDiagnostics(
+    gpuAdapterParallelism,
+    createGpuParallelismCounters()
+  );
 
   function createFrameConfigWriter(frameIndex) {
     let slot = 0;
@@ -3899,7 +4422,7 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
     };
   }
 
-  function dispatchGpuAccelerationBuild(frameIndex) {
+  function dispatchGpuAccelerationBuild(frameIndex, parallelism) {
     if (!config.gpuAccelerationBuildRequired || accelerationBuilt) {
       return false;
     }
@@ -3938,24 +4461,32 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
     });
     passEncoder.setBindGroup(0, bvhBuildBindGroup, [0]);
     passEncoder.setPipeline(pipelines.prepareMeshTrianglesAndLeaves);
-    passEncoder.dispatchWorkgroups(Math.ceil(config.bvhLeafSortCapacity / WORKGROUP_SIZE));
+    const prepareWorkgroups = Math.ceil(config.bvhLeafSortCapacity / WORKGROUP_SIZE);
+    passEncoder.dispatchWorkgroups(prepareWorkgroups);
+    recordDirectDispatch(parallelism, [prepareWorkgroups]);
     passEncoder.setPipeline(pipelines.sortBvhLeafRefs);
     for (let stageIndex = 0; stageIndex < config.bvhSortStages.length; stageIndex += 1) {
       passEncoder.setBindGroup(0, bvhBuildBindGroup, [
         (stageIndex + 1) * configBufferStride,
       ]);
-      passEncoder.dispatchWorkgroups(Math.ceil(config.bvhLeafSortCapacity / WORKGROUP_SIZE));
+      const sortWorkgroups = Math.ceil(config.bvhLeafSortCapacity / WORKGROUP_SIZE);
+      passEncoder.dispatchWorkgroups(sortWorkgroups);
+      recordDirectDispatch(parallelism, [sortWorkgroups]);
     }
     passEncoder.setBindGroup(0, bvhBuildBindGroup, [0]);
     passEncoder.setPipeline(pipelines.writeSortedBvhLeaves);
-    passEncoder.dispatchWorkgroups(Math.ceil(config.triangleCount / WORKGROUP_SIZE));
+    const leafWriteWorkgroups = Math.ceil(config.triangleCount / WORKGROUP_SIZE);
+    passEncoder.dispatchWorkgroups(leafWriteWorkgroups);
+    recordDirectDispatch(parallelism, [leafWriteWorkgroups]);
     passEncoder.setPipeline(pipelines.buildBvhInternalLevel);
     for (let levelIndex = 0; levelIndex < config.bvhBuildLevels.length; levelIndex += 1) {
       const buildLevel = config.bvhBuildLevels[levelIndex];
       passEncoder.setBindGroup(0, bvhBuildBindGroup, [
         (buildLevelConfigStart + levelIndex) * configBufferStride,
       ]);
-      passEncoder.dispatchWorkgroups(Math.ceil(buildLevel.count / WORKGROUP_SIZE));
+      const levelWorkgroups = Math.ceil(buildLevel.count / WORKGROUP_SIZE);
+      passEncoder.dispatchWorkgroups(levelWorkgroups);
+      recordDirectDispatch(parallelism, [levelWorkgroups]);
     }
     passEncoder.end();
     device.queue.submit([encoder.finish()]);
@@ -3964,7 +4495,7 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
     return true;
   }
 
-  function encodeTileSample(encoder, tile, configOffset) {
+  function encodeTileSample(encoder, tile, configOffset, parallelism) {
     const generatePass = encoder.beginComputePass({
       label: "plasius.wavefront.generatePrimaryRaysPass",
     });
@@ -3973,6 +4504,7 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
     generatePass.setBindGroup(0, bindGroups[0], [configOffset]);
     generatePass.setPipeline(pipelines.generatePrimaryRays);
     generatePass.dispatchWorkgroups(tileWorkgroups);
+    recordDirectDispatch(parallelism, [tileWorkgroups]);
     generatePass.end();
 
     for (let bounceIndex = 0; bounceIndex < config.maxDepth; bounceIndex += 1) {
@@ -3989,15 +4521,18 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
       passEncoder.setBindGroup(0, bindGroups[bounceIndex % 2], [configOffset]);
       passEncoder.setPipeline(pipelines.intersectActiveQueue);
       passEncoder.dispatchWorkgroupsIndirect(activeDispatchBuffer, 0);
+      recordIndirectDispatch(parallelism, tileWorkgroups);
       passEncoder.setPipeline(pipelines.resolveSurfaceRecords);
       passEncoder.dispatchWorkgroupsIndirect(activeDispatchBuffer, 0);
+      recordIndirectDispatch(parallelism, tileWorkgroups);
       passEncoder.setPipeline(pipelines.compactAndSwapQueues);
       passEncoder.dispatchWorkgroups(1);
+      recordDirectDispatch(parallelism, [1], 1);
       passEncoder.end();
     }
   }
 
-  function encodeTileOutput(encoder, tile, configOffset) {
+  function encodeTileOutput(encoder, tile, configOffset, parallelism) {
     const passEncoder = encoder.beginComputePass({
       label: "plasius.wavefront.outputPass",
     });
@@ -4006,19 +4541,23 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
     passEncoder.setBindGroup(0, bindGroups[0], [configOffset]);
     passEncoder.setPipeline(pipelines.accumulateTerminalRadiance);
     passEncoder.dispatchWorkgroups(tileWorkgroups);
+    recordDirectDispatch(parallelism, [tileWorkgroups]);
     passEncoder.end();
   }
 
-  function encodeDenoise(encoder, configOffset) {
+  function encodeDenoise(encoder, configOffset, parallelism) {
     if (!config.denoise) {
       return;
     }
+    const denoiseWorkgroupsX = Math.ceil(config.width / 8);
+    const denoiseWorkgroupsY = Math.ceil(config.height / 8);
     const radiancePass = encoder.beginComputePass({
       label: "plasius.wavefront.denoiseRadiancePass",
     });
     radiancePass.setBindGroup(0, denoiseRadianceBindGroup, [configOffset]);
     radiancePass.setPipeline(pipelines.denoiseLinearRadiance);
-    radiancePass.dispatchWorkgroups(Math.ceil(config.width / 8), Math.ceil(config.height / 8));
+    radiancePass.dispatchWorkgroups(denoiseWorkgroupsX, denoiseWorkgroupsY);
+    recordDirectDispatch(parallelism, [denoiseWorkgroupsX, denoiseWorkgroupsY]);
     radiancePass.end();
 
     const resolvePass = encoder.beginComputePass({
@@ -4026,7 +4565,8 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
     });
     resolvePass.setBindGroup(0, denoiseResolveBindGroup, [configOffset]);
     resolvePass.setPipeline(pipelines.resolveDenoisedOutputImage);
-    resolvePass.dispatchWorkgroups(Math.ceil(config.width / 8), Math.ceil(config.height / 8));
+    resolvePass.dispatchWorkgroups(denoiseWorkgroupsX, denoiseWorkgroupsY);
+    recordDirectDispatch(parallelism, [denoiseWorkgroupsX, denoiseWorkgroupsY]);
     resolvePass.end();
   }
 
@@ -4049,7 +4589,7 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
     passEncoder.end();
   }
 
-  function dispatchFrame(frameIndex) {
+  function dispatchFrame(frameIndex, parallelism) {
     const writeFrameConfig = createFrameConfigWriter(frameIndex);
     let submissionCount = 0;
     let encodedFramePasses = 0;
@@ -4086,20 +4626,25 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
           sampleIndex,
           sampleWeight: 1 / config.samplesPerPixel,
         });
-        encodeTileSample(reserveEncoder(), tile, configOffset);
+        encodeTileSample(reserveEncoder(), tile, configOffset, parallelism);
+        if (config.deferredPathResolve) {
+          encodeTileOutput(reserveEncoder(), tile, configOffset, parallelism);
+        }
       }
-      const outputConfigOffset = writeFrameConfig(tile, {
-        sampleIndex: 0,
-        sampleWeight: 1 / config.samplesPerPixel,
-      });
-      encodeTileOutput(reserveEncoder(), tile, outputConfigOffset);
+      if (!config.deferredPathResolve) {
+        const outputConfigOffset = writeFrameConfig(tile, {
+          sampleIndex: 0,
+          sampleWeight: 1 / config.samplesPerPixel,
+        });
+        encodeTileOutput(reserveEncoder(), tile, outputConfigOffset, parallelism);
+      }
     }
     if (config.denoise) {
       const denoiseConfigOffset = writeFrameConfig(
         { x: 0, y: 0, width: config.width, height: config.height },
         { sampleIndex: 0, sampleWeight: 1 / config.samplesPerPixel }
       );
-      encodeDenoise(reserveEncoder(), denoiseConfigOffset);
+      encodeDenoise(reserveEncoder(), denoiseConfigOffset, parallelism);
     }
     encodePresent(reserveEncoder());
     submitCurrentEncoder();
@@ -4109,8 +4654,10 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
   function renderOnce() {
     frame += 1;
     const frameIndex = frame + config.frameIndex;
-    const accelerationBuildSubmitted = dispatchGpuAccelerationBuild(frameIndex);
-    const frameSubmissionCount = dispatchFrame(frameIndex);
+    const parallelismCounters = createGpuParallelismCounters();
+    const accelerationBuildSubmitted = dispatchGpuAccelerationBuild(frameIndex, parallelismCounters);
+    const frameSubmissionCount = dispatchFrame(frameIndex, parallelismCounters);
+    lastGpuParallelism = createGpuParallelismDiagnostics(gpuAdapterParallelism, parallelismCounters);
     return Object.freeze({
       frame,
       width: config.width,
@@ -4127,6 +4674,8 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
       emissiveTriangleCount: config.emissiveTriangleCount,
       environmentPortalCount: config.environmentPortalCount,
       environmentPortalMode: config.environmentPortalMode,
+      environmentMap: createEnvironmentMapSnapshot(config.environmentMap),
+      deferredPathResolve: config.deferredPathResolve,
       bvhNodeCount: config.bvhNodeCount,
       displayQuality: config.displayQuality,
       accelerationBuildMode: config.accelerationBuildMode,
@@ -4136,6 +4685,7 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
       accelerationBuildCount,
       commandSubmissions: frameSubmissionCount + (accelerationBuildSubmitted ? 1 : 0),
       frameConfigSlots: frameConfigSlotCount,
+      gpuParallelism: lastGpuParallelism,
       memory: config.memory,
     });
   }
@@ -4252,6 +4802,8 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
       emissiveTriangleCount: config.emissiveTriangleCount,
       environmentPortalCount: config.environmentPortalCount,
       environmentPortalMode: config.environmentPortalMode,
+      environmentMap: createEnvironmentMapSnapshot(config.environmentMap),
+      deferredPathResolve: config.deferredPathResolve,
       bvhNodeCount: config.bvhNodeCount,
       displayQuality: config.displayQuality,
       accelerationBuildMode: config.accelerationBuildMode,
@@ -4259,6 +4811,7 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
       accelerationBuilt,
       accelerationBuildCount,
       frameConfigSlots: frameConfigSlotCount,
+      gpuParallelism: lastGpuParallelism,
       memory: config.memory,
     });
   }
@@ -4268,6 +4821,7 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
     nextQueue.destroy?.();
     hitBuffer.destroy?.();
     accumulationBuffer.destroy?.();
+    pathVertexBuffer.destroy?.();
     sceneObjectBuffer.destroy?.();
     triangleBuffer.destroy?.();
     bvhNodeBuffer.destroy?.();
@@ -4283,6 +4837,9 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
     radianceTexture.destroy?.();
     denoiseScratchTexture.destroy?.();
     outputTexture.destroy?.();
+    if (environmentMapResource.ownsTexture) {
+      environmentMapResource.texture?.destroy?.();
+    }
     context.unconfigure?.();
   }
 

--- a/src/wavefront-compute.js
+++ b/src/wavefront-compute.js
@@ -1922,12 +1922,22 @@ function float32ToFloat16Bits(value) {
   return sign | (exponent << 10) | ((mantissa + 0x1000) >> 13);
 }
 
-function readEnvironmentMapComponent(data, index, fallback) {
+function environmentMapIntegerScale(data) {
+  if (data instanceof Uint8Array) {
+    return 1 / 255;
+  }
+  if (data instanceof Uint16Array) {
+    return 1 / 65535;
+  }
+  return 1;
+}
+
+function readEnvironmentMapComponent(data, index, fallback, integerScale = 1) {
   if (!data || index >= data.length) {
     return fallback;
   }
   const value = Number(data[index]);
-  return Number.isFinite(value) ? Math.max(0, value) : fallback;
+  return Number.isFinite(value) ? Math.max(0, value) * integerScale : fallback;
 }
 
 function createEnvironmentMapUploadBytes(environmentMap, fallbackColor) {
@@ -1937,16 +1947,26 @@ function createEnvironmentMapUploadBytes(environmentMap, fallbackColor) {
   const bytesPerRow = alignTo(rowBytes, 256);
   const bytes = new Uint8Array(bytesPerRow * height);
   const data = environmentMap.data;
+  const integerScale = environmentMapIntegerScale(data);
   const view = new DataView(bytes.buffer);
+  const writeComponent = (targetOffset, sourceOffset, fallback) => {
+    view.setUint16(
+      targetOffset,
+      float32ToFloat16Bits(
+        readEnvironmentMapComponent(data, sourceOffset, fallback, integerScale)
+      ),
+      true
+    );
+  };
 
   for (let y = 0; y < height; y += 1) {
     for (let x = 0; x < width; x += 1) {
       const sourceOffset = (y * width + x) * 4;
       const targetOffset = y * bytesPerRow + x * 8;
-      view.setUint16(targetOffset, float32ToFloat16Bits(readEnvironmentMapComponent(data, sourceOffset, fallbackColor[0])), true);
-      view.setUint16(targetOffset + 2, float32ToFloat16Bits(readEnvironmentMapComponent(data, sourceOffset + 1, fallbackColor[1])), true);
-      view.setUint16(targetOffset + 4, float32ToFloat16Bits(readEnvironmentMapComponent(data, sourceOffset + 2, fallbackColor[2])), true);
-      view.setUint16(targetOffset + 6, float32ToFloat16Bits(readEnvironmentMapComponent(data, sourceOffset + 3, fallbackColor[3] ?? 1)), true);
+      writeComponent(targetOffset, sourceOffset, fallbackColor[0]);
+      writeComponent(targetOffset + 2, sourceOffset + 1, fallbackColor[1]);
+      writeComponent(targetOffset + 4, sourceOffset + 2, fallbackColor[2]);
+      writeComponent(targetOffset + 6, sourceOffset + 3, fallbackColor[3] ?? 1);
     }
   }
 

--- a/tests/wavefront-compute.test.js
+++ b/tests/wavefront-compute.test.js
@@ -241,9 +241,13 @@ class FakeWavefrontDevice {
         this.queue.writes.push({ buffer, offset, byteLength: data.byteLength ?? data.length ?? 0 });
       },
       writeTexture: (destination, data, layout, size) => {
+        const byteLength = data.byteLength ?? data.length ?? 0;
+        const byteOffset = data.byteOffset ?? 0;
+        const sourceBuffer = data.buffer ?? data;
         this.queue.textureWrites.push({
           destination,
-          byteLength: data.byteLength ?? data.length ?? 0,
+          byteLength,
+          data: new Uint8Array(sourceBuffer.slice(byteOffset, byteOffset + byteLength)),
           layout,
           size,
         });
@@ -1344,9 +1348,9 @@ test("wavefront compute renderer drives GPU-only mesh BVH passes", async () => {
       environmentMap: {
         width: 2,
         height: 1,
-        data: new Float32Array([
-          1.2, 0.8, 0.4, 1,
-          0.2, 0.5, 1.6, 1,
+        data: new Uint8Array([
+          255, 128, 0, 255,
+          64, 32, 16, 255,
         ]),
         intensity: 1.7,
         rotationRadians: 0.25,
@@ -1474,6 +1478,12 @@ test("wavefront compute renderer drives GPU-only mesh BVH passes", async () => {
     assert.equal(device.queue.textureWrites[0].size.width, 2);
     assert.equal(device.queue.textureWrites[0].size.height, 1);
     assert.equal(device.queue.textureWrites[0].layout.bytesPerRow, 256);
+    const environmentMapUpload = new DataView(device.queue.textureWrites[0].data.buffer);
+    assert.equal(environmentMapUpload.getUint16(0, true), 0x3c00);
+    assert.equal(environmentMapUpload.getUint16(4, true), 0);
+    assert.equal(environmentMapUpload.getUint16(6, true), 0x3c00);
+    assert.ok(environmentMapUpload.getUint16(8, true) > 0);
+    assert.ok(environmentMapUpload.getUint16(8, true) < 0x3c00);
     const submittedLabels = device.queue.submissions.flat().map((submission) => submission.encoderLabel);
     assert.equal(submittedLabels.filter((label) => label.includes("buildAcceleration")).length, 1);
     assert.equal(submittedLabels.filter((label) => label.includes(".batched")).length, 3);

--- a/tests/wavefront-compute.test.js
+++ b/tests/wavefront-compute.test.js
@@ -41,8 +41,9 @@ const gpuConstants = Object.freeze({
   }),
   texture: Object.freeze({
     COPY_SRC: 1,
-    STORAGE_BINDING: 2,
-    TEXTURE_BINDING: 4,
+    COPY_DST: 2,
+    STORAGE_BINDING: 4,
+    TEXTURE_BINDING: 8,
   }),
   shader: Object.freeze({
     COMPUTE: 1,
@@ -232,11 +233,20 @@ class FakeWavefrontDevice {
     this.queue = {
       submissions: [],
       writes: [],
+      textureWrites: [],
       submit: (buffers) => {
         this.queue.submissions.push(buffers);
       },
       writeBuffer: (buffer, offset, data) => {
         this.queue.writes.push({ buffer, offset, byteLength: data.byteLength ?? data.length ?? 0 });
+      },
+      writeTexture: (destination, data, layout, size) => {
+        this.queue.textureWrites.push({
+          destination,
+          byteLength: data.byteLength ?? data.length ?? 0,
+          layout,
+          size,
+        });
       },
     };
   }
@@ -298,6 +308,7 @@ function createFakeWavefrontNavigator(device = new FakeWavefrontDevice(), adapte
       async requestAdapter() {
         return {
           limits: adapterOptions.limits,
+          info: adapterOptions.info,
           async requestDevice(descriptor) {
             adapterOptions.onRequestDevice?.(descriptor);
             return device;
@@ -357,7 +368,8 @@ test("wavefront compute config keeps 4K queues tile-bounded", () => {
   assert.equal(rendererWavefrontComputeStatsStride, 8);
   assert.equal(config.memory.queueBytes, 128 * 128 * wavefrontPathTracingComputeLimits.rayRecordBytes);
   assert.equal(config.memory.hitBytes, 128 * 128 * wavefrontPathTracingComputeLimits.hitRecordBytes);
-  assert.equal(config.memory.configBytes, 272);
+  assert.equal(config.memory.pathVertexBytes, 128 * 128 * 9 * wavefrontPathTracingComputeLimits.pathVertexRecordBytes);
+  assert.equal(config.memory.configBytes, 304);
   assert.equal(config.memory.counterBytes, wavefrontPathTracingComputeLimits.counterRecordBytes);
   assert.equal(
     config.memory.indirectDispatchBytes,
@@ -610,6 +622,11 @@ test("wavefront compute guides and gates environment lighting through portals", 
   assert.match(source, /ENVIRONMENT_PORTAL_RECORD_BYTES = 96/);
   assert.match(source, /environmentPortalRecordBytes/);
   assert.match(source, /@group\(0\) @binding\(19\) var<storage, read> environmentPortals/);
+  assert.match(source, /@group\(0\) @binding\(20\) var environmentMapTexture: texture_2d<f32>/);
+  assert.match(source, /@group\(0\) @binding\(21\) var environmentMapSampler: sampler/);
+  assert.match(source, /@group\(0\) @binding\(22\) var<storage, read_write> pathVertices/);
+  assert.match(source, /fn environment_map_radiance/);
+  assert.match(source, /textureSampleLevel\(environmentMapTexture, environmentMapSampler, uv, 0\.0\)/);
   assert.match(source, /fn environment_portal_radiance_scale/);
   assert.match(source, /fn gated_environment_radiance/);
   assert.match(source, /fn sample_environment_portal_direction/);
@@ -619,9 +636,19 @@ test("wavefront compute guides and gates environment lighting through portals", 
 test("wavefront compute applies environment ambient on terminal surface collisions", () => {
   const source = readRendererSource();
 
+  assert.match(source, /fn terminal_surface_environment_source/);
   assert.match(source, /fn terminal_surface_environment_contribution/);
+  assert.match(source, /fn surface_path_response/);
+  assert.match(source, /fn sunlit_baseline_radiance/);
+  assert.match(source, /let baseline = max\(config\.pathResolveSettings\.y, 0\.0\);/);
   assert.match(source, /let surfaceColor = max\(hit\.color\.xyz, config\.ambientColor\.xyz\);/);
-  assert.match(source, /let environmentFloor = max\(config\.ambientColor\.xyz, normalEnvironment \* 0\.12\);/);
+  assert.match(source, /let sunlitFloor = sunlit_baseline_radiance\(normal\);/);
+  assert.match(source, /max\(config\.ambientColor\.xyz, sunlitFloor \* 0\.82\)/);
+  assert.match(source, /max\(config\.ambientColor\.xyz \* 0\.35, sunlitFloor \* 0\.58\)/);
+  assert.match(source, /max\(0\.12, config\.pathResolveSettings\.y \* 0\.42\)/);
+  assert.match(source, /let environmentFloor = max\(ambientFloor, max\(sunlitFloor, normalEnvironment \* environmentInfluence\)\);/);
+  assert.match(source, /record_deferred_path_response\(ray, response\);/);
+  assert.match(source, /record_deferred_terminal_source\(ray, terminal_surface_environment_source\(hit\)\);/);
   assert.match(
     source,
     /let terminalEnvironment = terminal_surface_environment_contribution\(ray, hit\);/
@@ -642,12 +669,14 @@ test("wavefront compute estimates direct environment light before random continu
   assert.match(source, /fn surface_direct_environment_contribution/);
   assert.match(source, /fn direct_environment_portal_irradiance/);
   assert.match(source, /let surfaceColor = clamp\(max\(hit\.color\.xyz, config\.ambientColor\.xyz \* 0\.35\)/);
-  assert.match(source, /let skyIrradiance = max\(config\.ambientColor\.xyz \* 0\.72, normalEnvironment \* skyVisibility \* 0\.16\);/);
+  assert.match(source, /sunlitFloor \* select\(0\.72, 0\.45, environment_map_enabled\(\)\)/);
+  assert.match(source, /max\(0\.16, config\.pathResolveSettings\.y \* 0\.45\)/);
+  assert.match(source, /let skyIrradiance = max\(ambientIrradiance, normalEnvironment \* skyVisibility \* environmentIrradianceScale\);/);
   assert.match(source, /let sunIrradiance = sunRadiance \* sunFacing \* 0\.2;/);
   assert.match(source, /let portalIrradiance = direct_environment_portal_irradiance\(origin, normal\);/);
   assert.match(
     source,
-    /let shouldEstimateDirectEnvironment =\s+\(hit\.materialKind == 0u \|\| hit\.materialKind == 1u\) && hit\.material\.z >= 0\.95;/
+    /let shouldEstimateDirectEnvironment =\s+!deferred_path_resolve_enabled\(\) &&\s+\(hit\.materialKind == 0u \|\| hit\.materialKind == 1u\) &&\s+hit\.material\.z >= 0\.95;/
   );
   assert.match(
     source,
@@ -665,6 +694,29 @@ test("wavefront compute estimates direct environment light before random continu
     source.indexOf("let directEnvironment = surface_direct_environment_contribution(ray, hit);") <
       source.indexOf("if (ray.bounce + 1u >= config.maxDepth)")
   );
+});
+
+test("wavefront compute defers visible colour until terminal path resolve", () => {
+  const source = readRendererSource();
+  const config = createWavefrontPathTracingComputeConfig({
+    width: 64,
+    height: 64,
+    deferredPathResolve: false,
+  });
+
+  assert.equal(createWavefrontPathTracingComputeConfig({ width: 64, height: 64 }).deferredPathResolve, true);
+  assert.equal(config.deferredPathResolve, false);
+  assert.match(source, /fn deferred_path_resolve_enabled\(\) -> bool/);
+  assert.match(source, /fn clear_deferred_path\(rayId: u32\)/);
+  assert.match(source, /record_deferred_terminal_source\(ray, sourceRadiance\);/);
+  assert.match(source, /record_deferred_terminal_source\(ray, hit\.color\.xyz\);/);
+  assert.match(source, /fn resolve_deferred_path_radiance\(rayId: u32\) -> vec3<f32>/);
+  assert.match(source, /let terminal = pathVertices\[path_vertex_index\(rayId, config\.maxDepth\)\];/);
+  assert.match(source, /depth = depth - 1u;/);
+  assert.match(source, /radiance = radiance \* response\.xyz;/);
+  assert.match(source, /let resolved = resolve_deferred_path_radiance\(index\) \* sample_weight\(\);/);
+  assert.match(source, /if \(config\.deferredPathResolve\) \{/);
+  assert.match(source, /encodeTileOutput\(reserveEncoder\(\), tile, configOffset, parallelism\);/);
 });
 
 test("analytic wavefront renderer rejects display-quality requests", () => {
@@ -1023,6 +1075,7 @@ test("wavefront compute config accepts lighting-owned environment payloads", () 
       intensity: 1.25,
       mode: 2,
       exposure: 0.9,
+      sunlitBaseline: 0.37,
     },
   });
 
@@ -1033,6 +1086,7 @@ test("wavefront compute config accepts lighting-owned environment payloads", () 
   assert.equal(config.environmentLighting.intensity, 1.25);
   assert.equal(config.environmentLighting.mode, 2);
   assert.equal(config.environmentLighting.exposure, 0.9);
+  assert.equal(config.environmentLighting.sunlitBaseline, 0.37);
 });
 
 test("wavefront compute config normalizes environment portal apertures", () => {
@@ -1249,7 +1303,7 @@ test("wavefront compute renderer rejects unavailable WebGPU setup paths", async 
         width: 8,
         height: 8,
       }),
-      /requires maxStorageBuffersPerShaderStage>=9/
+      /requires maxStorageBuffersPerShaderStage>=10/
     );
   });
 });
@@ -1262,7 +1316,20 @@ test("wavefront compute renderer drives GPU-only mesh BVH passes", async () => {
     const renderer = await createWavefrontPathTracingComputeRenderer({
       canvas,
       navigator: createFakeWavefrontNavigator(device, {
-        limits: { maxStorageBuffersPerShaderStage: 10 },
+        limits: {
+          maxComputeInvocationsPerWorkgroup: 256,
+          maxComputeWorkgroupSizeX: 256,
+          maxComputeWorkgroupSizeY: 256,
+          maxComputeWorkgroupSizeZ: 64,
+          maxComputeWorkgroupsPerDimension: 65_535,
+          maxStorageBuffersPerShaderStage: 10,
+        },
+        info: {
+          vendor: "plasius-test-vendor",
+          architecture: "test-architecture",
+          device: "test-device",
+          description: "fake WebGPU adapter",
+        },
         onRequestDevice(descriptor) {
           requestedDeviceDescriptor = descriptor;
         },
@@ -1274,6 +1341,17 @@ test("wavefront compute renderer drives GPU-only mesh BVH passes", async () => {
       samplesPerPixel: 2,
       denoise: true,
       displayQuality: true,
+      environmentMap: {
+        width: 2,
+        height: 1,
+        data: new Float32Array([
+          1.2, 0.8, 0.4, 1,
+          0.2, 0.5, 1.6, 1,
+        ]),
+        intensity: 1.7,
+        rotationRadians: 0.25,
+        ambientStrength: 0.44,
+      },
       meshes: [
         {
           id: 77,
@@ -1307,7 +1385,7 @@ test("wavefront compute renderer drives GPU-only mesh BVH passes", async () => {
     assert.equal(canvas.context.configured.format, "bgra8unorm");
     assert.equal(
       requestedDeviceDescriptor.requiredLimits.maxStorageBuffersPerShaderStage,
-      9
+      10
     );
     assert.equal(frame.frame, 1);
     assert.equal(frame.displayQuality, true);
@@ -1315,7 +1393,28 @@ test("wavefront compute renderer drives GPU-only mesh BVH passes", async () => {
     assert.equal(frame.accelerationBuildSubmitted, true);
     assert.equal(frame.accelerationBuilt, true);
     assert.equal(frame.accelerationBuildCount, 1);
+    assert.equal(frame.environmentMap.enabled, true);
+    assert.equal(frame.environmentMap.width, 2);
+    assert.equal(frame.environmentMap.height, 1);
+    assert.equal(frame.environmentMap.projection, "equirectangular");
+    assert.equal(frame.environmentMap.intensity, 1.7);
+    assert.equal(frame.environmentMap.rotationRadians, 0.25);
+    assert.equal(frame.environmentMap.ambientStrength, 0.44);
     assert.equal(frame.commandSubmissions, 2);
+    assert.equal(frame.gpuParallelism.physicalCoreCount, null);
+    assert.equal(frame.gpuParallelism.physicalCoreCountAvailable, false);
+    assert.equal(frame.gpuParallelism.coreUtilizationStatus, "not-exposed-by-webgpu");
+    assert.equal(frame.gpuParallelism.adapterInfo.vendor, "plasius-test-vendor");
+    assert.equal(frame.gpuParallelism.adapterLimits.maxComputeInvocationsPerWorkgroup, 256);
+    assert.equal(frame.gpuParallelism.adapterLimits.maxComputeWorkgroupsPerDimension, 65_535);
+    assert.equal(frame.gpuParallelism.adapterLimits.maxStorageBuffersPerShaderStage, 10);
+    assert.equal(frame.gpuParallelism.configuredWorkgroupSize, 64);
+    assert.ok(frame.gpuParallelism.directDispatches > 0);
+    assert.ok(frame.gpuParallelism.directWorkgroups > 0);
+    assert.ok(frame.gpuParallelism.directShaderInvocations > 0);
+    assert.ok(frame.gpuParallelism.indirectDispatches > 0);
+    assert.ok(frame.gpuParallelism.totalEstimatedWorkgroupsUpperBound >= frame.gpuParallelism.directWorkgroups);
+    assert.equal(frame.gpuParallelism.exposesMultiWorkgroupParallelism, false);
     assert.equal(secondFrame.frame, 2);
     assert.equal(secondFrame.accelerationBuildSubmitted, false);
     assert.equal(secondFrame.accelerationBuilt, true);
@@ -1333,7 +1432,8 @@ test("wavefront compute renderer drives GPU-only mesh BVH passes", async () => {
     });
     assert.equal(frame.primaryRays, 128);
     assert.equal(frame.tiles, 1);
-    assert.equal(frame.frameConfigSlots, 4);
+    assert.equal(frame.deferredPathResolve, true);
+    assert.equal(frame.frameConfigSlots, 3);
     assert.equal(probe.x, 2);
     assert.equal(probe.y, 3);
     assert.deepEqual(probe.rgba, [32, 64, 128, 255]);
@@ -1343,9 +1443,14 @@ test("wavefront compute renderer drives GPU-only mesh BVH passes", async () => {
     assert.equal(nextConfig.displayQuality, true);
     assert.equal(snapshot.frame, 3);
     assert.equal(snapshot.triangleCount, 1);
+    assert.equal(snapshot.environmentMap.enabled, true);
+    assert.equal(snapshot.environmentMap.width, 2);
     assert.equal(snapshot.accelerationBuilt, true);
     assert.equal(snapshot.accelerationBuildCount, 1);
-    assert.equal(snapshot.frameConfigSlots, 4);
+    assert.equal(snapshot.deferredPathResolve, true);
+    assert.equal(snapshot.frameConfigSlots, 3);
+    assert.equal(snapshot.gpuParallelism.physicalCoreCountAvailable, false);
+    assert.equal(snapshot.gpuParallelism.indirectDispatches, compatibilityFrame.gpuParallelism.indirectDispatches);
     assert.ok(device.pipelineLabels.includes("plasius.wavefront.prepareMeshTrianglesAndLeaves"));
     assert.ok(device.pipelineLabels.includes("plasius.wavefront.generatePrimaryRays"));
     assert.ok(device.pipelineLabels.includes("plasius.wavefront.denoiseLinearRadiance"));
@@ -1365,6 +1470,10 @@ test("wavefront compute renderer drives GPU-only mesh BVH passes", async () => {
     assert.ok(device.renderPasses >= 1);
     assert.equal(device.drawCalls.includes(3), true);
     assert.ok(device.queue.submissions.length >= 1);
+    assert.equal(device.queue.textureWrites.length, 1);
+    assert.equal(device.queue.textureWrites[0].size.width, 2);
+    assert.equal(device.queue.textureWrites[0].size.height, 1);
+    assert.equal(device.queue.textureWrites[0].layout.bytesPerRow, 256);
     const submittedLabels = device.queue.submissions.flat().map((submission) => submission.encoderLabel);
     assert.equal(submittedLabels.filter((label) => label.includes("buildAcceleration")).length, 1);
     assert.equal(submittedLabels.filter((label) => label.includes(".batched")).length, 3);
@@ -1399,9 +1508,17 @@ test("wavefront compute renderer splits large frames into bounded command submis
 
     assert.equal(frame.tiles, 16);
     assert.equal(frame.maxFramePassesPerSubmission, 5);
-    assert.equal(frame.commandSubmissions, 10);
-    assert.equal(frame.frameConfigSlots, 49);
-    assert.equal(device.queue.submissions.length, 10);
+    assert.equal(frame.commandSubmissions, 14);
+    assert.equal(frame.frameConfigSlots, 33);
+    assert.equal(frame.gpuParallelism.physicalCoreCountAvailable, false);
+    assert.equal(frame.gpuParallelism.exposesMultiWorkgroupParallelism, true);
+    assert.equal(frame.gpuParallelism.largestDirectWorkgroupsPerDispatch, 4096);
+    assert.equal(frame.gpuParallelism.largestEstimatedIndirectWorkgroupsPerDispatch, 256);
+    assert.equal(frame.gpuParallelism.indirectDispatchesWithMultiWorkgroupCapacity, frame.gpuParallelism.indirectDispatches);
+    assert.ok(frame.gpuParallelism.multiWorkgroupDispatches > 0);
+    assert.ok(frame.gpuParallelism.directWorkgroups > 1);
+    assert.ok(frame.gpuParallelism.totalEstimatedShaderInvocationsUpperBound > frame.gpuParallelism.directShaderInvocations);
+    assert.equal(device.queue.submissions.length, 14);
     assert.equal(submittedLabels.every((label) => label.includes(".batched.")), true);
 
     renderer.destroy();
@@ -1441,5 +1558,5 @@ test("default wavefront scene includes emissive termination geometry", () => {
     sceneObjectCapacity: 128,
   });
   assert.ok(estimate.queueBytes < 134_217_728);
-  assert.ok(estimate.totalHotBufferBytes < 32_000_000);
+  assert.ok(estimate.totalHotBufferBytes < 40_000_000);
 });


### PR DESCRIPTION
## Summary
- add deferred terminal path resolve for wavefront path tracing
- add HDRI/environment map sampling and GPU parallelism diagnostics
- consume environmentLighting.sunlitBaseline as a time-of-day daylight floor for terminal/direct environment estimates

## Local validation
- npm run typecheck
- npm run build
- npm run lint
- npm run test:unit -- tests/wavefront-compute.test.js
- npm run test:coverage
- npm run audit:npm
- git diff --check

## Visual validation
- Captured Eames grass-field-midday mesh at 1280x720, 1 spp, denoise on, deferred on.