### PR TITLE
[codex] Refine wavefront adaptive sampling and lighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,9 @@ All notable changes to this project will be documented in this file.
     renderer-specific ladder construction in app or demo code.
 
 - **Changed**
+  - Changed internal wavefront frame batching and dispatch-diagnostics plumbing
+    to live in a dedicated runtime helper module so scheduling concerns stay
+    separated from shader and pipeline assembly.
   - Changed wavefront frame dispatch to split large tile/sample workloads into
     bounded command submissions instead of encoding an entire high-resolution
     frame into one command buffer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ All notable changes to this project will be documented in this file.
 - **Added**
   - Added `updateCamera(...)` support for wavefront renderers so validation
     views can animate camera movement without rebuilding mesh buffers.
+  - Added `gpuWorkerJobs` diagnostics to wavefront frame stats so callers can
+    inspect completed compute-dispatch jobs per frame, per second, and per
+    command submission alongside the existing GPU parallelism figures.
   - Added `gpuParallelism` diagnostics to wavefront frame stats and snapshots so
     consumers can inspect adapter compute limits, direct workgroups,
     indirect-dispatch estimates, and whether a frame exposes multi-workgroup GPU
@@ -24,17 +27,69 @@ All notable changes to this project will be documented in this file.
   - Added default-on `deferredPathResolve` support for wavefront tracing so
     surface traversal records material responses and terminal source radiance
     before the output pass resolves the path backward into pixel accumulation.
+  - Added design and ADR coverage for shadow-tested direct light and bounded
+    bounce attenuation in deferred wavefront path resolution.
+  - Added display-quality material-response support for sheen, clearcoat, and
+    decoded base-colour, metallic-roughness, normal, and occlusion maps in the
+    wavefront mesh path.
+  - Added GPU hit-time material atlas sampling for display-quality wavefront
+    tracing so exact hit UVs now drive base-colour, metallic-roughness, normal,
+    occlusion, and emissive texture evaluation on the GPU instead of relying on
+    CPU-baked triangle averages.
+  - Added ADR and design coverage for generic glTF material transport so
+    specular colour, sheen colour, transmission, clearcoat, and IOR can travel
+    through the shared wavefront shading path instead of being inferred from
+    demo-specific material names.
+  - Added ADR and design coverage for environment-driven glossy surface
+    response so specular, sheen, and clearcoat shading can use reflection-
+    aligned environment radiance instead of leaning primarily on a sun-only
+    highlight proxy.
+  - Added ADR and design coverage for prefiltered HDRI, BRDF LUT, and MIS-based
+    environment lighting in the wavefront display-quality path.
+  - Added adaptive `renderFrame(...)` sampling controls so callers can cap a
+    frame with `frameTimeBudgetMs`, guarantee a `minimumSamplesPerPixel`, and
+    inspect actual `renderedSamplesPerPixel` separately from the configured SPP
+    ceiling.
+  - Added `createWavefrontAdaptiveSamplingLevels(...)` so consumers can hand
+    wavefront SPP adaptation to `@plasius/gpu-performance` without duplicating
+    renderer-specific ladder construction in app or demo code.
 
 - **Changed**
   - Changed wavefront frame dispatch to split large tile/sample workloads into
     bounded command submissions instead of encoding an entire high-resolution
     frame into one command buffer.
-  - Changed display-quality wavefront tracing to require one additional
-    path-vertex storage buffer, raising the trace-stage storage-buffer request
-    from 9 to 10.
+  - Changed display-quality wavefront tracing to pack HDRI importance-sampling
+    PDFs and CDFs into one GPU texture so the MIS path stays compatible with
+    adapters that expose only the existing 10 trace-stage storage buffers.
   - Changed wavefront terminal/direct environment estimates to consume
     `environmentLighting.sunlitBaseline` as a time-of-day daylight floor instead
     of relying only on restrained ambient colour.
+  - Changed deferred wavefront surface resolution to allow explicit
+    shadow-tested direct lighting before terminal continuation resolution and to
+    remap extremely dark bounce responses to a small scene-brightness floor.
+  - Changed wavefront denoise to adapt its kernel strength to SPP and to skip
+    the intermediate full-screen scratch pass for 4+ SPP frames, reducing blur
+    and denoise cost on cleaner renders.
+  - Changed async wavefront frame rendering to wait for submitted GPU work and
+    to batch higher-SPP workloads more defensibly, while raising the SPP ceiling
+    from 64 to 256 for higher-end GPUs.
+  - Changed awaited high-SPP wavefront rendering to fence submitted GPU work
+    once per `renderFrame(...)` call instead of after every intermediate command
+    submission.
+  - Changed wavefront scene, mesh, triangle, material, and hit records to carry
+    generic glTF-style specular colour, sheen colour, and transmission inputs
+    in addition to the existing roughness, metallic, clearcoat, and IOR data.
+  - Changed direct and terminal wavefront surface environment shading to sample
+    reflection-aligned environment radiance for glossy materials before adding
+    narrower sun highlights, improving leather, chrome, and polished-surface
+    response without model-specific rules.
+  - Changed wavefront environment-lighting setup to prepare roughness-aware HDRI
+    resources, a BRDF integration LUT, and HDRI importance-sampling tables for
+    display-quality renders.
+  - Changed wavefront continuation sampling to emit BSDF PDFs for diffuse,
+    conductor, clearcoat, and transmission paths so environment misses and
+    explicit HDRI samples can use MIS instead of the older light-guidance
+    heuristics.
 
 - **Fixed**
   - Fixed low-sample wavefront renders so non-emissive surface hits receive a
@@ -42,6 +97,12 @@ All notable changes to this project will be documented in this file.
   - Reduced deterministic environment fill on direct surface hits so ambient
     rescue lighting no longer washes dark materials toward the full scene
     ambient colour.
+  - Fixed wavefront output-probe readback so higher-SPP validation renders wait
+    for submitted GPU work before mapping the staging buffer, avoiding
+    `GPUBuffer.mapAsync(...)` lifetime failures during probe capture.
+  - Fixed display-quality environment misses so non-delta BSDF paths now apply
+    MIS weighting against the HDRI direction PDF instead of overcounting raw
+    sky radiance on termination.
 
 - **Security**
   - (placeholder)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,27 @@ All notable changes to this project will be documented in this file.
 - **Added**
   - Added `updateCamera(...)` support for wavefront renderers so validation
     views can animate camera movement without rebuilding mesh buffers.
+  - Added `gpuParallelism` diagnostics to wavefront frame stats and snapshots so
+    consumers can inspect adapter compute limits, direct workgroups,
+    indirect-dispatch estimates, and whether a frame exposes multi-workgroup GPU
+    parallelism.
+  - Added optional equirectangular `environmentMap` sampling for wavefront
+    tracing so environment misses and surface environment estimates can use a
+    bound radiance texture before falling back to procedural sky/ambient values.
+  - Added default-on `deferredPathResolve` support for wavefront tracing so
+    surface traversal records material responses and terminal source radiance
+    before the output pass resolves the path backward into pixel accumulation.
 
 - **Changed**
   - Changed wavefront frame dispatch to split large tile/sample workloads into
     bounded command submissions instead of encoding an entire high-resolution
     frame into one command buffer.
+  - Changed display-quality wavefront tracing to require one additional
+    path-vertex storage buffer, raising the trace-stage storage-buffer request
+    from 9 to 10.
+  - Changed wavefront terminal/direct environment estimates to consume
+    `environmentLighting.sunlitBaseline` as a time-of-day daylight floor instead
+    of relying only on restrained ambient colour.
 
 - **Fixed**
   - Fixed low-sample wavefront renders so non-emissive surface hits receive a

--- a/README.md
+++ b/README.md
@@ -168,7 +168,8 @@ debugRenderer.renderOnce();
 ```
 
 Scene objects currently support analytic `sphere` and axis-aligned `box`
-records with colour, emission, roughness, metallic, opacity, and IOR fields.
+records with colour, emission, roughness, metallic, opacity, IOR, clearcoat,
+sheen colour, specular colour, and transmission fields.
 These records are debug fixtures only. Product Studio visual rendering requires
 the mesh BVH path described in
 `docs/adrs/adr-0007-triangle-mesh-wavefront-path-tracing.md`. This is a
@@ -185,6 +186,18 @@ fixtures and deterministic layout tests. GPU BVH construction now uses
 Morton-style centroid keys to sort leaf references before sorted leaves and
 level-concurrent internal nodes are materialized. The current mesh path is the
 GPU runtime baseline under active hardening.
+When mesh inputs also carry UVs plus decoded base-colour,
+metallic-roughness, normal, occlusion, or emissive maps, the display-quality
+path now packs them into GPU texture atlases and samples them at the resolved
+hit UV inside the wavefront trace pass. Generic glTF-style material factors
+such as clearcoat, sheen colour, specular colour, transmission, and IOR are
+also preserved through the GPU records so demo validation does not need
+model-name overrides. CPU-side texture work is limited to load-time decode and
+atlas packing; per-hit shading stays on the GPU. Direct and terminal glossy
+response now also samples reflection-aligned environment radiance so leather,
+chrome, and other polished authored materials can read from the active
+environment map or procedural sky instead of relying mostly on a sun-direction
+proxy.
 
 `samplesPerPixel` controls how many GPU primary-ray samples are accumulated per
 screen pixel within a single render. This multiplies dispatch work but does not
@@ -207,9 +220,12 @@ better material PDFs are hardened. By default, `deferredPathResolve` records
 per-bounce material responses in a tile-bounded path buffer and records the
 terminal emissive/HDRI/environment source in the final path slot. The output
 pass then resolves that recorded path backward and adds the weighted sample to
-the pixel accumulation, so surface traversal no longer injects broad visible
-ambient/direct environment light before a terminal source is known. Set
-`deferredPathResolve: false` only for legacy forward-accumulation comparison.
+the pixel accumulation, so unresolved continuation light is still deferred until
+a terminal source is known. Surface resolution may still add a small
+shadow-tested direct-light term immediately when it has an explicit source and
+visibility result, which keeps true occlusion shadows possible without falling
+back to broad per-bounce ambient fill. Set `deferredPathResolve: false` only
+for legacy forward-accumulation comparison.
 When an `environmentMap` is provided, the wavefront trace shader samples it as
 an equirectangular radiance source for environment misses and uses the same
 mapped radiance for terminal residuals before falling back to static ambient.
@@ -217,14 +233,28 @@ The procedural horizon/zenith/sun model remains the fallback for callers that
 have not supplied an HDRI/radiance texture. `environmentLighting.sunlitBaseline`
 adds a time-of-day daylight floor to terminal and direct environment estimates,
 so bright presets retain colour at the last collision without returning to a
-whitewashed global ambient term.
+whitewashed global ambient term. Extremely dark recorded bounce responses are
+also remapped to a small scene-brightness-driven luminance floor so bright
+low-sample scenes do not produce isolated black speckles when a valid terminal
+source was already found.
 For static mesh scenes, the GPU acceleration build is submitted once and then
 reused by subsequent frames. Per-frame tracing writes one dynamic uniform slot
 per tile/sample or post-process pass and batches tile tracing, tile output,
 optional denoise, and presentation into bounded command submissions controlled
 by `maxFramePassesPerSubmission` to keep 4K/high-spp command buffers from
 becoming oversized. `updateCamera(...)` can update the per-frame camera uniforms
-between renders without rebuilding mesh buffers. Frame stats and snapshots expose
+without rebuilding scene buffers. `renderFrame(...)` also accepts an optional
+`frameTimeBudgetMs` plus `minimumSamplesPerPixel`: when present, configured
+`samplesPerPixel` becomes a ceiling instead of a hard requirement, the renderer
+guarantees at least the minimum full-screen pass, and frame stats report both
+configured `samplesPerPixel` and actual `renderedSamplesPerPixel` so realtime
+callers can budget motion frames without overstating delivered quality.
+For consumers that want to hand wavefront SPP adaptation to
+`@plasius/gpu-performance`, `createWavefrontAdaptiveSamplingLevels(...)` exposes
+a bounded low-to-high ladder of per-frame `samplesPerPixel`,
+`frameTimeBudgetMs`, and `minimumSamplesPerPixel` configs that stay aligned
+with the renderer's supported adaptive-sampling surface. Frame stats and
+snapshots expose
 `gpuParallelism` diagnostics with adapter compute limits, configured workgroup
 size, direct compute dispatches, known workgroups/invocations, indirect dispatch
 counts, and upper-bound indirect work estimates. WebGPU does not expose physical

--- a/README.md
+++ b/README.md
@@ -113,7 +113,10 @@ debug validation scenes. It is compute-driven, tiled, and breadth-first by
 bounce depth, so queue buffers are bounded by tile size instead of presentation
 resolution. Renderer-owned GPU record sizes are part of the public compute
 limits so ray, hit, triangle, BVH, and accumulation buffers stay aligned with
-their WGSL layouts.
+their WGSL layouts. Frame submission batching and dispatch diagnostics are kept
+in dedicated runtime helpers so performance-facing integrations can consume
+stable frame stats without inheriting the renderer's shader and pipeline
+assembly internals.
 
 ```js
 import {

--- a/README.md
+++ b/README.md
@@ -196,21 +196,42 @@ tone mapping into the presented `rgba8unorm` output. Filtering in linear
 radiance space lets the denoise pass cross tile boundaries without compressing
 energy/detail before the final resolve. The renderer also stores compact
 emissive-triangle metadata in the existing BVH buffer tail and uses it to guide
-diffuse continuation rays toward finite mesh light geometry without adding a
-ninth trace storage buffer. This is not a separate shadow/direct-light pass: the
-active ray still has to hit emissive geometry or miss into the environment
-before radiance is accumulated. Guided emissive hits carry a bounded estimator
-weight so finite light guidance does not over-expose low-sample renders before
-full material PDFs/MIS are implemented. High-energy samples are clamped in
-linear radiance space to keep low-sample preview output stable while production
-sampling, temporal accumulation, and better material PDFs are hardened.
+diffuse continuation rays toward finite mesh light geometry. This is not a
+separate shadow/direct-light pass: the active ray still has to hit emissive
+geometry or miss into the environment before radiance is committed. Guided
+emissive hits carry a bounded estimator weight so finite light guidance does not
+over-expose low-sample renders before full material PDFs/MIS are implemented.
+High-energy samples are clamped in linear radiance space to keep low-sample
+preview output stable while production sampling, temporal accumulation, and
+better material PDFs are hardened. By default, `deferredPathResolve` records
+per-bounce material responses in a tile-bounded path buffer and records the
+terminal emissive/HDRI/environment source in the final path slot. The output
+pass then resolves that recorded path backward and adds the weighted sample to
+the pixel accumulation, so surface traversal no longer injects broad visible
+ambient/direct environment light before a terminal source is known. Set
+`deferredPathResolve: false` only for legacy forward-accumulation comparison.
+When an `environmentMap` is provided, the wavefront trace shader samples it as
+an equirectangular radiance source for environment misses and uses the same
+mapped radiance for terminal residuals before falling back to static ambient.
+The procedural horizon/zenith/sun model remains the fallback for callers that
+have not supplied an HDRI/radiance texture. `environmentLighting.sunlitBaseline`
+adds a time-of-day daylight floor to terminal and direct environment estimates,
+so bright presets retain colour at the last collision without returning to a
+whitewashed global ambient term.
 For static mesh scenes, the GPU acceleration build is submitted once and then
 reused by subsequent frames. Per-frame tracing writes one dynamic uniform slot
 per tile/sample or post-process pass and batches tile tracing, tile output,
 optional denoise, and presentation into bounded command submissions controlled
 by `maxFramePassesPerSubmission` to keep 4K/high-spp command buffers from
 becoming oversized. `updateCamera(...)` can update the per-frame camera uniforms
-between renders without rebuilding mesh buffers. After each
+between renders without rebuilding mesh buffers. Frame stats and snapshots expose
+`gpuParallelism` diagnostics with adapter compute limits, configured workgroup
+size, direct compute dispatches, known workgroups/invocations, indirect dispatch
+counts, and upper-bound indirect work estimates. WebGPU does not expose physical
+GPU core counts, so `physicalCoreCount` remains `null`; use
+`exposesMultiWorkgroupParallelism`, `largestDirectWorkgroupsPerDispatch`, and
+`largestEstimatedIndirectWorkgroupsPerDispatch` to confirm the renderer is
+submitting work that can occupy more than one GPU execution unit. After each
 primary-ray or compaction pass, the GPU writes the active-ray workgroup count
 into the counter buffer and the encoder copies it into an indirect-dispatch
 argument buffer. Intersection and surface-resolution passes therefore scale

--- a/docs/adrs/adr-0008-deferred-terminal-path-resolve.md
+++ b/docs/adrs/adr-0008-deferred-terminal-path-resolve.md
@@ -74,4 +74,6 @@ result.
 The implementation does not yet include texture-material sampling, material
 lookup tables, medium entry/exit distance tracking, Beer-Lambert absorption,
 Russian roulette, PDF-correct throughput, MIS, or spectral prism dispersion.
-Those are follow-up renderer material-system features.
+Those are follow-up renderer material-system features. Shadow-tested direct
+lighting and bounded attenuation were added later under ADR 0009 without
+changing the core terminal-source model.

--- a/docs/adrs/adr-0008-deferred-terminal-path-resolve.md
+++ b/docs/adrs/adr-0008-deferred-terminal-path-resolve.md
@@ -1,0 +1,77 @@
+# ADR 0008: Deferred Terminal Path Resolve For Wavefront Path Tracing
+
+## Status
+
+Accepted
+
+## Context
+
+The first wavefront path tracer accumulated some visible radiance while a path
+was still traversing the scene. Surface resolution could add broad direct
+environment estimates, terminal ambient floors could multiply material colour
+immediately, and continuation rays carried an already-tinted throughput. That
+made low-sample renders brighter and more stable, but it also made lighting
+levels difficult to reason about because sun, HDRI, ambient residual, and
+material response were mixed before the path had reached a real terminal light
+source.
+
+The renderer needs a path model where a camera sample first reaches an
+emissive surface, an HDRI/environment miss, or an explicit residual termination
+before visible colour is committed. This gives better control over exposure and
+ambient residuals, and it makes path diagnostics easier because every sample has
+a clear terminal source and a bounded list of material responses.
+
+## Decision
+
+`@plasius/gpu-renderer` will support deferred terminal path resolution for the
+wavefront path tracer. In deferred mode the trace pass:
+
+- records one compact material response per ray bounce;
+- records the terminal source radiance in the final path slot when the path hits
+  emissive geometry, misses into the HDRI/environment, reaches max depth, or
+  overflows the active queue;
+- uses the lighting-owned `sunlitBaseline` scalar as a time-of-day terminal
+  daylight floor instead of raising the global ambient colour;
+- avoids adding direct environment or ambient contribution to the visible
+  accumulation buffer during surface traversal;
+- resolves the path in the terminal pass by walking recorded responses from the
+  last bounce back to the first camera hit and then adding the weighted sample
+  to the pixel accumulation.
+
+The first implementation remains a single stochastic continuation path per
+sample. Reflective or refractive materials do not branch into separate reflected
+and transmitted paths yet.
+
+## Consequences
+
+- Display-quality lighting becomes less dependent on fake per-bounce brightening
+  and more dependent on the terminal emissive/HDRI source discovered by the
+  active path.
+- Low-sample images can become darker when paths fail to find strong light
+  sources. Bright time-of-day presets still retain a bounded terminal daylight
+  floor through `environmentLighting.sunlitBaseline`; further noise and light
+  reach issues should be addressed with better light/HDRI sampling, PDFs, MIS,
+  and denoising rather than by restoring broad ambient floors.
+- The trace stage requires one additional storage buffer for path vertices. The
+  renderer therefore requests `maxStorageBuffersPerShaderStage >= 10`.
+- The path response record intentionally stores the current approximate material
+  response, not a final physical BSDF. Future material-table, texture, medium,
+  Beer-Lambert absorption, Fresnel PDF, and spectral-dispersion work should
+  replace the response calculation without changing the terminal-source model.
+- A legacy forward accumulation switch remains available for before/after
+  comparison and regression isolation.
+
+## Current Implementation Boundary
+
+Deferred resolution stores path data in a tile-bounded `pathVertices` buffer
+with `(maxDepth + 1)` `vec4<f32>` slots per tile pixel. Slots `0..maxDepth-1`
+store per-bounce RGB response and a validity flag. Slot `maxDepth` stores the
+terminal source RGB and validity flag. The output pass resolves the current
+sample immediately after its bounce loop so the next sample can clear and reuse
+the same path slots while the pixel accumulation buffer preserves the weighted
+result.
+
+The implementation does not yet include texture-material sampling, material
+lookup tables, medium entry/exit distance tracking, Beer-Lambert absorption,
+Russian roulette, PDF-correct throughput, MIS, or spectral prism dispersion.
+Those are follow-up renderer material-system features.

--- a/docs/adrs/adr-0009-shadowed-direct-light-for-deferred-wavefront-resolve.md
+++ b/docs/adrs/adr-0009-shadowed-direct-light-for-deferred-wavefront-resolve.md
@@ -1,0 +1,44 @@
+# ADR 0009: Shadowed Direct Light And Bounded Attenuation For Deferred Wavefront Resolve
+
+## Status
+
+Accepted
+
+## Context
+
+ADR 0008 established deferred terminal path resolution so the renderer no
+longer committed continuation radiance before a path reached a known terminal
+source. That improved exposure control, but deferred mode still had no
+shadow-tested direct-light estimate during surface resolution, and its recorded
+per-bounce response could numerically collapse a valid terminal source into
+isolated black pixels.
+
+Debug captures showed a non-black terminal source with black pixels appearing
+only after several reverse response multiplications. The failure was therefore
+not an absent environment source; it was a combination of missing explicit
+direct-light visibility and overly aggressive multiplicative attenuation.
+
+## Decision
+
+`@plasius/gpu-renderer` will extend deferred wavefront resolution with two
+stabilizers:
+
+- surface resolution may add an explicit shadow-tested direct environment term
+  before terminal path resolution completes;
+- recorded per-bounce response is remapped to a small, scene-brightness-driven
+  luminance floor so lit paths do not numerically die into isolated black
+  pixels.
+
+This direct-light term is allowed in deferred mode because it is already tied to
+an identified source and an explicit visibility check. Unresolved continuation
+radiance still remains deferred until the path reaches its terminal source.
+
+## Consequences
+
+- Occlusion shadows remain possible and become more believable because direct
+  light is now visibility-tested instead of inferred from broad ambient fill.
+- Bright scenes become more stable at low spp because explicit direct lighting
+  and bounded attenuation reduce speckled black failures.
+- The estimator remains biased. It is still a pragmatic preview-oriented
+  wavefront integrator pending fuller MIS/PDF-correct direct lighting, material
+  tables, and medium transport.

--- a/docs/adrs/adr-0010-gpu-hit-material-texture-sampling.md
+++ b/docs/adrs/adr-0010-gpu-hit-material-texture-sampling.md
@@ -1,0 +1,54 @@
+# ADR 0010: GPU Hit-Time Material Texture Sampling For Wavefront Path Tracing
+
+## Status
+
+Accepted
+
+## Context
+
+The display-quality wavefront renderer already resolved exact triangle UVs on
+the GPU, but it still shaded mesh hits from CPU-baked triangle averages for
+base color, metallic-roughness, and normal-map influence. That mismatch caused
+three problems:
+
+- shading could not use the exact texel at the final hit UV;
+- normal-map detail and material variation were smeared across each triangle;
+- CPU-side texture sampling remained part of the active render path even though
+  the renderer already had the information needed to shade on the GPU.
+
+For higher-quality reflective and textured assets, especially the Eames chair
+validation scene, this was a hard realism ceiling.
+
+## Decision
+
+`@plasius/gpu-renderer` will evaluate mesh material textures on the GPU at
+hit-time for the display-quality wavefront path tracer.
+
+The renderer now:
+
+- builds GPU-uploaded atlases for base-color, metallic-roughness, normal,
+  occlusion, and emissive textures during scene/config preparation;
+- writes one compact GPU material record per submitted mesh;
+- carries a dense `materialSlot` through mesh ranges, triangle records, and hit
+  records;
+- samples the material atlases in `intersectActiveQueue` using the resolved hit
+  UV before the hit record is written;
+- stores the sampled base color, material factors, emissive term, occlusion,
+  and exact normal-mapped shading normal in the hit record for later lighting
+  passes.
+
+CPU-side texture decoding and atlas packing remain load-time preparation only.
+They are not part of per-frame or per-hit shading.
+
+## Consequences
+
+- Display-quality shading now uses the exact hit texel instead of a
+  triangle-averaged CPU approximation.
+- Normal maps, roughness variation, AO, and emissive maps can influence the
+  actual GPU shading path.
+- The renderer consumes one additional storage buffer and several sampled
+  textures in the trace bind group, so its required storage-buffer count rises
+  to `11`.
+- The current implementation still uses pragmatic atlas packing rather than a
+  streaming virtual texture system. It is correct for this validation workload,
+  but very large scenes will eventually need a more explicit residency model.

--- a/docs/adrs/adr-0011-generic-gltf-material-transport.md
+++ b/docs/adrs/adr-0011-generic-gltf-material-transport.md
@@ -1,0 +1,55 @@
+# ADR 0011: Generic glTF Material Transport For Wavefront Shading
+
+## Status
+
+Accepted
+
+## Context
+
+The Eames validation scene had drifted toward demo-specific material overrides.
+The loader and validation page inferred chrome, leather, and wood behaviour from
+material names, then injected tuned roughness, sheen, clearcoat, and colour
+values before the renderer saw the asset.
+
+That approach created two problems:
+
+- improvements were specific to one asset instead of generic renderer
+  capability;
+- the shared wavefront renderer could not faithfully consume authored glTF
+  material inputs such as specular colour, transmission, sheen colour, and IOR.
+
+For product-quality validation, material response must come from the asset and
+the renderer's generic shading model rather than from demo naming conventions.
+
+## Decision
+
+`@plasius/gpu-renderer` will carry generic glTF-style material inputs through
+its wavefront path instead of relying on demo-local surface overrides.
+
+The renderer now transports and shades the following per-surface inputs:
+
+- base colour and opacity
+- roughness and metallic
+- IOR
+- clearcoat and clearcoat roughness
+- sheen colour
+- specular weight and specular colour
+- transmission
+
+The GPU record layout for scene objects, mesh ranges, triangle records, GPU
+material records, and hit records is expanded so these values remain available
+inside GPU shading and scattering.
+
+The Eames validation integration must pass authored material values through
+without material-name heuristics.
+
+## Consequences
+
+- Demo-specific material overrides are no longer the primary source of leather,
+  chrome, or wood response in validation renders.
+- Shared wavefront shading can now use generic material inputs that map more
+  directly to glTF PBR and selected `KHR_materials_*` extensions.
+- Buffer layouts become larger, so all record-byte constants and buffer packing
+  code must remain aligned with the WGSL structs.
+- This is still not a complete glTF BSDF implementation. Extension textures,
+  MIS, and prefiltered HDRI reflection remain follow-on work.

--- a/docs/adrs/adr-0012-environment-specular-response-for-wavefront-shading.md
+++ b/docs/adrs/adr-0012-environment-specular-response-for-wavefront-shading.md
@@ -1,0 +1,46 @@
+# ADR 0012: Environment Specular Response For Wavefront Shading
+
+## Status
+
+Accepted
+
+## Context
+
+The wavefront renderer already supports environment maps, portal-gated sky
+lighting, GPU hit-time texture sampling, and generic glTF material transport.
+That made diffuse environment response materially better, but reflective and
+semi-reflective surfaces still relied too heavily on a narrow sun-direction
+heuristic during direct-light resolution.
+
+In practice this meant:
+
+- leather sheen did not pick up the room or HDRI convincingly;
+- chrome and polished wood read flatter than their authored material inputs;
+- environment maps influenced misses and ambient floors more than glossy
+  surface response, which is the opposite of what physically-based shading
+  needs.
+
+## Decision
+
+`@plasius/gpu-renderer` will evaluate a generic environment-driven glossy term
+for direct and terminal surface response in the display-quality wavefront path.
+
+The renderer now:
+
+- derives reflection-aligned environment sample directions from the hit normal,
+  incoming ray, and roughness rather than treating the sun direction as the
+  primary glossy light source;
+- uses visibility-tested environment radiance for specular, sheen, and
+  clearcoat response before adding any narrower sun highlight term;
+- blends the terminal environment fallback toward reflection-aligned response
+  for glossy materials so the last collision retains plausible environment
+  colour instead of collapsing toward a mostly diffuse ambient estimate.
+
+## Consequences
+
+- Glossy materials respond to the actual environment map or procedural sky more
+  consistently.
+- The shading path remains generic across glTF-authored materials instead of
+  relying on model-specific overrides.
+- This is still an approximation, not a full split-sum IBL or MIS pipeline.
+  Prefiltered environment maps and full BSDF PDFs remain follow-on work.

--- a/docs/adrs/adr-0013-hdri-brdf-lut-and-mis-for-wavefront-environment-lighting.md
+++ b/docs/adrs/adr-0013-hdri-brdf-lut-and-mis-for-wavefront-environment-lighting.md
@@ -1,0 +1,42 @@
+# ADR 0013: HDRI Prefilter, BRDF LUT, And MIS For Wavefront Environment Lighting
+
+## Status
+
+Accepted
+
+## Context
+
+The wavefront renderer already transports generic glTF material data and can
+sample exact texture hits on the GPU, but its environment-lighting path still
+leans on heuristic glossy response and non-MIS continuation.
+
+That leaves three hard realism gaps:
+
+- reflective and semi-reflective materials do not consume the HDRI with the
+  same fidelity expected from a modern PBR pipeline;
+- specular response lacks a proper BRDF integration term;
+- environment contribution is not balanced against BSDF continuation with a
+  multiple-importance heuristic.
+
+## Decision
+
+`@plasius/gpu-renderer` will adopt a fuller environment-lighting pipeline for
+the display-quality wavefront renderer:
+
+- prefiltered HDRI mip levels for roughness-aware specular environment lookup;
+- a BRDF integration LUT for split-sum specular environment response;
+- environment importance-sampling tables for explicit HDRI light samples;
+- MIS weighting between explicit HDRI samples and BSDF-sampled continuation
+  rays that terminate against the environment.
+
+## Consequences
+
+- First-bounce and terminal glossy response align more closely with established
+  physically-based HDRI workflows.
+- Continuation rays that miss to the environment are less biased toward either
+  brute-force BSDF sampling or explicit light sampling.
+- Renderer setup becomes heavier because environment resources now include
+  prefiltered mip data, a BRDF LUT, and HDRI sampling tables in addition to the
+  base environment texture.
+- This remains compatible with the current equirectangular HDRI input model;
+  cubemap conversion is not required for this step.

--- a/docs/adrs/index.md
+++ b/docs/adrs/index.md
@@ -7,3 +7,4 @@
 - [ADR 0005: Ray-Tracing-First Hybrid Render Graph](./adr-0005-ray-tracing-first-hybrid-render-graph.md)
 - [ADR 0006: WebGPU Wavefront Compute Path Tracing](./adr-0006-webgpu-wavefront-compute-path-tracing.md)
 - [ADR 0007: Mesh BVH Wavefront Path Tracing As Display Quality Baseline](./adr-0007-triangle-mesh-wavefront-path-tracing.md)
+- [ADR 0008: Deferred Terminal Path Resolve For Wavefront Path Tracing](./adr-0008-deferred-terminal-path-resolve.md)

--- a/docs/adrs/index.md
+++ b/docs/adrs/index.md
@@ -8,3 +8,8 @@
 - [ADR 0006: WebGPU Wavefront Compute Path Tracing](./adr-0006-webgpu-wavefront-compute-path-tracing.md)
 - [ADR 0007: Mesh BVH Wavefront Path Tracing As Display Quality Baseline](./adr-0007-triangle-mesh-wavefront-path-tracing.md)
 - [ADR 0008: Deferred Terminal Path Resolve For Wavefront Path Tracing](./adr-0008-deferred-terminal-path-resolve.md)
+- [ADR 0009: Shadowed Direct Light And Bounded Attenuation For Deferred Wavefront Resolve](./adr-0009-shadowed-direct-light-for-deferred-wavefront-resolve.md)
+- [ADR 0010: GPU Hit-Time Material Texture Sampling For Wavefront Path Tracing](./adr-0010-gpu-hit-material-texture-sampling.md)
+- [ADR 0011: Generic glTF Material Transport For Wavefront Shading](./adr-0011-generic-gltf-material-transport.md)
+- [ADR 0012: Environment Specular Response For Wavefront Shading](./adr-0012-environment-specular-response-for-wavefront-shading.md)
+- [ADR 0013: HDRI Prefilter, BRDF LUT, And MIS For Wavefront Environment Lighting](./adr-0013-hdri-brdf-lut-and-mis-for-wavefront-environment-lighting.md)

--- a/docs/design/environment-specular-response.md
+++ b/docs/design/environment-specular-response.md
@@ -1,0 +1,42 @@
+# Environment Specular Response
+
+## Problem
+
+The renderer had enough material data to distinguish diffuse, metallic,
+clearcoat, sheen, and transmission surfaces, but it still evaluated most
+glossy response from a sun-direction proxy. That was acceptable for preview
+contrast, but it limited realism because authored materials could not reflect
+the actual HDRI or procedural environment strongly enough.
+
+## Decision
+
+Add a generic environment-reflection shading step inside the wavefront WGSL
+surface-resolution path.
+
+## Approach
+
+1. Derive a reflection direction from the incoming ray and shading normal.
+2. Blend that direction back toward the normal as roughness increases so broad
+   surfaces do not use a razor-sharp reflection sample.
+3. Visibility-test the chosen direction against scene geometry.
+4. Use that environment radiance for:
+   - glossy/specular response,
+   - sheen response,
+   - clearcoat response,
+   - terminal environment fallback at the last resolved collision.
+5. Keep the narrower sun highlight as a secondary term instead of the main
+   glossy light source.
+
+## Non-Goals
+
+- prefiltered specular environment mip chains;
+- BRDF integration LUTs;
+- full multiple-importance sampling across BSDF and environment PDFs.
+
+## Validation
+
+- `npm test`
+- `npm run typecheck`
+- `npm run build`
+- screenshot validation remains a follow-on runtime check once local WebGPU
+  capture is available again on this machine.

--- a/docs/design/generic-gltf-material-transport.md
+++ b/docs/design/generic-gltf-material-transport.md
@@ -1,0 +1,26 @@
+# Generic glTF Material Transport
+
+## Goal
+
+Remove Eames-specific surface overrides and make the renderer consume authored
+material inputs generically.
+
+## Scope
+
+- parse and forward generic glTF material factors from the validation loader;
+- preserve those values through `buildEamesMeshes(...)`;
+- extend wavefront GPU records so shading can read specular colour, sheen
+  colour, clearcoat, transmission, and IOR;
+- use those values in direct lighting and scatter selection.
+
+## Explicit Non-Goals
+
+- full glTF extension-texture support for every `KHR_materials_*` feature;
+- a complete microfacet/MIS rewrite in this change;
+- HDRI prefilter/LUT integration in this change.
+
+## Validation
+
+- unit tests for generic material forwarding and packed GPU records;
+- package typecheck/build/test;
+- follow-on screenshot validation after the shader path is stable again.

--- a/docs/design/hdri-brdf-lut-mis-environment-lighting.md
+++ b/docs/design/hdri-brdf-lut-mis-environment-lighting.md
@@ -1,0 +1,38 @@
+# HDRI, BRDF LUT, And MIS Environment Lighting
+
+## Goal
+
+Replace the remaining heuristic environment-lighting path with a fuller PBR
+environment workflow for the display-quality wavefront renderer.
+
+## Scope
+
+- roughness-aware prefiltered HDRI sampling;
+- BRDF integration LUT support;
+- explicit HDRI light sampling tables;
+- MIS weighting between HDRI light samples and BSDF continuation misses.
+
+## Approach
+
+1. Precompute a mipmapped roughness-aware HDRI resource from the authored
+   equirectangular environment map.
+2. Precompute a BRDF LUT for split-sum environment response.
+3. Build HDRI sampling tables from luminance-weighted texel probabilities.
+4. Update the WGSL trace path so:
+   - glossy direct/terminal response uses prefiltered HDRI plus BRDF LUT;
+   - explicit HDRI direct-light samples are weighted against BSDF PDFs;
+   - BSDF-sampled environment misses use the complementary MIS weight.
+
+## Non-Goals
+
+- cubemap-only environment workflows;
+- temporal reuse or reservoir sampling;
+- replacing emissive-triangle guidance in this change.
+
+## Validation
+
+- renderer unit tests for resource creation and shader-source integration;
+- `npm run typecheck`
+- `npm test`
+- `npm run build`
+- screenshot validation once local WebGPU capture is available again.

--- a/docs/design/wavefront-shadowed-direct-light-stability.md
+++ b/docs/design/wavefront-shadowed-direct-light-stability.md
@@ -1,0 +1,86 @@
+# Wavefront Shadowed Direct Light Stability
+
+## Context
+
+The deferred terminal path resolve model improved exposure control by waiting
+until a path reached emissive geometry, an HDRI/environment miss, or a terminal
+environment residual before committing the continuation radiance to the visible
+pixel. That removed broad fake ambient fill, but it also exposed a new failure
+mode in low-sample scenes: a path could have a non-black terminal source while
+several recorded per-bounce response terms still drove the visible result toward
+isolated black pixels.
+
+Local Eames-chair debug captures confirmed the issue. Terminal-source-only
+frames remained lit, while exact black pixels first appeared only after several
+reverse response multiplications. That points to two concrete gaps:
+
+- deferred mode has no explicit shadow-tested direct-light estimate before the
+  continuation path reaches a terminal source;
+- the current multiplicative response chain is too aggressive for dark or
+  saturated low-sample paths.
+
+## Goals
+
+- Preserve real occlusion shadows: lit surfaces should become dark because a
+  source is blocked, not because a continuation path numerically died.
+- Keep brightness source-driven: sun, HDRI sky, portals, and emissive geometry
+  should dominate the visible estimate.
+- Prevent isolated black speckles on otherwise lit surfaces in bright scenes.
+
+## Non-Goals
+
+- This is not a physically complete MIS/PDF-correct direct-lighting system.
+- This does not add material tables, texture lookups, spectral transport, or
+  full medium absorption.
+- This does not restore broad per-bounce ambient injection.
+
+## Proposal
+
+### 1. Add shadow-tested direct environment lighting during surface resolution
+
+Deferred mode should still allow an additive direct-light estimate when the
+source and its visibility are known immediately.
+
+For diffuse and rough metallic surfaces, surface resolution should:
+
+- evaluate direct sky/sun/HDRI contribution using explicit visibility tests;
+- evaluate environment-light portals with the same occlusion check;
+- add that direct term to pixel accumulation even when continuation radiance is
+  still deferred.
+
+This keeps deferred terminal resolution for unresolved continuation light while
+allowing real shadows to appear from source visibility.
+
+### 2. Bound the per-bounce material response floor
+
+The current recorded response is multiplied backward without any protection
+against low-sample collapse. Instead of adding ambient at every bounce, the
+renderer should remap extremely dark responses upward to a small,
+environment-derived luminance floor.
+
+Requirements:
+
+- preserve hue/chroma as much as possible;
+- keep the floor low enough that true occlusion shadows remain dark;
+- allow deeper bounces to decay more than early bounces.
+
+The floor should derive from scene brightness inputs already owned by the
+renderer, primarily `environmentLighting.sunlitBaseline` and the environment-map
+ambient strength.
+
+## Expected Outcome
+
+- Sunlit or bright-HDRI scenes retain colour and brightness on first-bounce
+  surfaces even at 1-2 spp.
+- Dark regions stay dark when the direct sample is blocked and the terminal
+  environment residual is low.
+- Isolated black speckles become rare because lit paths no longer depend only on
+  a terminal source multiplied through an unrestricted response chain.
+
+## Validation
+
+- Source-level renderer tests should assert the presence of visibility-tested
+  direct lighting and bounded response remapping.
+- Eames-chair validation should show that terminal-source frames are already
+  lit, while later reverse-pass frames no longer introduce large pockets of
+  exact black pixels in bright presets.

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "build": "tsup",
     "demo": "python3 -m http.server --directory ..",
-    "typecheck": "node --check src/index.js && node --check src/wavefront-compute.js",
+    "typecheck": "node --check src/index.js && node --check src/wavefront-frame-runtime.js && node --check src/wavefront-compute.js",
     "audit:eslint": "eslint . --max-warnings=0",
     "audit:deps": "npm ls --all --omit=optional --omit=peer > /dev/null 2>&1 || true",
     "audit:npm": "npm audit --audit-level=high --omit=dev",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -13,6 +13,35 @@ export type WavefrontMaterialKind =
   | "light"
   | number;
 
+export interface WavefrontAdaptiveSamplingLevelConfig {
+  readonly samplesPerPixel: number;
+  readonly frameTimeBudgetMs: number;
+  readonly minimumSamplesPerPixel: number;
+}
+
+export interface WavefrontAdaptiveSamplingLevel {
+  readonly id: string;
+  readonly label: string;
+  readonly estimatedCostMs: number;
+  readonly config: WavefrontAdaptiveSamplingLevelConfig;
+}
+
+export interface CreateWavefrontAdaptiveSamplingLevelsResult {
+  readonly requestedSamplesPerPixel: number;
+  readonly minimumSamplesPerPixel: number;
+  readonly frameTimeBudgetMs: number;
+  readonly levels: readonly WavefrontAdaptiveSamplingLevel[];
+}
+
+export interface WavefrontTextureSampleInput {
+  readonly texCoord?: number;
+  readonly scale?: number;
+  readonly strength?: number;
+  readonly width: number;
+  readonly height: number;
+  readonly data: Uint8ClampedArray | Uint8Array | readonly number[];
+}
+
 export interface WavefrontCameraOptions {
   readonly position?: readonly [number, number, number] | readonly number[];
   readonly target?: readonly [number, number, number] | readonly number[];
@@ -20,6 +49,12 @@ export interface WavefrontCameraOptions {
   readonly fovYDegrees?: number;
   readonly fov?: number;
 }
+
+export function createWavefrontAdaptiveSamplingLevels(options?: {
+  readonly samplesPerPixel?: number;
+  readonly frameTimeBudgetMs?: number;
+  readonly minimumSamplesPerPixel?: number;
+}): CreateWavefrontAdaptiveSamplingLevelsResult;
 
 export interface WavefrontSceneObjectInput {
   readonly id?: number;
@@ -48,6 +83,14 @@ export interface WavefrontSceneObjectInput {
   readonly metallic?: number;
   readonly opacity?: number;
   readonly ior?: number;
+  readonly sheen?: number;
+  readonly sheenTint?: number;
+  readonly sheenColor?: RendererColor | readonly number[];
+  readonly clearcoat?: number;
+  readonly clearcoatRoughness?: number;
+  readonly specular?: number;
+  readonly specularColor?: RendererColor | readonly number[];
+  readonly transmission?: number;
   readonly material?: {
     readonly kind?: WavefrontMaterialKind;
     readonly color?: RendererColor | readonly number[];
@@ -58,6 +101,14 @@ export interface WavefrontSceneObjectInput {
     readonly metallic?: number;
     readonly opacity?: number;
     readonly ior?: number;
+    readonly sheen?: number;
+    readonly sheenTint?: number;
+    readonly sheenColor?: RendererColor | readonly number[];
+    readonly clearcoat?: number;
+    readonly clearcoatRoughness?: number;
+    readonly specular?: number;
+    readonly specularColor?: RendererColor | readonly number[];
+    readonly transmission?: number;
   };
 }
 
@@ -74,6 +125,14 @@ export interface WavefrontSceneObject {
   readonly metallic: number;
   readonly opacity: number;
   readonly ior: number;
+  readonly sheen: number;
+  readonly sheenTint: number;
+  readonly sheenColor: readonly [number, number, number, number] | readonly number[];
+  readonly clearcoat: number;
+  readonly clearcoatRoughness: number;
+  readonly specular: number;
+  readonly specularColor: readonly [number, number, number, number] | readonly number[];
+  readonly transmission: number;
 }
 
 export interface WavefrontMeshInput {
@@ -99,6 +158,14 @@ export interface WavefrontMeshInput {
   readonly metallic?: number;
   readonly opacity?: number;
   readonly ior?: number;
+  readonly sheen?: number;
+  readonly sheenTint?: number;
+  readonly sheenColor?: RendererColor | readonly number[];
+  readonly clearcoat?: number;
+  readonly clearcoatRoughness?: number;
+  readonly specular?: number;
+  readonly specularColor?: RendererColor | readonly number[];
+  readonly transmission?: number;
   readonly material?: {
     readonly kind?: WavefrontMaterialKind;
     readonly color?: RendererColor | readonly number[];
@@ -109,8 +176,26 @@ export interface WavefrontMeshInput {
     readonly metallic?: number;
     readonly opacity?: number;
     readonly ior?: number;
+    readonly sheen?: number;
+    readonly sheenTint?: number;
+    readonly sheenColor?: RendererColor | readonly number[];
+    readonly clearcoat?: number;
+    readonly clearcoatRoughness?: number;
+    readonly specular?: number;
+    readonly specularColor?: RendererColor | readonly number[];
+    readonly transmission?: number;
     readonly id?: number;
+    readonly baseColorTexture?: WavefrontTextureSampleInput | null;
+    readonly metallicRoughnessTexture?: WavefrontTextureSampleInput | null;
+    readonly normalTexture?: WavefrontTextureSampleInput | null;
+    readonly occlusionTexture?: WavefrontTextureSampleInput | null;
+    readonly emissiveTexture?: WavefrontTextureSampleInput | null;
   };
+  readonly baseColorTexture?: WavefrontTextureSampleInput | null;
+  readonly metallicRoughnessTexture?: WavefrontTextureSampleInput | null;
+  readonly normalTexture?: WavefrontTextureSampleInput | null;
+  readonly occlusionTexture?: WavefrontTextureSampleInput | null;
+  readonly emissiveTexture?: WavefrontTextureSampleInput | null;
   readonly medium?: {
     readonly id?: number;
   };
@@ -123,6 +208,7 @@ export interface WavefrontTriangleRecord {
   readonly flags: number;
   readonly materialRefId: number;
   readonly mediumRefId: number;
+  readonly materialSlot?: number;
   readonly v0: readonly number[];
   readonly v1: readonly number[];
   readonly v2: readonly number[];
@@ -135,6 +221,15 @@ export interface WavefrontTriangleRecord {
   readonly color: readonly number[];
   readonly emission: readonly number[];
   readonly material: readonly number[];
+  readonly materialResponse: readonly number[];
+  readonly materialExtension?: readonly number[];
+  readonly specularColor?: readonly number[];
+  readonly baseColorAtlas?: readonly number[];
+  readonly metallicRoughnessAtlas?: readonly number[];
+  readonly normalAtlas?: readonly number[];
+  readonly occlusionAtlas?: readonly number[];
+  readonly emissiveAtlas?: readonly number[];
+  readonly textureSettings?: readonly number[];
   readonly bounds: Readonly<{ min: readonly number[]; max: readonly number[] }>;
   readonly centroid: readonly number[];
 }
@@ -214,6 +309,7 @@ export interface WavefrontReferenceHit {
   readonly color: readonly number[];
   readonly emission: readonly number[];
   readonly material: readonly number[];
+  readonly materialResponse: readonly number[];
 }
 
 export interface IntersectWavefrontReferenceTriangleOptions {
@@ -256,12 +352,43 @@ export interface WavefrontGpuMeshSource {
       readonly metallic: number;
       readonly opacity: number;
       readonly ior: number;
+      readonly sheen: number;
+      readonly sheenTint: number;
+      readonly sheenColor: readonly [number, number, number, number] | readonly number[];
+      readonly clearcoat: number;
+      readonly clearcoatRoughness: number;
+      readonly specular: number;
+      readonly specularColor: readonly [number, number, number, number] | readonly number[];
+      readonly transmission: number;
+      readonly baseColorTexture: WavefrontTextureSampleInput | null;
+      readonly metallicRoughnessTexture: WavefrontTextureSampleInput | null;
+      readonly normalTexture: WavefrontTextureSampleInput | null;
+      readonly occlusionTexture: WavefrontTextureSampleInput | null;
+      readonly emissiveTexture: WavefrontTextureSampleInput | null;
     }>[];
     readonly count: number;
     readonly recordBytes: number;
   }>;
   readonly triangleCount: number;
   readonly bvhNodeCapacity: number;
+}
+
+export interface WavefrontGpuTextureAtlasSource {
+  readonly width: number;
+  readonly height: number;
+  readonly data: Uint8Array;
+  readonly defaultRect: readonly [number, number, number, number] | readonly number[];
+}
+
+export interface WavefrontGpuMaterialSource {
+  readonly buffer: ArrayBuffer;
+  readonly count: number;
+  readonly recordBytes: number;
+  readonly baseColorAtlas: WavefrontGpuTextureAtlasSource;
+  readonly metallicRoughnessAtlas: WavefrontGpuTextureAtlasSource;
+  readonly normalAtlas: WavefrontGpuTextureAtlasSource;
+  readonly occlusionAtlas: WavefrontGpuTextureAtlasSource;
+  readonly emissiveAtlas: WavefrontGpuTextureAtlasSource;
 }
 
 export interface WavefrontEmissiveTriangleIndexSource {
@@ -350,6 +477,7 @@ export interface WavefrontPathTracingComputeConfig {
   readonly accelerationBuildMode: WavefrontAccelerationBuildMode;
   readonly gpuAccelerationBuildRequired: boolean;
   readonly gpuMeshSource: WavefrontGpuMeshSource;
+  readonly gpuMaterialSource: WavefrontGpuMaterialSource;
   readonly meshAcceleration: WavefrontMeshAcceleration;
   readonly emissiveTriangleIndices: WavefrontEmissiveTriangleIndexSource;
   readonly emissiveTriangleCount: number;
@@ -424,6 +552,7 @@ export interface WavefrontPathTracingMemoryEstimate {
   readonly pathVertexBytes: number;
   readonly sceneObjectBytes: number;
   readonly triangleBytes: number;
+  readonly materialTableBytes: number;
   readonly bvhNodeBytes: number;
   readonly bvhLeafReferenceBytes: number;
   readonly emissiveTriangleMetadataBytes: number;
@@ -525,6 +654,11 @@ export interface WavefrontPathTracingComputeRenderer {
   renderFrame(options?: {
     readStats?: boolean;
     readOutputProbe?: boolean;
+    awaitGPUCompletion?: boolean;
+    submittedWorkTimeoutMs?: number;
+    samplesPerPixel?: number;
+    minimumSamplesPerPixel?: number;
+    frameTimeBudgetMs?: number;
     probe?: { x?: number; y?: number };
   }): Promise<WavefrontPathTracingComputeFrameStats>;
   readOutputProbe(options?: { x?: number; y?: number }): Promise<
@@ -574,6 +708,9 @@ export interface WavefrontPathTracingComputeFrameStats {
   readonly tiles: number;
   readonly tileSize: number;
   readonly samplesPerPixel: number;
+  readonly renderedSamplesPerPixel: number;
+  readonly frameTimeBudgetMs: number | null;
+  readonly budgetConstrained: boolean;
   readonly maxFramePassesPerSubmission: number;
   readonly screenRays: number;
   readonly primaryRays: number;
@@ -592,6 +729,15 @@ export interface WavefrontPathTracingComputeFrameStats {
   readonly accelerationBuilt: boolean;
   readonly accelerationBuildCount: number;
   readonly commandSubmissions: number;
+  readonly gpuWorkerJobs: Readonly<{
+    completedPerFrame: number;
+    completedPerSecond: number | null;
+    completedPerSubmission: number;
+    directDispatchesCompleted: number;
+    indirectDispatchesCompleted: number;
+    frameTimeMs: number;
+    awaitedGpuCompletion: boolean;
+  }>;
   readonly frameConfigSlots: number;
   readonly gpuParallelism: WavefrontGpuParallelismDiagnostics;
   readonly memory: WavefrontPathTracingMemoryEstimate;
@@ -618,6 +764,9 @@ export function normalizeWavefrontSceneObject(
   input?: WavefrontSceneObjectInput,
   index?: number
 ): WavefrontSceneObject;
+export function createWavefrontGpuMaterialSource(
+  meshes?: readonly WavefrontMeshInput[] | WavefrontMeshInput
+): WavefrontGpuMaterialSource;
 export function createDefaultWavefrontSceneObjects(): readonly WavefrontSceneObject[];
 export function estimateWavefrontPathTracingMemory(options?: {
   tilePixelCapacity?: number;
@@ -646,12 +795,25 @@ export function normalizeWavefrontMesh(
   metallic: number;
   opacity: number;
   ior: number;
+  sheen: number;
+  sheenTint: number;
+  sheenColor: readonly [number, number, number, number] | readonly number[];
+  clearcoat: number;
+  clearcoatRoughness: number;
+  specular: number;
+  specularColor: readonly [number, number, number, number] | readonly number[];
+  transmission: number;
+  baseColorTexture: WavefrontTextureSampleInput | null;
+  metallicRoughnessTexture: WavefrontTextureSampleInput | null;
+  normalTexture: WavefrontTextureSampleInput | null;
+  occlusionTexture: WavefrontTextureSampleInput | null;
 }>;
 export function createWavefrontMeshAcceleration(
   meshes?: readonly WavefrontMeshInput[] | WavefrontMeshInput
 ): WavefrontMeshAcceleration;
 export function createWavefrontGpuMeshSource(
-  meshes?: readonly WavefrontMeshInput[] | WavefrontMeshInput
+  meshes?: readonly WavefrontMeshInput[] | WavefrontMeshInput,
+  gpuMaterialSource?: WavefrontGpuMaterialSource | null
 ): WavefrontGpuMeshSource;
 export function createWavefrontEmissiveTriangleIndexSource(
   meshes?: readonly WavefrontMeshInput[] | WavefrontMeshInput,
@@ -731,12 +893,14 @@ export const rendererWavefrontComputeStatsStride: 8;
 
 export const wavefrontPathTracingComputeLimits: Readonly<{
   workgroupSize: 64;
+  traceStorageBufferBindings: number;
   rayRecordBytes: 80;
-  hitRecordBytes: 208;
-  sceneObjectRecordBytes: 96;
+  hitRecordBytes: 224;
+  sceneObjectRecordBytes: 112;
   meshVertexRecordBytes: 48;
-  meshRangeRecordBytes: 96;
-  triangleRecordBytes: 208;
+  meshRangeRecordBytes: 208;
+  triangleRecordBytes: 320;
+  materialRecordBytes: 160;
   bvhNodeRecordBytes: 48;
   bvhLeafReferenceRecordBytes: 16;
   emissiveTriangleIndexBytes: 4;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -308,6 +308,33 @@ export interface WavefrontEnvironmentPortalRecord {
   readonly color: readonly [number, number, number, number] | readonly number[];
 }
 
+export interface WavefrontEnvironmentMapInput {
+  readonly enabled?: boolean;
+  readonly width?: number;
+  readonly height?: number;
+  readonly projection?: "equirectangular" | string;
+  readonly format?: GPUTextureFormat | "rgba16float";
+  readonly texture?: GPUTexture;
+  readonly view?: GPUTextureView;
+  readonly sampler?: GPUSampler;
+  readonly data?: readonly number[] | Float32Array | Uint16Array | Uint8Array;
+  readonly intensity?: number;
+  readonly radianceScale?: number;
+  readonly rotationRadians?: number;
+  readonly rotation?: number;
+  readonly ambientStrength?: number;
+}
+
+export interface WavefrontEnvironmentMapSnapshot {
+  readonly enabled: boolean;
+  readonly width: number;
+  readonly height: number;
+  readonly projection: string;
+  readonly intensity: number;
+  readonly rotationRadians: number;
+  readonly ambientStrength: number;
+}
+
 export interface WavefrontPathTracingComputeConfig {
   readonly mode: typeof rendererWavefrontComputeMode;
   readonly width: number;
@@ -331,6 +358,8 @@ export interface WavefrontPathTracingComputeConfig {
   readonly environmentPortalCount: number;
   readonly environmentPortalCapacity: number;
   readonly environmentPortalMode: 0 | 1 | 2;
+  readonly environmentMap: WavefrontEnvironmentMapInput;
+  readonly deferredPathResolve: boolean;
   readonly triangleCount: number;
   readonly triangleCapacity: number;
   readonly bvhNodeCount: number;
@@ -367,8 +396,11 @@ export interface WavefrontEnvironmentLightingInput {
   readonly intensity?: number;
   readonly mode?: number;
   readonly exposure?: number;
+  readonly sunlitBaseline?: number;
+  readonly daylightBaseline?: number;
   readonly environmentPortals?: readonly WavefrontEnvironmentPortalInput[];
   readonly environmentPortalMode?: WavefrontEnvironmentPortalMode;
+  readonly environmentMap?: WavefrontEnvironmentMapInput;
 }
 
 export interface WavefrontEnvironmentLightingConfig {
@@ -381,6 +413,7 @@ export interface WavefrontEnvironmentLightingConfig {
   readonly intensity: number;
   readonly mode: number;
   readonly exposure: number;
+  readonly sunlitBaseline: number;
 }
 
 export interface WavefrontPathTracingMemoryEstimate {
@@ -388,6 +421,7 @@ export interface WavefrontPathTracingMemoryEstimate {
   readonly queuePairBytes: number;
   readonly hitBytes: number;
   readonly accumulationBytes: number;
+  readonly pathVertexBytes: number;
   readonly sceneObjectBytes: number;
   readonly triangleBytes: number;
   readonly bvhNodeBytes: number;
@@ -398,6 +432,43 @@ export interface WavefrontPathTracingMemoryEstimate {
   readonly counterBytes: number;
   readonly indirectDispatchBytes: number;
   readonly totalHotBufferBytes: number;
+}
+
+export interface WavefrontGpuParallelismDiagnostics {
+  readonly physicalCoreCount: number | null;
+  readonly physicalCoreCountAvailable: boolean;
+  readonly physicalCoreCountUnavailableReason: string;
+  readonly adapterInfo: Readonly<{
+    readonly vendor: string;
+    readonly architecture: string;
+    readonly device: string;
+    readonly description: string;
+  }> | null;
+  readonly adapterLimits: Readonly<{
+    readonly maxComputeInvocationsPerWorkgroup: number | null;
+    readonly maxComputeWorkgroupSizeX: number | null;
+    readonly maxComputeWorkgroupSizeY: number | null;
+    readonly maxComputeWorkgroupSizeZ: number | null;
+    readonly maxComputeWorkgroupsPerDimension: number | null;
+    readonly maxStorageBuffersPerShaderStage: number | null;
+    readonly maxStorageBufferBindingSize: number | null;
+  }>;
+  readonly configuredWorkgroupSize: number;
+  readonly directDispatches: number;
+  readonly directWorkgroups: number;
+  readonly directShaderInvocations: number;
+  readonly multiWorkgroupDispatches: number;
+  readonly largestDirectWorkgroupsPerDispatch: number;
+  readonly indirectDispatches: number;
+  readonly estimatedIndirectWorkgroupsUpperBound: number;
+  readonly estimatedIndirectShaderInvocationsUpperBound: number;
+  readonly indirectDispatchesWithMultiWorkgroupCapacity: number;
+  readonly largestEstimatedIndirectWorkgroupsPerDispatch: number;
+  readonly totalEstimatedWorkgroupsUpperBound: number;
+  readonly totalEstimatedShaderInvocationsUpperBound: number;
+  readonly exposesMultiWorkgroupParallelism: boolean;
+  readonly likelyUsesMoreThanOnePhysicalGpuCore: boolean | null;
+  readonly coreUtilizationStatus: "not-exposed-by-webgpu";
 }
 
 export interface CreateWavefrontPathTracingComputeRendererOptions {
@@ -429,6 +500,11 @@ export interface CreateWavefrontPathTracingComputeRendererOptions {
   readonly environmentLightPortals?: readonly WavefrontEnvironmentPortalInput[];
   readonly environmentPortalMode?: WavefrontEnvironmentPortalMode;
   readonly portalMode?: WavefrontEnvironmentPortalMode;
+  readonly environmentMap?: WavefrontEnvironmentMapInput;
+  readonly environmentTexture?: WavefrontEnvironmentMapInput;
+  readonly deferredPathResolve?: boolean;
+  readonly deferredResolve?: boolean;
+  readonly pathResolve?: { readonly deferred?: boolean };
   readonly accelerationBuildMode?: WavefrontAccelerationBuildMode;
   readonly camera?: WavefrontCameraOptions;
   readonly environmentColor?: readonly [number, number, number, number?] | readonly number[];
@@ -475,6 +551,8 @@ export interface WavefrontPathTracingComputeRenderer {
     emissiveTriangleCount: number;
     environmentPortalCount: number;
     environmentPortalMode: 0 | 1 | 2;
+    environmentMap: WavefrontEnvironmentMapSnapshot;
+    deferredPathResolve: boolean;
     bvhNodeCount: number;
     displayQuality: boolean;
     accelerationBuildMode: WavefrontAccelerationBuildMode;
@@ -482,6 +560,7 @@ export interface WavefrontPathTracingComputeRenderer {
     accelerationBuilt: boolean;
     accelerationBuildCount: number;
     frameConfigSlots: number;
+    gpuParallelism: WavefrontGpuParallelismDiagnostics;
     memory: WavefrontPathTracingMemoryEstimate;
   }>;
   destroy(): void;
@@ -503,6 +582,8 @@ export interface WavefrontPathTracingComputeFrameStats {
   readonly emissiveTriangleCount: number;
   readonly environmentPortalCount: number;
   readonly environmentPortalMode: 0 | 1 | 2;
+  readonly environmentMap: WavefrontEnvironmentMapSnapshot;
+  readonly deferredPathResolve: boolean;
   readonly bvhNodeCount: number;
   readonly displayQuality: boolean;
   readonly accelerationBuildMode: WavefrontAccelerationBuildMode;
@@ -512,6 +593,7 @@ export interface WavefrontPathTracingComputeFrameStats {
   readonly accelerationBuildCount: number;
   readonly commandSubmissions: number;
   readonly frameConfigSlots: number;
+  readonly gpuParallelism: WavefrontGpuParallelismDiagnostics;
   readonly memory: WavefrontPathTracingMemoryEstimate;
   readonly outputProbe?: Readonly<{
     x: number;
@@ -661,6 +743,7 @@ export const wavefrontPathTracingComputeLimits: Readonly<{
   emissiveTriangleMetadataRecordBytes: 48;
   environmentPortalRecordBytes: 96;
   accumulationRecordBytes: 16;
+  pathVertexRecordBytes: 16;
   counterRecordBytes: 32;
   indirectDispatchRecordBytes: 12;
 }>;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -439,6 +439,7 @@ export interface WavefrontEnvironmentMapInput {
   readonly enabled?: boolean;
   readonly width?: number;
   readonly height?: number;
+  readonly mipLevelCount?: number;
   readonly projection?: "equirectangular" | string;
   readonly format?: GPUTextureFormat | "rgba16float";
   readonly texture?: GPUTexture;
@@ -450,16 +451,19 @@ export interface WavefrontEnvironmentMapInput {
   readonly rotationRadians?: number;
   readonly rotation?: number;
   readonly ambientStrength?: number;
+  readonly hasImportanceData?: boolean;
 }
 
 export interface WavefrontEnvironmentMapSnapshot {
   readonly enabled: boolean;
   readonly width: number;
   readonly height: number;
+  readonly mipLevelCount: number;
   readonly projection: string;
   readonly intensity: number;
   readonly rotationRadians: number;
   readonly ambientStrength: number;
+  readonly hasImportanceData: boolean;
 }
 
 export interface WavefrontPathTracingComputeConfig {
@@ -895,12 +899,12 @@ export const wavefrontPathTracingComputeLimits: Readonly<{
   workgroupSize: 64;
   traceStorageBufferBindings: number;
   rayRecordBytes: 80;
-  hitRecordBytes: 224;
-  sceneObjectRecordBytes: 112;
+  hitRecordBytes: 256;
+  sceneObjectRecordBytes: 144;
   meshVertexRecordBytes: 48;
-  meshRangeRecordBytes: 208;
-  triangleRecordBytes: 320;
-  materialRecordBytes: 160;
+  meshRangeRecordBytes: 240;
+  triangleRecordBytes: 352;
+  materialRecordBytes: 192;
   bvhNodeRecordBytes: 48;
   bvhLeafReferenceRecordBytes: 16;
   emissiveTriangleIndexBytes: 4;

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ export {
   createWavefrontBvhBuildLevels,
   createWavefrontBvhSortStages,
   createWavefrontEmissiveTriangleIndexSource,
+  createWavefrontGpuMaterialSource,
   createWavefrontGpuMeshSource,
   createWavefrontMeshAcceleration,
   createWavefrontPathTracingComputeConfig,
@@ -148,6 +149,57 @@ const rendererAccelerationStructurePolicies = Object.freeze(
     })
   )
 );
+
+function clampWavefrontAdaptiveSamplesPerPixel(value) {
+  if (!Number.isFinite(value)) {
+    return 1;
+  }
+  return Math.max(1, Math.min(256, Math.round(value)));
+}
+
+export function createWavefrontAdaptiveSamplingLevels(options = {}) {
+  const requestedSamplesPerPixel = clampWavefrontAdaptiveSamplesPerPixel(
+    options.samplesPerPixel ?? 1
+  );
+  const minimumSamplesPerPixel = Math.min(
+    requestedSamplesPerPixel,
+    clampWavefrontAdaptiveSamplesPerPixel(options.minimumSamplesPerPixel ?? 1)
+  );
+  const frameTimeBudgetMs = Number.isFinite(options.frameTimeBudgetMs)
+    ? Math.max(0, Number(options.frameTimeBudgetMs))
+    : 0;
+  const levels = new Set([minimumSamplesPerPixel, requestedSamplesPerPixel]);
+  let currentSamplesPerPixel = minimumSamplesPerPixel;
+
+  while (currentSamplesPerPixel < requestedSamplesPerPixel) {
+    levels.add(currentSamplesPerPixel);
+    currentSamplesPerPixel *= 2;
+  }
+
+  levels.add(Math.min(currentSamplesPerPixel, requestedSamplesPerPixel));
+
+  return Object.freeze({
+    requestedSamplesPerPixel,
+    minimumSamplesPerPixel,
+    frameTimeBudgetMs,
+    levels: Object.freeze(
+      [...levels]
+        .sort((left, right) => left - right)
+        .map((samplesPerPixel) =>
+          Object.freeze({
+            id: `${samplesPerPixel}spp`,
+            label: `${samplesPerPixel} spp`,
+            estimatedCostMs: samplesPerPixel,
+            config: Object.freeze({
+              samplesPerPixel,
+              frameTimeBudgetMs,
+              minimumSamplesPerPixel,
+            }),
+          })
+        )
+    ),
+  });
+}
 
 function createWavefrontField(name, type, description) {
   return Object.freeze({

--- a/src/wavefront-compute.js
+++ b/src/wavefront-compute.js
@@ -2936,7 +2936,6 @@ function createEnvironmentMapUploadBytes(environmentMap, fallbackColor) {
     width,
     height,
   });
-  BRDF_LUT_UPLOAD_CACHE.set(cacheKey, upload);
   return upload;
 }
 
@@ -6778,7 +6777,6 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
     } finally {
       if (timeoutHandle !== null) {
         clearTimeout(timeoutHandle);
-        timeoutHandle = null;
         settleTimeoutPromise({ status: "cancelled" });
       }
     }

--- a/src/wavefront-compute.js
+++ b/src/wavefront-compute.js
@@ -3,6 +3,8 @@ const DEFAULT_HEIGHT = 720;
 const DEFAULT_MAX_DEPTH = 6;
 const DEFAULT_TILE_SIZE = 128;
 const DEFAULT_SAMPLES_PER_PIXEL = 1;
+const MAX_SAMPLES_PER_PIXEL = 256;
+const DEFAULT_BRDF_LUT_SIZE = 256;
 const DEFAULT_MAX_FRAME_PASSES_PER_SUBMISSION = 256;
 const DEFAULT_SCENE_OBJECT_CAPACITY = 128;
 const DEFAULT_ENVIRONMENT_PORTAL_CAPACITY = 32;
@@ -11,22 +13,27 @@ export const rendererWavefrontComputeMode = "webgpu-compute";
 export const rendererWavefrontComputeWorkgroupSize = WORKGROUP_SIZE;
 export const rendererWavefrontComputeStatsStride = 8;
 const RAY_RECORD_BYTES = 80;
-const HIT_RECORD_BYTES = 208;
-const SCENE_OBJECT_RECORD_BYTES = 96;
+const HIT_RECORD_BYTES = 256;
+const SCENE_OBJECT_RECORD_BYTES = 144;
 const MESH_VERTEX_RECORD_BYTES = 48;
-const MESH_RANGE_RECORD_BYTES = 96;
-const TRIANGLE_RECORD_BYTES = 208;
+const MESH_RANGE_RECORD_BYTES = 240;
+const TRIANGLE_RECORD_BYTES = 352;
+const GPU_MATERIAL_RECORD_BYTES = 192;
 const BVH_NODE_RECORD_BYTES = 48;
 const BVH_LEAF_REF_RECORD_BYTES = 16;
 const EMISSIVE_TRIANGLE_INDEX_BYTES = 4;
 const ENVIRONMENT_PORTAL_RECORD_BYTES = 96;
 const ACCUMULATION_RECORD_BYTES = 16;
 const PATH_VERTEX_RECORD_BYTES = 16;
-const CONFIG_BUFFER_BYTES = 304;
+const GPU_SUBMITTED_WORK_TIMEOUT_MS = 5_000;
+const GPU_READBACK_COMPLETION_TIMEOUT_MS = 60_000;
+const GPU_MAX_SUBMITTED_WORK_TIMEOUT_MS = 60_000;
+const CONFIG_BUFFER_BYTES = 320;
 const COUNTER_DISPATCH_ARGS_OFFSET = 16;
 const INDIRECT_DISPATCH_ARGS_BYTES = 12;
 const COUNTER_BUFFER_BYTES = 32;
 const TRACE_STORAGE_BUFFER_BINDINGS = 10;
+const BRDF_LUT_UPLOAD_CACHE = new Map();
 const HIT_TYPE_SURFACE = 0;
 const HIT_TYPE_EMISSIVE = 1;
 const MATERIAL_DIFFUSE = 0;
@@ -66,6 +73,7 @@ export const wavefrontPathTracingComputeLimits = Object.freeze({
   meshVertexRecordBytes: MESH_VERTEX_RECORD_BYTES,
   meshRangeRecordBytes: MESH_RANGE_RECORD_BYTES,
   triangleRecordBytes: TRIANGLE_RECORD_BYTES,
+  materialRecordBytes: GPU_MATERIAL_RECORD_BYTES,
   bvhNodeRecordBytes: BVH_NODE_RECORD_BYTES,
   bvhLeafReferenceRecordBytes: BVH_LEAF_REF_RECORD_BYTES,
   emissiveTriangleIndexBytes: EMISSIVE_TRIANGLE_INDEX_BYTES,
@@ -162,6 +170,38 @@ function asColor(value, fallback = [1, 1, 1, 1]) {
     clamp(readFiniteNumber("color[2]", value[2], fallback[2]), 0, 64),
     clamp(readFiniteNumber("color[3]", value[3], fallback[3] ?? 1), 0, 1),
   ];
+}
+
+function maxComponent(value) {
+  return Math.max(value?.[0] ?? 0, value?.[1] ?? 0, value?.[2] ?? 0);
+}
+
+function deriveLegacySheenColor(baseColor, sheen, sheenTint) {
+  const sheenStrength = clamp(Number(sheen) || 0, 0, 1);
+  if (sheenStrength <= 0) {
+    return [0, 0, 0, 1];
+  }
+  const tint = clamp(Number(sheenTint) || 0, 0, 1);
+  const base = asColor(baseColor, [1, 1, 1, 1]);
+  return [
+    clamp((1 - tint) * sheenStrength + base[0] * tint * sheenStrength, 0, 1),
+    clamp((1 - tint) * sheenStrength + base[1] * tint * sheenStrength, 0, 1),
+    clamp((1 - tint) * sheenStrength + base[2] * tint * sheenStrength, 0, 1),
+    1,
+  ];
+}
+
+function resolveSheenColor(input, fallbackBaseColor) {
+  if (input?.sheenColor || input?.material?.sheenColor) {
+    return asColor(input.sheenColor ?? input.material?.sheenColor, [0, 0, 0, 1]).map((value, index) =>
+      index < 3 ? clamp(value, 0, 1) : 1
+    );
+  }
+  return deriveLegacySheenColor(
+    fallbackBaseColor,
+    input?.sheen ?? input?.material?.sheen,
+    input?.sheenTint ?? input?.material?.sheenTint
+  );
 }
 
 function resolveEnvironmentMap(input = null) {
@@ -394,7 +434,8 @@ export function normalizeWavefrontSceneObject(input = {}, index = 0) {
           input.halfExtent ?? input.halfExtents ?? input.extents ?? bounds?.halfExtent,
           [0.5, 0.5, 0.5]
         ).map((value) => Math.max(value, 0.001));
-  const materialKind = readMaterialKind(input.materialKind ?? input.material?.kind);
+  const materialKindInput = input.materialKind ?? input.material?.kind;
+  const materialKind = readMaterialKind(materialKindInput);
   const color = asColor(
     input.color ??
       input.baseColor ??
@@ -407,14 +448,30 @@ export function normalizeWavefrontSceneObject(input = {}, index = 0) {
     input.emission ?? input.emissive ?? input.material?.emission ?? input.material?.emissive,
     [0, 0, 0, 1]
   );
+  const opacity = clamp(readFiniteNumber("opacity", input.opacity ?? input.material?.opacity, color[3] ?? 1), 0, 1);
+  const transmission = clamp(
+    readFiniteNumber("transmission", input.transmission ?? input.material?.transmission, 0),
+    0,
+    1
+  );
+  const sheenColor = resolveSheenColor(input, color);
+  const specularColor = asColor(
+    input.specularColor ?? input.material?.specularColor,
+    [1, 1, 1, 1]
+  ).map((value, componentIndex) => (componentIndex < 3 ? clamp(value, 0, 1) : 1));
+  const resolvedMaterialKind =
+    emission[0] > 0 || emission[1] > 0 || emission[2] > 0
+      ? MATERIAL_EMISSIVE
+      : materialKindInput === undefined || materialKindInput === null
+        ? transmission > 0.001 || opacity < 0.999
+          ? MATERIAL_TRANSPARENT
+          : materialKind
+        : materialKind;
 
   return Object.freeze({
     id: readNonNegativeInteger("id", input.id, index + 1),
     kind,
-    materialKind:
-      emission[0] > 0 || emission[1] > 0 || emission[2] > 0
-        ? MATERIAL_EMISSIVE
-        : materialKind,
+    materialKind: resolvedMaterialKind,
     flags: readNonNegativeInteger("flags", input.flags, 0),
     center: Object.freeze(center),
     halfExtent: Object.freeze(halfExtent),
@@ -422,8 +479,24 @@ export function normalizeWavefrontSceneObject(input = {}, index = 0) {
     emission: Object.freeze(emission),
     roughness: clamp(readFiniteNumber("roughness", input.roughness ?? input.material?.roughness, 0.72), 0, 1),
     metallic: clamp(readFiniteNumber("metallic", input.metallic ?? input.material?.metallic, 0), 0, 1),
-    opacity: clamp(readFiniteNumber("opacity", input.opacity ?? input.material?.opacity, color[3] ?? 1), 0, 1),
+    opacity,
     ior: clamp(readFiniteNumber("ior", input.ior ?? input.material?.ior, 1.45), 1, 3),
+    sheen: clamp(readFiniteNumber("sheen", input.sheen ?? input.material?.sheen, 0), 0, 1),
+    sheenTint: clamp(readFiniteNumber("sheenTint", input.sheenTint ?? input.material?.sheenTint, 0), 0, 1),
+    sheenColor: Object.freeze(sheenColor),
+    clearcoat: clamp(readFiniteNumber("clearcoat", input.clearcoat ?? input.material?.clearcoat, 0), 0, 1),
+    clearcoatRoughness: clamp(
+      readFiniteNumber(
+        "clearcoatRoughness",
+        input.clearcoatRoughness ?? input.material?.clearcoatRoughness,
+        0.08
+      ),
+      0,
+      1
+    ),
+    specular: clamp(readFiniteNumber("specular", input.specular ?? input.material?.specular, 1), 0, 1),
+    specularColor: Object.freeze(specularColor),
+    transmission,
   });
 }
 
@@ -507,7 +580,8 @@ export function normalizeWavefrontMesh(input = {}, meshIndex = 0) {
           readFiniteNumber("mesh uv", value, 0)
         )
       : null;
-  const materialKind = readMaterialKind(input.materialKind ?? input.material?.kind);
+  const materialKindInput = input.materialKind ?? input.material?.kind;
+  const materialKind = readMaterialKind(materialKindInput);
   const color = asColor(
     input.color ??
       input.baseColor ??
@@ -520,6 +594,25 @@ export function normalizeWavefrontMesh(input = {}, meshIndex = 0) {
     input.emission ?? input.emissive ?? input.material?.emission ?? input.material?.emissive,
     [0, 0, 0, 1]
   );
+  const opacity = clamp(readFiniteNumber("opacity", input.opacity ?? input.material?.opacity, color[3] ?? 1), 0, 1);
+  const transmission = clamp(
+    readFiniteNumber("transmission", input.transmission ?? input.material?.transmission, 0),
+    0,
+    1
+  );
+  const sheenColor = resolveSheenColor(input, color);
+  const specularColor = asColor(
+    input.specularColor ?? input.material?.specularColor,
+    [1, 1, 1, 1]
+  ).map((value, componentIndex) => (componentIndex < 3 ? clamp(value, 0, 1) : 1));
+  const resolvedMaterialKind =
+    emission[0] > 0 || emission[1] > 0 || emission[2] > 0
+      ? MATERIAL_EMISSIVE
+      : materialKindInput === undefined || materialKindInput === null
+        ? transmission > 0.001 || opacity < 0.999
+          ? MATERIAL_TRANSPARENT
+          : materialKind
+        : materialKind;
 
   return Object.freeze({
     id: readNonNegativeInteger("mesh id", input.id, meshIndex + 1),
@@ -527,10 +620,7 @@ export function normalizeWavefrontMesh(input = {}, meshIndex = 0) {
     indices: Object.freeze(indices),
     normals: normals ? Object.freeze(normals) : null,
     uvs: uvs ? Object.freeze(uvs) : null,
-    materialKind:
-      emission[0] > 0 || emission[1] > 0 || emission[2] > 0
-        ? MATERIAL_EMISSIVE
-        : materialKind,
+    materialKind: resolvedMaterialKind,
     flags: readNonNegativeInteger("mesh flags", input.flags, 0),
     materialRefId: readNonNegativeInteger(
       "mesh materialRefId",
@@ -546,9 +636,172 @@ export function normalizeWavefrontMesh(input = {}, meshIndex = 0) {
     emission: Object.freeze(emission),
     roughness: clamp(readFiniteNumber("roughness", input.roughness ?? input.material?.roughness, 0.72), 0, 1),
     metallic: clamp(readFiniteNumber("metallic", input.metallic ?? input.material?.metallic, 0), 0, 1),
-    opacity: clamp(readFiniteNumber("opacity", input.opacity ?? input.material?.opacity, color[3] ?? 1), 0, 1),
+    opacity,
     ior: clamp(readFiniteNumber("ior", input.ior ?? input.material?.ior, 1.45), 1, 3),
+    sheen: clamp(readFiniteNumber("sheen", input.sheen ?? input.material?.sheen, 0), 0, 1),
+    sheenTint: clamp(readFiniteNumber("sheenTint", input.sheenTint ?? input.material?.sheenTint, 0), 0, 1),
+    sheenColor: Object.freeze(sheenColor),
+    clearcoat: clamp(readFiniteNumber("clearcoat", input.clearcoat ?? input.material?.clearcoat, 0), 0, 1),
+    clearcoatRoughness: clamp(
+      readFiniteNumber(
+        "clearcoatRoughness",
+        input.clearcoatRoughness ?? input.material?.clearcoatRoughness,
+        0.08
+      ),
+      0,
+      1
+    ),
+    specular: clamp(readFiniteNumber("specular", input.specular ?? input.material?.specular, 1), 0, 1),
+    specularColor: Object.freeze(specularColor),
+    transmission,
+    baseColorTexture: input.baseColorTexture ?? input.material?.baseColorTexture ?? null,
+    metallicRoughnessTexture:
+      input.metallicRoughnessTexture ?? input.material?.metallicRoughnessTexture ?? null,
+    normalTexture: input.normalTexture ?? input.material?.normalTexture ?? null,
+    occlusionTexture: input.occlusionTexture ?? input.material?.occlusionTexture ?? null,
+    emissiveTexture: input.emissiveTexture ?? input.material?.emissiveTexture ?? null,
   });
+}
+
+function clampUnit(value) {
+  return clamp(Number(value) || 0, 0, 1);
+}
+
+function srgbToLinear(value) {
+  const channel = clampUnit(value);
+  if (channel <= 0.04045) {
+    return channel / 12.92;
+  }
+  return ((channel + 0.055) / 1.055) ** 2.4;
+}
+
+function sampleTextureRgba(texture, uv = [0, 0], colorSpace = "linear") {
+  if (
+    !texture ||
+    !Number.isFinite(texture.width) ||
+    !Number.isFinite(texture.height) ||
+    !texture.data ||
+    texture.width <= 0 ||
+    texture.height <= 0
+  ) {
+    return [1, 1, 1, 1];
+  }
+  const u = ((uv[0] % 1) + 1) % 1;
+  const v = ((uv[1] % 1) + 1) % 1;
+  const x = Math.min(texture.width - 1, Math.max(0, Math.round(u * (texture.width - 1))));
+  const y = Math.min(texture.height - 1, Math.max(0, Math.round((1 - v) * (texture.height - 1))));
+  const offset = (y * texture.width + x) * 4;
+  const data = texture.data;
+  const color = [
+    (data[offset] ?? 255) / 255,
+    (data[offset + 1] ?? 255) / 255,
+    (data[offset + 2] ?? 255) / 255,
+    (data[offset + 3] ?? 255) / 255,
+  ];
+  if (colorSpace === "srgb") {
+    return [srgbToLinear(color[0]), srgbToLinear(color[1]), srgbToLinear(color[2]), color[3]];
+  }
+  return color;
+}
+
+function normalizeVectorOrFallback(vector, fallback) {
+  return normalize(Array.isArray(vector) ? vector : fallback, fallback);
+}
+
+function buildTriangleTangentBasis(v0, v1, v2, uv0, uv1, uv2, fallbackNormal) {
+  const edge1 = subtract(v1, v0);
+  const edge2 = subtract(v2, v0);
+  const deltaUv1 = [uv1[0] - uv0[0], uv1[1] - uv0[1]];
+  const deltaUv2 = [uv2[0] - uv0[0], uv2[1] - uv0[1]];
+  const determinant = deltaUv1[0] * deltaUv2[1] - deltaUv1[1] * deltaUv2[0];
+  if (Math.abs(determinant) < 1e-6) {
+    const tangentFallback = Math.abs(fallbackNormal[1]) < 0.999 ? [0, 1, 0] : [1, 0, 0];
+    const tangent = normalize(cross(tangentFallback, fallbackNormal), [1, 0, 0]);
+    const bitangent = normalize(cross(fallbackNormal, tangent), [0, 0, 1]);
+    return { tangent, bitangent };
+  }
+  const inverse = 1 / determinant;
+  const tangent = normalize(
+    [
+      inverse * (edge1[0] * deltaUv2[1] - edge2[0] * deltaUv1[1]),
+      inverse * (edge1[1] * deltaUv2[1] - edge2[1] * deltaUv1[1]),
+      inverse * (edge1[2] * deltaUv2[1] - edge2[2] * deltaUv1[1]),
+    ],
+    [1, 0, 0]
+  );
+  const bitangent = normalize(
+    [
+      inverse * (-edge1[0] * deltaUv2[0] + edge2[0] * deltaUv1[0]),
+      inverse * (-edge1[1] * deltaUv2[0] + edge2[1] * deltaUv1[0]),
+      inverse * (-edge1[2] * deltaUv2[0] + edge2[2] * deltaUv1[0]),
+    ],
+    [0, 0, 1]
+  );
+  return { tangent, bitangent };
+}
+
+function applyNormalMap(normal, tangent, bitangent, normalTexture, uv) {
+  if (!normalTexture) {
+    return normalizeVectorOrFallback(normal, [0, 1, 0]);
+  }
+  const sample = sampleTextureRgba(normalTexture, uv, "linear");
+  const strength = clampUnit(normalTexture.scale ?? 1);
+  const tangentNormal = normalize(
+    [
+      sample[0] * 2 - 1,
+      sample[1] * 2 - 1,
+      1 + (sample[2] * 2 - 1 - 1) * strength,
+    ],
+    [0, 0, 1]
+  );
+  return normalize(
+    [
+      tangent[0] * tangentNormal[0] + bitangent[0] * tangentNormal[1] + normal[0] * tangentNormal[2],
+      tangent[1] * tangentNormal[0] + bitangent[1] * tangentNormal[1] + normal[1] * tangentNormal[2],
+      tangent[2] * tangentNormal[0] + bitangent[2] * tangentNormal[1] + normal[2] * tangentNormal[2],
+    ],
+    normal
+  );
+}
+
+function sampleBaseColor(mesh, uv) {
+  const sample = mesh.baseColorTexture ? sampleTextureRgba(mesh.baseColorTexture, uv, "srgb") : [1, 1, 1, 1];
+  return [
+    clampUnit(mesh.color[0] * sample[0]),
+    clampUnit(mesh.color[1] * sample[1]),
+    clampUnit(mesh.color[2] * sample[2]),
+    clampUnit((mesh.color[3] ?? 1) * sample[3]),
+  ];
+}
+
+function sampleSurfaceMaterial(mesh, uv) {
+  const textureSample = mesh.metallicRoughnessTexture
+    ? sampleTextureRgba(mesh.metallicRoughnessTexture, uv, "linear")
+    : [1, 1, 1, 1];
+  return {
+    roughness: clamp(mesh.roughness * textureSample[1], 0, 1),
+    metallic: clamp(mesh.metallic * textureSample[2], 0, 1),
+  };
+}
+
+function averageColors(colors) {
+  const count = Math.max(colors.length, 1);
+  return colors.reduce(
+    (accumulator, color) => [
+      accumulator[0] + color[0] / count,
+      accumulator[1] + color[1] / count,
+      accumulator[2] + color[2] / count,
+      accumulator[3] + color[3] / count,
+    ],
+    [0, 0, 0, 0]
+  );
+}
+
+function averageNumbers(values, fallback = 0) {
+  if (!Array.isArray(values) || values.length === 0) {
+    return fallback;
+  }
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
 }
 
 function createMeshTriangleRecords(meshes) {
@@ -571,6 +824,16 @@ function createMeshTriangleRecords(meshes) {
       const uv0 = mesh.uvs ? readVector2(mesh.uvs, a) : [0, 0];
       const uv1 = mesh.uvs ? readVector2(mesh.uvs, b) : [0, 0];
       const uv2 = mesh.uvs ? readVector2(mesh.uvs, c) : [0, 0];
+      const tangentBasis = buildTriangleTangentBasis(v0, v1, v2, uv0, uv1, uv2, faceNormal);
+      const shadedN0 = applyNormalMap(n0, tangentBasis.tangent, tangentBasis.bitangent, mesh.normalTexture, uv0);
+      const shadedN1 = applyNormalMap(n1, tangentBasis.tangent, tangentBasis.bitangent, mesh.normalTexture, uv1);
+      const shadedN2 = applyNormalMap(n2, tangentBasis.tangent, tangentBasis.bitangent, mesh.normalTexture, uv2);
+      const sampledColors = [sampleBaseColor(mesh, uv0), sampleBaseColor(mesh, uv1), sampleBaseColor(mesh, uv2)];
+      const sampledMaterials = [
+        sampleSurfaceMaterial(mesh, uv0),
+        sampleSurfaceMaterial(mesh, uv1),
+        sampleSurfaceMaterial(mesh, uv2),
+      ];
       const bounds = triangleBounds(v0, v1, v2);
 
       triangles.push(
@@ -581,18 +844,42 @@ function createMeshTriangleRecords(meshes) {
           flags: mesh.flags,
           materialRefId: mesh.materialRefId,
           mediumRefId: mesh.mediumRefId,
+          materialSlot: meshIndex,
           v0: Object.freeze(v0),
           v1: Object.freeze(v1),
           v2: Object.freeze(v2),
-          n0: Object.freeze(n0),
-          n1: Object.freeze(n1),
-          n2: Object.freeze(n2),
+          n0: Object.freeze(shadedN0),
+          n1: Object.freeze(shadedN1),
+          n2: Object.freeze(shadedN2),
           uv0: Object.freeze(uv0),
           uv1: Object.freeze(uv1),
           uv2: Object.freeze(uv2),
-          color: mesh.color,
+          color: Object.freeze(averageColors(sampledColors)),
           emission: mesh.emission,
-          material: Object.freeze([mesh.roughness, mesh.metallic, mesh.opacity, mesh.ior]),
+          material: Object.freeze([
+            averageNumbers(sampledMaterials.map((sample) => sample.roughness), mesh.roughness),
+            averageNumbers(sampledMaterials.map((sample) => sample.metallic), mesh.metallic),
+            mesh.opacity,
+            mesh.ior,
+          ]),
+          materialResponse: Object.freeze([
+            mesh.sheenColor[0] ?? 0,
+            mesh.sheenColor[1] ?? 0,
+            mesh.sheenColor[2] ?? 0,
+            mesh.clearcoat,
+          ]),
+          materialExtension: Object.freeze([
+            mesh.clearcoatRoughness,
+            mesh.specular,
+            mesh.transmission,
+            0,
+          ]),
+          specularColor: Object.freeze([
+            mesh.specularColor[0] ?? 1,
+            mesh.specularColor[1] ?? 1,
+            mesh.specularColor[2] ?? 1,
+            1,
+          ]),
           bounds: Object.freeze({
             min: Object.freeze(bounds.min),
             max: Object.freeze(bounds.max),
@@ -713,6 +1000,245 @@ function nextPowerOfTwo(value) {
   return 2 ** Math.ceil(Math.log2(value));
 }
 
+function textureComponentToByte(value, fallback) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) {
+    return fallback;
+  }
+  if (numeric >= 0 && numeric <= 1) {
+    return Math.max(0, Math.min(255, Math.round(numeric * 255)));
+  }
+  return Math.max(0, Math.min(255, Math.round(numeric)));
+}
+
+function createSolidTextureSample(width, height, rgba) {
+  const data = new Uint8Array(width * height * 4);
+  for (let offset = 0; offset < data.length; offset += 4) {
+    data[offset] = rgba[0];
+    data[offset + 1] = rgba[1];
+    data[offset + 2] = rgba[2];
+    data[offset + 3] = rgba[3];
+  }
+  return Object.freeze({
+    width,
+    height,
+    data,
+  });
+}
+
+function normalizeTextureSampleInput(texture, fallbackColor) {
+  if (
+    !texture ||
+    !Number.isFinite(texture.width) ||
+    !Number.isFinite(texture.height) ||
+    texture.width <= 0 ||
+    texture.height <= 0
+  ) {
+    return createSolidTextureSample(1, 1, fallbackColor);
+  }
+
+  const pixelCount = Math.trunc(texture.width) * Math.trunc(texture.height) * 4;
+  const source =
+    ArrayBuffer.isView(texture.data) || Array.isArray(texture.data) ? texture.data : null;
+  if (!source || source.length < pixelCount) {
+    return createSolidTextureSample(1, 1, fallbackColor);
+  }
+
+  const data = new Uint8Array(pixelCount);
+  for (let index = 0; index < pixelCount; index += 1) {
+    data[index] = textureComponentToByte(source[index], fallbackColor[index % 4]);
+  }
+
+  return Object.freeze({
+    width: Math.trunc(texture.width),
+    height: Math.trunc(texture.height),
+    data,
+  });
+}
+
+function buildTextureAtlas(textures, fallbackColor) {
+  const padding = 1;
+  const defaultTexture = createSolidTextureSample(1, 1, fallbackColor);
+  const uniqueEntries = [{ source: null, texture: defaultTexture }];
+  const bySource = new Map();
+
+  for (const texture of Array.isArray(textures) ? textures : []) {
+    if (!texture || bySource.has(texture)) {
+      continue;
+    }
+    const normalized = normalizeTextureSampleInput(texture, fallbackColor);
+    bySource.set(texture, uniqueEntries.length);
+    uniqueEntries.push({ source: texture, texture: normalized });
+  }
+
+  const totalArea = uniqueEntries.reduce((sum, entry) => {
+    return sum + (entry.texture.width + padding * 2) * (entry.texture.height + padding * 2);
+  }, 0);
+  const maxTileWidth = uniqueEntries.reduce((maxWidth, entry) => {
+    return Math.max(maxWidth, entry.texture.width + padding * 2);
+  }, 1);
+  const targetWidth = Math.max(
+    maxTileWidth,
+    nextPowerOfTwo(Math.max(maxTileWidth, Math.ceil(Math.sqrt(totalArea))))
+  );
+
+  let cursorX = 0;
+  let cursorY = 0;
+  let rowHeight = 0;
+  let atlasWidth = 0;
+  const placements = uniqueEntries.map((entry) => {
+    const tileWidth = entry.texture.width + padding * 2;
+    const tileHeight = entry.texture.height + padding * 2;
+    if (cursorX > 0 && cursorX + tileWidth > targetWidth) {
+      cursorX = 0;
+      cursorY += rowHeight;
+      rowHeight = 0;
+    }
+    const placement = Object.freeze({
+      x: cursorX,
+      y: cursorY,
+      tileWidth,
+      tileHeight,
+      width: entry.texture.width,
+      height: entry.texture.height,
+    });
+    cursorX += tileWidth;
+    atlasWidth = Math.max(atlasWidth, cursorX);
+    rowHeight = Math.max(rowHeight, tileHeight);
+    return placement;
+  });
+
+  const atlasHeight = Math.max(1, cursorY + rowHeight);
+  const atlasData = new Uint8Array(Math.max(1, atlasWidth * atlasHeight * 4));
+
+  const writePixel = (x, y, rgba) => {
+    const offset = (y * atlasWidth + x) * 4;
+    atlasData[offset] = rgba[0];
+    atlasData[offset + 1] = rgba[1];
+    atlasData[offset + 2] = rgba[2];
+    atlasData[offset + 3] = rgba[3];
+  };
+
+  const rects = placements.map((placement, entryIndex) => {
+    const { texture } = uniqueEntries[entryIndex];
+    for (let y = 0; y < placement.tileHeight; y += 1) {
+      for (let x = 0; x < placement.tileWidth; x += 1) {
+        const sampleX = Math.max(0, Math.min(texture.width - 1, x - padding));
+        const sampleY = Math.max(0, Math.min(texture.height - 1, y - padding));
+        const sourceOffset = (sampleY * texture.width + sampleX) * 4;
+        writePixel(placement.x + x, placement.y + y, texture.data.slice(sourceOffset, sourceOffset + 4));
+      }
+    }
+    return Object.freeze([
+      (placement.x + padding) / Math.max(1, atlasWidth),
+      (placement.y + padding) / Math.max(1, atlasHeight),
+      placement.width / Math.max(1, atlasWidth),
+      placement.height / Math.max(1, atlasHeight),
+    ]);
+  });
+
+  const rectBySource = new Map();
+  uniqueEntries.forEach((entry, index) => {
+    if (entry.source) {
+      rectBySource.set(entry.source, rects[index]);
+    }
+  });
+
+  return Object.freeze({
+    width: Math.max(1, atlasWidth),
+    height: Math.max(1, atlasHeight),
+    data: atlasData,
+    defaultRect: rects[0],
+    resolveRect(texture) {
+      return rectBySource.get(texture) ?? rects[0];
+    },
+  });
+}
+
+export function createWavefrontGpuMaterialSource(meshes = []) {
+  const source = Array.isArray(meshes) ? meshes : [meshes];
+  const normalized = source.map((meshInput, meshIndex) => normalizeWavefrontMesh(meshInput, meshIndex));
+  const baseColorAtlas = buildTextureAtlas(
+    normalized.map((mesh) => mesh.baseColorTexture),
+    [255, 255, 255, 255]
+  );
+  const metallicRoughnessAtlas = buildTextureAtlas(
+    normalized.map((mesh) => mesh.metallicRoughnessTexture),
+    [255, 255, 255, 255]
+  );
+  const normalAtlas = buildTextureAtlas(
+    normalized.map((mesh) => mesh.normalTexture),
+    [128, 128, 255, 255]
+  );
+  const occlusionAtlas = buildTextureAtlas(
+    normalized.map((mesh) => mesh.occlusionTexture),
+    [255, 255, 255, 255]
+  );
+  const emissiveAtlas = buildTextureAtlas(
+    normalized.map((mesh) => mesh.emissiveTexture),
+    [255, 255, 255, 255]
+  );
+  const bytes = new ArrayBuffer(Math.max(1, normalized.length) * GPU_MATERIAL_RECORD_BYTES);
+  const floatView = new Float32Array(bytes);
+
+  normalized.forEach((mesh, meshIndex) => {
+    const byteOffset = meshIndex * GPU_MATERIAL_RECORD_BYTES;
+    writeVec4(floatView, byteOffset, mesh.color);
+    writeVec4(floatView, byteOffset + 16, mesh.emission);
+    writeVec4(floatView, byteOffset + 32, [
+      mesh.roughness,
+      mesh.metallic,
+      mesh.opacity,
+      mesh.ior,
+    ]);
+    writeVec4(floatView, byteOffset + 48, [
+      mesh.sheenColor[0] ?? 0,
+      mesh.sheenColor[1] ?? 0,
+      mesh.sheenColor[2] ?? 0,
+      mesh.clearcoat,
+    ]);
+    writeVec4(floatView, byteOffset + 64, [
+      mesh.clearcoatRoughness,
+      mesh.specular,
+      mesh.transmission,
+      0,
+    ]);
+    writeVec4(floatView, byteOffset + 80, [
+      mesh.specularColor[0] ?? 1,
+      mesh.specularColor[1] ?? 1,
+      mesh.specularColor[2] ?? 1,
+      1,
+    ]);
+    writeVec4(floatView, byteOffset + 96, baseColorAtlas.resolveRect(mesh.baseColorTexture));
+    writeVec4(
+      floatView,
+      byteOffset + 112,
+      metallicRoughnessAtlas.resolveRect(mesh.metallicRoughnessTexture)
+    );
+    writeVec4(floatView, byteOffset + 128, normalAtlas.resolveRect(mesh.normalTexture));
+    writeVec4(floatView, byteOffset + 144, occlusionAtlas.resolveRect(mesh.occlusionTexture));
+    writeVec4(floatView, byteOffset + 160, emissiveAtlas.resolveRect(mesh.emissiveTexture));
+    writeVec4(floatView, byteOffset + 176, [
+      clampUnit(mesh.normalTexture?.scale ?? mesh.normalTexture?.strength ?? 1),
+      clampUnit(mesh.occlusionTexture?.strength ?? 1),
+      clampUnit(mesh.emissiveTexture?.strength ?? 1),
+      0,
+    ]);
+  });
+
+  return Object.freeze({
+    buffer: bytes,
+    count: normalized.length,
+    recordBytes: GPU_MATERIAL_RECORD_BYTES,
+    records: Object.freeze(normalized),
+    baseColorAtlas,
+    metallicRoughnessAtlas,
+    normalAtlas,
+    occlusionAtlas,
+    emissiveAtlas,
+  });
+}
+
 function estimateBvhLeafSortCapacity(triangleCount) {
   return triangleCount <= 0 ? 0 : nextPowerOfTwo(triangleCount);
 }
@@ -783,9 +1309,10 @@ function resolveAccelerationBuildMode(options = {}) {
   return mode;
 }
 
-export function createWavefrontGpuMeshSource(meshes = []) {
+export function createWavefrontGpuMeshSource(meshes = [], gpuMaterialSourceInput = null) {
   const source = Array.isArray(meshes) ? meshes : [meshes];
   const normalized = source.map((meshInput, meshIndex) => normalizeWavefrontMesh(meshInput, meshIndex));
+  const gpuMaterialSource = gpuMaterialSourceInput ?? createWavefrontGpuMaterialSource(normalized);
   const vertexCount = normalized.reduce((count, mesh) => count + mesh.positions.length / 3, 0);
   const indexCount = normalized.reduce((count, mesh) => count + mesh.indices.length, 0);
   const triangleCount = Math.floor(indexCount / 3);
@@ -842,7 +1369,7 @@ export function createWavefrontGpuMeshSource(meshes = []) {
     meshUints[meshOffset + 8] = mesh.indices.length / 3;
     meshUints[meshOffset + 9] = meshVertexBase;
     meshUints[meshOffset + 10] = meshVertexCount;
-    meshUints[meshOffset + 11] = 0;
+    meshUints[meshOffset + 11] = meshIndex;
     const floatOffset = meshOffset;
     writeVec4(meshFloats, floatOffset * 4 + 48, mesh.color);
     writeVec4(meshFloats, floatOffset * 4 + 64, mesh.emission);
@@ -851,6 +1378,55 @@ export function createWavefrontGpuMeshSource(meshes = []) {
       mesh.metallic,
       mesh.opacity,
       mesh.ior,
+    ]);
+    writeVec4(meshFloats, floatOffset * 4 + 96, [
+      mesh.sheenColor[0] ?? 0,
+      mesh.sheenColor[1] ?? 0,
+      mesh.sheenColor[2] ?? 0,
+      mesh.clearcoat,
+    ]);
+    writeVec4(meshFloats, floatOffset * 4 + 112, [
+      mesh.clearcoatRoughness,
+      mesh.specular,
+      mesh.transmission,
+      0,
+    ]);
+    writeVec4(meshFloats, floatOffset * 4 + 128, [
+      mesh.specularColor[0] ?? 1,
+      mesh.specularColor[1] ?? 1,
+      mesh.specularColor[2] ?? 1,
+      1,
+    ]);
+    writeVec4(
+      meshFloats,
+      floatOffset * 4 + 144,
+      gpuMaterialSource.baseColorAtlas.resolveRect(mesh.baseColorTexture)
+    );
+    writeVec4(
+      meshFloats,
+      floatOffset * 4 + 160,
+      gpuMaterialSource.metallicRoughnessAtlas.resolveRect(mesh.metallicRoughnessTexture)
+    );
+    writeVec4(
+      meshFloats,
+      floatOffset * 4 + 176,
+      gpuMaterialSource.normalAtlas.resolveRect(mesh.normalTexture)
+    );
+    writeVec4(
+      meshFloats,
+      floatOffset * 4 + 192,
+      gpuMaterialSource.occlusionAtlas.resolveRect(mesh.occlusionTexture)
+    );
+    writeVec4(
+      meshFloats,
+      floatOffset * 4 + 208,
+      gpuMaterialSource.emissiveAtlas.resolveRect(mesh.emissiveTexture)
+    );
+    writeVec4(meshFloats, floatOffset * 4 + 224, [
+      clampUnit(mesh.normalTexture?.scale ?? mesh.normalTexture?.strength ?? 1),
+      clampUnit(mesh.occlusionTexture?.strength ?? 1),
+      clampUnit(mesh.emissiveTexture?.strength ?? 1),
+      0,
     ]);
 
     vertexCursor += meshVertexCount;
@@ -1188,12 +1764,14 @@ export function estimateWavefrontPathTracingMemory(options = {}) {
     options.environmentPortalCapacity,
     0
   );
+  const materialCapacity = readNonNegativeInteger("materialCapacity", options.materialCapacity, 0);
   const queueBytes = tilePixelCapacity * RAY_RECORD_BYTES;
   const hitBytes = tilePixelCapacity * HIT_RECORD_BYTES;
   const accumulationBytes = tilePixelCapacity * ACCUMULATION_RECORD_BYTES;
   const pathVertexBytes = tilePixelCapacity * (maxDepth + 1) * PATH_VERTEX_RECORD_BYTES;
   const sceneObjectBytes = sceneObjectCapacity * SCENE_OBJECT_RECORD_BYTES;
   const triangleBytes = triangleCapacity * TRIANGLE_RECORD_BYTES;
+  const materialTableBytes = materialCapacity * GPU_MATERIAL_RECORD_BYTES;
   const bvhNodeBytes = bvhNodeCapacity * BVH_NODE_RECORD_BYTES;
   const bvhLeafReferenceBytes = bvhLeafSortCapacity * BVH_LEAF_REF_RECORD_BYTES;
   const emissiveTriangleMetadataBytes =
@@ -1209,6 +1787,7 @@ export function estimateWavefrontPathTracingMemory(options = {}) {
     pathVertexBytes,
     sceneObjectBytes,
     triangleBytes,
+    materialTableBytes,
     bvhNodeBytes,
     bvhLeafReferenceBytes,
     emissiveTriangleMetadataBytes,
@@ -1223,6 +1802,7 @@ export function estimateWavefrontPathTracingMemory(options = {}) {
       pathVertexBytes +
       sceneObjectBytes +
       triangleBytes +
+      materialTableBytes +
       bvhNodeBytes +
       bvhLeafReferenceBytes +
       emissiveTriangleMetadataBytes +
@@ -1244,7 +1824,7 @@ export function createWavefrontPathTracingComputeConfig(options = {}) {
   const samplesPerPixel = clamp(
     readPositiveInteger("samplesPerPixel", options.samplesPerPixel, DEFAULT_SAMPLES_PER_PIXEL),
     1,
-    64
+    MAX_SAMPLES_PER_PIXEL
   );
   const maxFramePassesPerSubmission = clamp(
     readPositiveInteger(
@@ -1262,9 +1842,13 @@ export function createWavefrontPathTracingComputeConfig(options = {}) {
   );
   const meshes = normalizeMeshes(options);
   const meshSourceShape = estimateMeshSourceShape(meshes);
+  const gpuMaterialSource =
+    meshes.length > 0
+      ? createWavefrontGpuMaterialSource(meshes)
+      : createWavefrontGpuMaterialSource([]);
   const gpuMeshSource =
     meshes.length > 0
-      ? createWavefrontGpuMeshSource(meshes)
+      ? createWavefrontGpuMeshSource(meshes, gpuMaterialSource)
       : createWavefrontGpuMeshSource([]);
   const meshAcceleration =
     accelerationBuildMode === "cpu-debug"
@@ -1360,6 +1944,7 @@ export function createWavefrontPathTracingComputeConfig(options = {}) {
     accelerationBuildMode,
     gpuAccelerationBuildRequired: accelerationBuildMode === "gpu" && triangleCount > 0,
     gpuMeshSource,
+    gpuMaterialSource,
     meshAcceleration,
     emissiveTriangleIndices,
     emissiveTriangleCount: emissiveTriangleIndices.count,
@@ -1390,6 +1975,7 @@ export function createWavefrontPathTracingComputeConfig(options = {}) {
       maxDepth,
       sceneObjectCapacity,
       triangleCapacity,
+      materialCapacity: gpuMaterialSource.count,
       bvhNodeCapacity,
       bvhLeafSortCapacity,
       emissiveTriangleCapacity: emissiveTriangleIndices.capacity,
@@ -1483,6 +2069,24 @@ export function packWavefrontSceneObjects(sceneObjects, capacity = sceneObjects.
       object.opacity,
       object.ior,
     ]);
+    writeVec4(floatView, byteOffset + 96, [
+      object.sheenColor[0] ?? 0,
+      object.sheenColor[1] ?? 0,
+      object.sheenColor[2] ?? 0,
+      object.clearcoat,
+    ]);
+    writeVec4(floatView, byteOffset + 112, [
+      object.clearcoatRoughness,
+      object.specular,
+      object.transmission,
+      0,
+    ]);
+    writeVec4(floatView, byteOffset + 128, [
+      object.specularColor[0] ?? 1,
+      object.specularColor[1] ?? 1,
+      object.specularColor[2] ?? 1,
+      1,
+    ]);
   });
 
   return Object.freeze({
@@ -1511,7 +2115,7 @@ export function packWavefrontTriangles(triangles, capacity = triangles.length) {
     uintView[u32 + 3] = triangle.flags;
     uintView[u32 + 4] = triangle.materialRefId;
     uintView[u32 + 5] = triangle.mediumRefId;
-    uintView[u32 + 6] = 0;
+    uintView[u32 + 6] = triangle.materialSlot ?? 0;
     uintView[u32 + 7] = 0;
     writeVec4(floatView, byteOffset + 32, [...triangle.v0, 0]);
     writeVec4(floatView, byteOffset + 48, [...triangle.v1, 0]);
@@ -1524,6 +2128,15 @@ export function packWavefrontTriangles(triangles, capacity = triangles.length) {
     writeVec4(floatView, byteOffset + 160, triangle.color);
     writeVec4(floatView, byteOffset + 176, triangle.emission);
     writeVec4(floatView, byteOffset + 192, triangle.material);
+    writeVec4(floatView, byteOffset + 208, triangle.materialResponse);
+    writeVec4(floatView, byteOffset + 224, triangle.materialExtension ?? [0.08, 1, 0, 0]);
+    writeVec4(floatView, byteOffset + 240, triangle.specularColor ?? [1, 1, 1, 1]);
+    writeVec4(floatView, byteOffset + 256, triangle.baseColorAtlas ?? [0, 0, 1, 1]);
+    writeVec4(floatView, byteOffset + 272, triangle.metallicRoughnessAtlas ?? [0, 0, 1, 1]);
+    writeVec4(floatView, byteOffset + 288, triangle.normalAtlas ?? [0, 0, 1, 1]);
+    writeVec4(floatView, byteOffset + 304, triangle.occlusionAtlas ?? [0, 0, 1, 1]);
+    writeVec4(floatView, byteOffset + 320, triangle.emissiveAtlas ?? [0, 0, 1, 1]);
+    writeVec4(floatView, byteOffset + 336, triangle.textureSettings ?? [1, 1, 1, 0]);
   });
 
   return Object.freeze({
@@ -1621,6 +2234,12 @@ function createConfigPayload(config, tile, frameIndex, buildRange = {}) {
     config.deferredPathResolve ? 1 : 0,
     config.environmentLighting.sunlitBaseline,
     0,
+    0,
+  ]);
+  writeVec4(floatView, 304, [
+    config.environmentMap.width ?? 1,
+    config.environmentMap.height ?? 1,
+    config.environmentMap.mipLevelCount ?? 1,
     0,
   ]);
   return bytes;
@@ -1932,12 +2551,353 @@ function environmentMapIntegerScale(data) {
   return 1;
 }
 
+function createRgba8TextureUpload(source) {
+  const width = Math.max(1, Math.trunc(source.width));
+  const height = Math.max(1, Math.trunc(source.height));
+  const bytesPerRow = alignTo(width * 4, 256);
+  const bytes = new Uint8Array(bytesPerRow * height);
+  const data = source.data instanceof Uint8Array ? source.data : new Uint8Array(source.data);
+  for (let y = 0; y < height; y += 1) {
+    const sourceOffset = y * width * 4;
+    const targetOffset = y * bytesPerRow;
+    bytes.set(data.subarray(sourceOffset, sourceOffset + width * 4), targetOffset);
+  }
+  return Object.freeze({
+    bytes,
+    bytesPerRow,
+    width,
+    height,
+  });
+}
+
 function readEnvironmentMapComponent(data, index, fallback, integerScale = 1) {
   if (!data || index >= data.length) {
     return fallback;
   }
   const value = Number(data[index]);
   return Number.isFinite(value) ? Math.max(0, value) * integerScale : fallback;
+}
+
+function reflectVector(direction, normal) {
+  return subtract(direction, scale(normal, 2 * dot(direction, normal)));
+}
+
+function buildOrthonormalBasis(normal) {
+  const tangentFallback = Math.abs(normal[1]) < 0.999 ? [0, 1, 0] : [1, 0, 0];
+  const tangent = normalize(cross(tangentFallback, normal), [1, 0, 0]);
+  const bitangent = normalize(cross(normal, tangent), [0, 0, 1]);
+  return { tangent, bitangent };
+}
+
+function localToWorld(local, normal) {
+  const basis = buildOrthonormalBasis(normal);
+  return normalize(
+    add(
+      add(scale(basis.tangent, local[0]), scale(basis.bitangent, local[1])),
+      scale(normal, local[2])
+    ),
+    normal
+  );
+}
+
+function radicalInverseVdc(bits) {
+  let value = bits >>> 0;
+  value = ((value << 16) | (value >>> 16)) >>> 0;
+  value = (((value & 0x55555555) << 1) | ((value & 0xaaaaaaaa) >>> 1)) >>> 0;
+  value = (((value & 0x33333333) << 2) | ((value & 0xcccccccc) >>> 2)) >>> 0;
+  value = (((value & 0x0f0f0f0f) << 4) | ((value & 0xf0f0f0f0) >>> 4)) >>> 0;
+  value = (((value & 0x00ff00ff) << 8) | ((value & 0xff00ff00) >>> 8)) >>> 0;
+  return value * 2.3283064365386963e-10;
+}
+
+function hammersley(index, count) {
+  return [index / Math.max(count, 1), radicalInverseVdc(index)];
+}
+
+function importanceSampleGgx(sample, roughness, normal) {
+  const alpha = Math.max(roughness * roughness, 0.0001);
+  const phi = 2 * Math.PI * sample[0];
+  const cosTheta = Math.sqrt((1 - sample[1]) / (1 + (alpha * alpha - 1) * sample[1]));
+  const sinTheta = Math.sqrt(Math.max(0, 1 - cosTheta * cosTheta));
+  const halfVector = localToWorld(
+    [Math.cos(phi) * sinTheta, Math.sin(phi) * sinTheta, cosTheta],
+    normal
+  );
+  return normalize(halfVector, normal);
+}
+
+function distributionGgx(nDotH, roughness) {
+  const alpha = Math.max(roughness * roughness, 0.0001);
+  const alpha2 = alpha * alpha;
+  const denom = (nDotH * nDotH) * (alpha2 - 1) + 1;
+  return alpha2 / Math.max(Math.PI * denom * denom, 0.000001);
+}
+
+function geometrySchlickGgx(nDotV, roughness) {
+  const k = ((roughness + 1) * (roughness + 1)) / 8;
+  return nDotV / Math.max(nDotV * (1 - k) + k, 0.000001);
+}
+
+function geometrySmith(nDotV, nDotL, roughness) {
+  return geometrySchlickGgx(nDotV, roughness) * geometrySchlickGgx(nDotL, roughness);
+}
+
+function integrateBrdfSample(nDotV, roughness, sampleCount) {
+  const viewDirection = [Math.sqrt(Math.max(0, 1 - nDotV * nDotV)), 0, nDotV];
+  const normal = [0, 0, 1];
+  let scaleTerm = 0;
+  let biasTerm = 0;
+  for (let index = 0; index < sampleCount; index += 1) {
+    const xi = hammersley(index, sampleCount);
+    const halfVector = importanceSampleGgx(xi, roughness, normal);
+    const vDotH = Math.max(dot(viewDirection, halfVector), 0);
+    const lightDirection = normalize(
+      subtract(scale(halfVector, 2 * vDotH), viewDirection),
+      normal
+    );
+    const nDotL = Math.max(lightDirection[2], 0);
+    const nDotH = Math.max(halfVector[2], 0);
+    if (nDotL <= 0 || nDotH <= 0 || vDotH <= 0) {
+      continue;
+    }
+    const geometry = geometrySmith(nDotV, nDotL, roughness);
+    const visibility = (geometry * vDotH) / Math.max(nDotH * nDotV, 0.000001);
+    const fresnel = (1 - vDotH) ** 5;
+    scaleTerm += (1 - fresnel) * visibility;
+    biasTerm += fresnel * visibility;
+  }
+  return [scaleTerm / sampleCount, biasTerm / sampleCount];
+}
+
+function createBrdfLutUploadBytes(size = DEFAULT_BRDF_LUT_SIZE, sampleCount = 1024) {
+  const cacheKey = `${Math.max(1, Math.trunc(size))}:${Math.max(1, Math.trunc(sampleCount))}`;
+  const cached = BRDF_LUT_UPLOAD_CACHE.get(cacheKey);
+  if (cached) {
+    return cached;
+  }
+  const width = Math.max(1, Math.trunc(size));
+  const height = Math.max(1, Math.trunc(size));
+  const rowBytes = width * 8;
+  const bytesPerRow = alignTo(rowBytes, 256);
+  const bytes = new Uint8Array(bytesPerRow * height);
+  const view = new DataView(bytes.buffer);
+  for (let y = 0; y < height; y += 1) {
+    const roughness = (y + 0.5) / height;
+    for (let x = 0; x < width; x += 1) {
+      const nDotV = Math.max((x + 0.5) / width, 0.0001);
+      const [scaleTerm, biasTerm] = integrateBrdfSample(nDotV, roughness, sampleCount);
+      const offset = y * bytesPerRow + x * 8;
+      view.setUint16(offset, float32ToFloat16Bits(scaleTerm), true);
+      view.setUint16(offset + 2, float32ToFloat16Bits(biasTerm), true);
+      view.setUint16(offset + 4, float32ToFloat16Bits(0), true);
+      view.setUint16(offset + 6, float32ToFloat16Bits(1), true);
+    }
+  }
+  return Object.freeze({ bytes, bytesPerRow, width, height });
+}
+
+function createLinearEnvironmentPixels(environmentMap, fallbackColor) {
+  const width = Math.max(1, environmentMap.width);
+  const height = Math.max(1, environmentMap.height);
+  const pixels = new Float32Array(width * height * 4);
+  const data = environmentMap.data;
+  const integerScale = environmentMapIntegerScale(data);
+  for (let index = 0; index < width * height; index += 1) {
+    const sourceOffset = index * 4;
+    const targetOffset = index * 4;
+    pixels[targetOffset] = readEnvironmentMapComponent(data, sourceOffset, fallbackColor[0], integerScale);
+    pixels[targetOffset + 1] = readEnvironmentMapComponent(data, sourceOffset + 1, fallbackColor[1], integerScale);
+    pixels[targetOffset + 2] = readEnvironmentMapComponent(data, sourceOffset + 2, fallbackColor[2], integerScale);
+    pixels[targetOffset + 3] = readEnvironmentMapComponent(data, sourceOffset + 3, fallbackColor[3] ?? 1, integerScale);
+  }
+  return pixels;
+}
+
+function environmentUvToDirection(u, v, rotationRadians = 0) {
+  const angle = (u - rotationRadians / (2 * Math.PI) - 0.5) * 2 * Math.PI;
+  const theta = v * Math.PI;
+  const sinTheta = Math.sin(theta);
+  return [
+    Math.cos(angle) * sinTheta,
+    Math.cos(theta),
+    Math.sin(angle) * sinTheta,
+  ];
+}
+
+function sampleEnvironmentPixelsBilinear(pixels, width, height, u, v) {
+  const wrappedU = ((u % 1) + 1) % 1;
+  const clampedV = clamp(v, 0, 1);
+  const x = wrappedU * width - 0.5;
+  const y = clampedV * height - 0.5;
+  const x0 = ((Math.floor(x) % width) + width) % width;
+  const y0 = clamp(Math.floor(y), 0, height - 1);
+  const x1 = (x0 + 1) % width;
+  const y1 = clamp(y0 + 1, 0, height - 1);
+  const tx = x - Math.floor(x);
+  const ty = y - Math.floor(y);
+  const read = (px, py) => {
+    const offset = (py * width + px) * 4;
+    return [pixels[offset], pixels[offset + 1], pixels[offset + 2], pixels[offset + 3]];
+  };
+  const a = read(x0, y0);
+  const b = read(x1, y0);
+  const c = read(x0, y1);
+  const d = read(x1, y1);
+  const mixPair = (first, second, factor) => first * (1 - factor) + second * factor;
+  return [
+    mixPair(mixPair(a[0], b[0], tx), mixPair(c[0], d[0], tx), ty),
+    mixPair(mixPair(a[1], b[1], tx), mixPair(c[1], d[1], tx), ty),
+    mixPair(mixPair(a[2], b[2], tx), mixPair(c[2], d[2], tx), ty),
+    mixPair(mixPair(a[3], b[3], tx), mixPair(c[3], d[3], tx), ty),
+  ];
+}
+
+function directionToEnvironmentUv(direction, rotationRadians = 0) {
+  const unitDirection = normalize(direction, [0, 1, 0]);
+  const rotationTurns = rotationRadians / (2 * Math.PI);
+  const u = ((((Math.atan2(unitDirection[2], unitDirection[0]) / (2 * Math.PI)) + 0.5 + rotationTurns) % 1) + 1) % 1;
+  const v = Math.acos(clamp(unitDirection[1], -1, 1)) / Math.PI;
+  return [u, clamp(v, 0, 1)];
+}
+
+function sampleEnvironmentRadiance(pixels, width, height, direction, rotationRadians = 0) {
+  const [u, v] = directionToEnvironmentUv(direction, rotationRadians);
+  return sampleEnvironmentPixelsBilinear(pixels, width, height, u, v);
+}
+
+function createFloat16RgbaUploadFromLevels(levels) {
+  return levels.map((level) => {
+    const rowBytes = level.width * 8;
+    const bytesPerRow = alignTo(rowBytes, 256);
+    const bytes = new Uint8Array(bytesPerRow * level.height);
+    const view = new DataView(bytes.buffer);
+    for (let y = 0; y < level.height; y += 1) {
+      for (let x = 0; x < level.width; x += 1) {
+        const sourceOffset = (y * level.width + x) * 4;
+        const targetOffset = y * bytesPerRow + x * 8;
+        view.setUint16(targetOffset, float32ToFloat16Bits(level.data[sourceOffset]), true);
+        view.setUint16(targetOffset + 2, float32ToFloat16Bits(level.data[sourceOffset + 1]), true);
+        view.setUint16(targetOffset + 4, float32ToFloat16Bits(level.data[sourceOffset + 2]), true);
+        view.setUint16(targetOffset + 6, float32ToFloat16Bits(level.data[sourceOffset + 3]), true);
+      }
+    }
+    return Object.freeze({ bytes, bytesPerRow, width: level.width, height: level.height });
+  });
+}
+
+function createPrefilteredEnvironmentLevels(environmentMap, fallbackColor) {
+  const sourcePixels = createLinearEnvironmentPixels(environmentMap, fallbackColor);
+  const sourceWidth = Math.max(1, environmentMap.width);
+  const sourceHeight = Math.max(1, environmentMap.height);
+  const mipLevelCount = Math.max(1, Math.floor(Math.log2(Math.max(sourceWidth, sourceHeight))) + 1);
+  const levels = [
+    Object.freeze({
+      width: sourceWidth,
+      height: sourceHeight,
+      data: sourcePixels,
+    }),
+  ];
+  for (let mipLevel = 1; mipLevel < mipLevelCount; mipLevel += 1) {
+    const width = Math.max(1, sourceWidth >> mipLevel);
+    const height = Math.max(1, sourceHeight >> mipLevel);
+    const roughness = mipLevelCount <= 1 ? 0 : mipLevel / (mipLevelCount - 1);
+    const data = new Float32Array(width * height * 4);
+    const sampleCount = roughness < 0.25 ? 64 : roughness < 0.6 ? 96 : 128;
+    for (let y = 0; y < height; y += 1) {
+      for (let x = 0; x < width; x += 1) {
+        const direction = environmentUvToDirection((x + 0.5) / width, (y + 0.5) / height, environmentMap.rotationRadians);
+        const normal = normalize(direction, [0, 1, 0]);
+        const viewDirection = normal;
+        let totalWeight = 0;
+        const accum = [0, 0, 0];
+        for (let sampleIndex = 0; sampleIndex < sampleCount; sampleIndex += 1) {
+          const xi = hammersley(sampleIndex, sampleCount);
+          const halfVector = importanceSampleGgx(xi, roughness, normal);
+          const viewDotHalf = Math.max(dot(viewDirection, halfVector), 0);
+          const lightDirection = normalize(
+            subtract(scale(halfVector, 2 * viewDotHalf), viewDirection),
+            normal
+          );
+          const nDotL = Math.max(dot(normal, lightDirection), 0);
+          if (nDotL <= 0.000001) {
+            continue;
+          }
+          const radiance = sampleEnvironmentRadiance(
+            sourcePixels,
+            sourceWidth,
+            sourceHeight,
+            lightDirection,
+            environmentMap.rotationRadians
+          );
+          accum[0] += radiance[0] * nDotL;
+          accum[1] += radiance[1] * nDotL;
+          accum[2] += radiance[2] * nDotL;
+          totalWeight += nDotL;
+        }
+        const offset = (y * width + x) * 4;
+        data[offset] = accum[0] / Math.max(totalWeight, 0.000001);
+        data[offset + 1] = accum[1] / Math.max(totalWeight, 0.000001);
+        data[offset + 2] = accum[2] / Math.max(totalWeight, 0.000001);
+        data[offset + 3] = 1;
+      }
+    }
+    levels.push(Object.freeze({ width, height, data }));
+  }
+  return Object.freeze({
+    levels,
+    mipLevelCount,
+    width: sourceWidth,
+    height: sourceHeight,
+  });
+}
+
+function createEnvironmentSamplingTables(environmentMap, fallbackColor) {
+  const pixels = createLinearEnvironmentPixels(environmentMap, fallbackColor);
+  const width = Math.max(1, environmentMap.width);
+  const height = Math.max(1, environmentMap.height);
+  const pdf = new Float32Array(width * height);
+  const marginalCdf = new Float32Array(height);
+  const conditionalCdf = new Float32Array(width * height);
+  const rowSums = new Float32Array(height);
+  let totalWeight = 0;
+  for (let y = 0; y < height; y += 1) {
+    const theta = ((y + 0.5) / height) * Math.PI;
+    const sinTheta = Math.max(Math.sin(theta), 0.0001);
+    let rowWeight = 0;
+    for (let x = 0; x < width; x += 1) {
+      const offset = (y * width + x) * 4;
+      const luminance = pixels[offset] * 0.2126 + pixels[offset + 1] * 0.7152 + pixels[offset + 2] * 0.0722;
+      const weight = Math.max(luminance * sinTheta, 0.000001);
+      pdf[y * width + x] = weight;
+      rowWeight += weight;
+      conditionalCdf[y * width + x] = rowWeight;
+    }
+    rowSums[y] = rowWeight;
+    totalWeight += rowWeight;
+    if (rowWeight > 0) {
+      for (let x = 0; x < width; x += 1) {
+        conditionalCdf[y * width + x] /= rowWeight;
+      }
+    } else {
+      for (let x = 0; x < width; x += 1) {
+        conditionalCdf[y * width + x] = (x + 1) / width;
+      }
+    }
+    marginalCdf[y] = totalWeight;
+  }
+  for (let y = 0; y < height; y += 1) {
+    marginalCdf[y] /= Math.max(totalWeight, 0.000001);
+  }
+  for (let index = 0; index < pdf.length; index += 1) {
+    pdf[index] /= Math.max(totalWeight, 0.000001);
+  }
+  return Object.freeze({
+    width,
+    height,
+    pdf,
+    marginalCdf,
+    conditionalCdf,
+  });
 }
 
 function createEnvironmentMapUploadBytes(environmentMap, fallbackColor) {
@@ -1970,12 +2930,14 @@ function createEnvironmentMapUploadBytes(environmentMap, fallbackColor) {
     }
   }
 
-  return Object.freeze({
+  const upload = Object.freeze({
     bytes,
     bytesPerRow,
     width,
     height,
   });
+  BRDF_LUT_UPLOAD_CACHE.set(cacheKey, upload);
+  return upload;
 }
 
 function createEnvironmentMapResource(device, constants, environmentMap, fallbackColor) {
@@ -1988,9 +2950,13 @@ function createEnvironmentMapResource(device, constants, environmentMap, fallbac
         addressModeV: "clamp-to-edge",
         magFilter: "linear",
         minFilter: "linear",
+        mipmapFilter: "linear",
       }),
       texture: null,
       ownsTexture: false,
+      width: Math.max(1, environmentMap.width),
+      height: Math.max(1, environmentMap.height),
+      mipLevelCount: 1,
     });
   }
 
@@ -2003,17 +2969,94 @@ function createEnvironmentMapResource(device, constants, environmentMap, fallbac
         addressModeV: "clamp-to-edge",
         magFilter: "linear",
         minFilter: "linear",
+        mipmapFilter: "linear",
       }),
       texture: environmentMap.texture,
       ownsTexture: false,
+      width: Math.max(1, environmentMap.width),
+      height: Math.max(1, environmentMap.height),
+      mipLevelCount: 1,
     });
   }
 
-  const upload = createEnvironmentMapUploadBytes(environmentMap, fallbackColor);
+  const prefiltered = createPrefilteredEnvironmentLevels(environmentMap, fallbackColor);
+  const uploads = createFloat16RgbaUploadFromLevels(prefiltered.levels);
   const texture = device.createTexture({
     label: environmentMap.enabled
       ? "plasius.wavefront.environmentMap"
       : "plasius.wavefront.environmentMapFallback",
+    size: { width: prefiltered.width, height: prefiltered.height },
+    format: "rgba16float",
+    mipLevelCount: prefiltered.mipLevelCount,
+    usage: constants.texture.TEXTURE_BINDING | constants.texture.COPY_DST,
+  });
+  uploads.forEach((upload, mipLevel) => {
+    device.queue.writeTexture(
+      { texture, mipLevel },
+      upload.bytes,
+      { bytesPerRow: upload.bytesPerRow, rowsPerImage: upload.height },
+      { width: upload.width, height: upload.height, depthOrArrayLayers: 1 }
+    );
+  });
+  return Object.freeze({
+    view: texture.createView(),
+    sampler: environmentMap.sampler ?? device.createSampler({
+      label: "plasius.wavefront.environmentMapSampler",
+      addressModeU: "repeat",
+      addressModeV: "clamp-to-edge",
+      magFilter: "linear",
+      minFilter: "linear",
+      mipmapFilter: "linear",
+    }),
+    texture,
+    ownsTexture: true,
+    width: prefiltered.width,
+    height: prefiltered.height,
+    mipLevelCount: prefiltered.mipLevelCount,
+  });
+}
+
+function createEnvironmentSamplingTextureResource(device, constants, environmentMap, fallbackColor) {
+  const tables = createEnvironmentSamplingTables(environmentMap, fallbackColor);
+  const rowBytes = tables.width * 8;
+  const bytesPerRow = alignTo(rowBytes, 256);
+  const bytes = new Uint8Array(bytesPerRow * tables.height);
+  const view = new DataView(bytes.buffer);
+  for (let y = 0; y < tables.height; y += 1) {
+    for (let x = 0; x < tables.width; x += 1) {
+      const probability = tables.pdf[y * tables.width + x];
+      const conditional = tables.conditionalCdf[y * tables.width + x];
+      const marginal = tables.marginalCdf[y];
+      const offset = y * bytesPerRow + x * 8;
+      view.setUint16(offset, float32ToFloat16Bits(probability), true);
+      view.setUint16(offset + 2, float32ToFloat16Bits(conditional), true);
+      view.setUint16(offset + 4, float32ToFloat16Bits(marginal), true);
+      view.setUint16(offset + 6, float32ToFloat16Bits(1), true);
+    }
+  }
+  const texture = device.createTexture({
+    label: "plasius.wavefront.environmentSampling",
+    size: { width: tables.width, height: tables.height },
+    format: "rgba16float",
+    usage: constants.texture.TEXTURE_BINDING | constants.texture.COPY_DST,
+  });
+  device.queue.writeTexture(
+    { texture },
+    bytes,
+    { bytesPerRow, rowsPerImage: tables.height },
+    { width: tables.width, height: tables.height, depthOrArrayLayers: 1 }
+  );
+  return Object.freeze({
+    view: texture.createView(),
+    texture,
+    ownsTexture: true,
+  });
+}
+
+function createBrdfLutResource(device, constants, size = DEFAULT_BRDF_LUT_SIZE) {
+  const upload = createBrdfLutUploadBytes(size);
+  const texture = device.createTexture({
+    label: "plasius.wavefront.brdfLut",
     size: { width: upload.width, height: upload.height },
     format: "rgba16float",
     usage: constants.texture.TEXTURE_BINDING | constants.texture.COPY_DST,
@@ -2026,14 +3069,37 @@ function createEnvironmentMapResource(device, constants, environmentMap, fallbac
   );
   return Object.freeze({
     view: texture.createView(),
-    sampler: environmentMap.sampler ?? device.createSampler({
-      label: "plasius.wavefront.environmentMapSampler",
-      addressModeU: "repeat",
+    sampler: device.createSampler({
+      label: "plasius.wavefront.brdfLutSampler",
+      addressModeU: "clamp-to-edge",
       addressModeV: "clamp-to-edge",
       magFilter: "linear",
       minFilter: "linear",
     }),
     texture,
+    ownsTexture: true,
+    width: upload.width,
+    height: upload.height,
+  });
+}
+
+function createAtlasTextureResource(device, constants, atlas, label) {
+  const upload = createRgba8TextureUpload(atlas);
+  const texture = device.createTexture({
+    label,
+    size: { width: upload.width, height: upload.height },
+    format: "rgba8unorm",
+    usage: constants.texture.TEXTURE_BINDING | constants.texture.COPY_DST,
+  });
+  device.queue.writeTexture(
+    { texture },
+    upload.bytes,
+    { bytesPerRow: upload.bytesPerRow, rowsPerImage: upload.height },
+    { width: upload.width, height: upload.height, depthOrArrayLayers: 1 }
+  );
+  return Object.freeze({
+    texture,
+    view: texture.createView(),
     ownsTexture: true,
   });
 }
@@ -2084,6 +3150,26 @@ async function createComputePipeline(device, shaderModule, layout, entryPoint, l
   }
 }
 
+async function assertShaderModuleCompiles(shaderModule, label) {
+  if (typeof shaderModule?.compilationInfo !== "function") {
+    return;
+  }
+  const info = await shaderModule.compilationInfo();
+  const messages = Array.isArray(info?.messages) ? info.messages : [];
+  const errors = messages.filter((message) => message?.type === "error");
+  if (errors.length <= 0) {
+    return;
+  }
+  const diagnostics = errors
+    .map((message) => {
+      const line = Number.isFinite(message.lineNum) ? message.lineNum : "?";
+      const column = Number.isFinite(message.linePos) ? message.linePos : "?";
+      return `line ${line}:${column} ${message.message}`;
+    })
+    .join("\n");
+  throw new Error(`WGSL compilation preflight failed for ${label}:\n${diagnostics}`);
+}
+
 async function createRenderPipeline(device, descriptor) {
   if (typeof device.createRenderPipelineAsync === "function") {
     return device.createRenderPipelineAsync(descriptor);
@@ -2093,6 +3179,7 @@ async function createRenderPipeline(device, descriptor) {
 
 const WAVEFRONT_COMPUTE_WGSL = `
 const RAY_FLAG_GUIDED_EMISSIVE: u32 = 1u;
+const RAY_FLAG_DELTA_SAMPLE: u32 = 2u;
 
 struct RayRecord {
   rayId: u32,
@@ -2118,11 +3205,12 @@ struct HitRecord {
   primitiveId: u32,
   materialRefId: u32,
   mediumRefId: u32,
+  materialSlot: u32,
   pad0: u32,
   pad1: u32,
-  pad2: u32,
   distance: f32,
-  pad3: vec3<f32>,
+  occlusion: f32,
+  pad2: vec2<f32>,
   position: vec4<f32>,
   geometricNormal: vec4<f32>,
   shadingNormal: vec4<f32>,
@@ -2131,6 +3219,9 @@ struct HitRecord {
   color: vec4<f32>,
   emission: vec4<f32>,
   material: vec4<f32>,
+  materialResponse: vec4<f32>,
+  materialExtension: vec4<f32>,
+  specularColor: vec4<f32>,
 };
 
 struct SceneObject {
@@ -2143,6 +3234,9 @@ struct SceneObject {
   color: vec4<f32>,
   emission: vec4<f32>,
   material: vec4<f32>,
+  materialResponse: vec4<f32>,
+  materialExtension: vec4<f32>,
+  specularColor: vec4<f32>,
 };
 
 struct TriangleRecord {
@@ -2152,7 +3246,7 @@ struct TriangleRecord {
   flags: u32,
   materialRefId: u32,
   mediumRefId: u32,
-  pad0: u32,
+  materialSlot: u32,
   pad1: u32,
   v0: vec4<f32>,
   v1: vec4<f32>,
@@ -2165,6 +3259,15 @@ struct TriangleRecord {
   color: vec4<f32>,
   emission: vec4<f32>,
   material: vec4<f32>,
+  materialResponse: vec4<f32>,
+  materialExtension: vec4<f32>,
+  specularColor: vec4<f32>,
+  baseColorAtlas: vec4<f32>,
+  metallicRoughnessAtlas: vec4<f32>,
+  normalAtlas: vec4<f32>,
+  occlusionAtlas: vec4<f32>,
+  emissiveAtlas: vec4<f32>,
+  textureSettings: vec4<f32>,
 };
 
 struct BvhNode {
@@ -2185,10 +3288,10 @@ struct BvhLeafRef {
 
 struct ScatterResult {
   direction: vec4<f32>,
+  pdf: f32,
   flags: u32,
   pad0: u32,
   pad1: u32,
-  pad2: u32,
 };
 
 struct MeshVertex {
@@ -2209,10 +3312,19 @@ struct MeshRange {
   triangleCount: u32,
   firstVertex: u32,
   vertexCount: u32,
-  pad0: u32,
+  materialSlot: u32,
   color: vec4<f32>,
   emission: vec4<f32>,
   material: vec4<f32>,
+  materialResponse: vec4<f32>,
+  materialExtension: vec4<f32>,
+  specularColor: vec4<f32>,
+  baseColorAtlas: vec4<f32>,
+  metallicRoughnessAtlas: vec4<f32>,
+  normalAtlas: vec4<f32>,
+  occlusionAtlas: vec4<f32>,
+  emissiveAtlas: vec4<f32>,
+  textureSettings: vec4<f32>,
 };
 
 struct FrameConfig {
@@ -2253,6 +3365,7 @@ struct FrameConfig {
   _portalPad1: u32,
   environmentMapSettings: vec4<f32>,
   pathResolveSettings: vec4<f32>,
+  environmentMapMeta: vec4<f32>,
 };
 
 struct Counters {
@@ -2315,6 +3428,15 @@ struct EnvironmentPortal {
 @group(0) @binding(20) var environmentMapTexture: texture_2d<f32>;
 @group(0) @binding(21) var environmentMapSampler: sampler;
 @group(0) @binding(22) var<storage, read_write> pathVertices: array<vec4<f32>>;
+@group(0) @binding(23) var baseColorAtlasTexture: texture_2d<f32>;
+@group(0) @binding(24) var metallicRoughnessAtlasTexture: texture_2d<f32>;
+@group(0) @binding(25) var normalAtlasTexture: texture_2d<f32>;
+@group(0) @binding(26) var occlusionAtlasTexture: texture_2d<f32>;
+@group(0) @binding(27) var emissiveAtlasTexture: texture_2d<f32>;
+@group(0) @binding(28) var materialAtlasSampler: sampler;
+@group(0) @binding(29) var brdfLutTexture: texture_2d<f32>;
+@group(0) @binding(30) var brdfLutSampler: sampler;
+@group(0) @binding(31) var environmentSamplingTexture: texture_2d<f32>;
 
 fn hash_u32(value: u32) -> u32 {
   var x = value;
@@ -2351,12 +3473,152 @@ fn safe_normalize(value: vec3<f32>, fallback: vec3<f32>) -> vec3<f32> {
   return value / len;
 }
 
+struct TangentBasis {
+  tangent: vec3<f32>,
+  bitangent: vec3<f32>,
+};
+
+struct SurfaceMaterialSample {
+  color: vec4<f32>,
+  emission: vec4<f32>,
+  material: vec4<f32>,
+  materialResponse: vec4<f32>,
+  materialExtension: vec4<f32>,
+  specularColor: vec4<f32>,
+  shadingNormal: vec3<f32>,
+  occlusion: f32,
+};
+
+fn srgb_to_linear_channel(value: f32) -> f32 {
+  if (value <= 0.04045) {
+    return value / 12.92;
+  }
+  return pow((value + 0.055) / 1.055, 2.4);
+}
+
+fn srgb_to_linear_vec3(value: vec3<f32>) -> vec3<f32> {
+  return vec3<f32>(
+    srgb_to_linear_channel(value.x),
+    srgb_to_linear_channel(value.y),
+    srgb_to_linear_channel(value.z)
+  );
+}
+
+fn wrap_uv(uv: vec2<f32>) -> vec2<f32> {
+  return fract(fract(uv) + vec2<f32>(1.0));
+}
+
+fn atlas_sample_uv(rect: vec4<f32>, uv: vec2<f32>) -> vec2<f32> {
+  let local = wrap_uv(uv);
+  let clamped = clamp(local, vec2<f32>(0.001), vec2<f32>(0.999));
+  return rect.xy + clamped * rect.zw;
+}
+
+fn sample_atlas(textureRef: texture_2d<f32>, rect: vec4<f32>, uv: vec2<f32>) -> vec4<f32> {
+  return textureSampleLevel(textureRef, materialAtlasSampler, atlas_sample_uv(rect, uv), 0.0);
+}
+
+fn build_triangle_tangent_basis(
+  triangle: TriangleRecord,
+  fallbackNormal: vec3<f32>
+) -> TangentBasis {
+  let edge1 = triangle.v1.xyz - triangle.v0.xyz;
+  let edge2 = triangle.v2.xyz - triangle.v0.xyz;
+  let uv0 = triangle.uv0uv1.xy;
+  let uv1 = triangle.uv0uv1.zw;
+  let uv2 = triangle.uv2Pad.xy;
+  let deltaUv1 = uv1 - uv0;
+  let deltaUv2 = uv2 - uv0;
+  let determinant = deltaUv1.x * deltaUv2.y - deltaUv1.y * deltaUv2.x;
+  if (abs(determinant) <= 0.000001) {
+    let tangentFallback = select(vec3<f32>(0.0, 1.0, 0.0), vec3<f32>(1.0, 0.0, 0.0), abs(fallbackNormal.y) >= 0.999);
+    let tangent = safe_normalize(cross(tangentFallback, fallbackNormal), vec3<f32>(1.0, 0.0, 0.0));
+    let bitangent = safe_normalize(cross(fallbackNormal, tangent), vec3<f32>(0.0, 0.0, 1.0));
+    return TangentBasis(tangent, bitangent);
+  }
+  let inverse = 1.0 / determinant;
+  let tangent = safe_normalize(
+    inverse * (edge1 * deltaUv2.y - edge2 * deltaUv1.y),
+    vec3<f32>(1.0, 0.0, 0.0)
+  );
+  let bitangent = safe_normalize(
+    inverse * (-edge1 * deltaUv2.x + edge2 * deltaUv1.x),
+    vec3<f32>(0.0, 0.0, 1.0)
+  );
+  return TangentBasis(tangent, bitangent);
+}
+
+fn sample_surface_material(
+  triangle: TriangleRecord,
+  uv: vec2<f32>,
+  geometricNormal: vec3<f32>,
+  shadingNormal: vec3<f32>
+) -> SurfaceMaterialSample {
+  let baseColorTexel = sample_atlas(baseColorAtlasTexture, triangle.baseColorAtlas, uv);
+  let baseColor = vec4<f32>(
+    clamp(triangle.color.rgb * srgb_to_linear_vec3(baseColorTexel.rgb), vec3<f32>(0.0), vec3<f32>(1.0)),
+    clamp(triangle.color.a * baseColorTexel.a, 0.0, 1.0)
+  );
+  let metallicRoughnessTexel = sample_atlas(
+    metallicRoughnessAtlasTexture,
+    triangle.metallicRoughnessAtlas,
+    uv
+  );
+  let normalTexel = sample_atlas(normalAtlasTexture, triangle.normalAtlas, uv);
+  let occlusionTexel = sample_atlas(occlusionAtlasTexture, triangle.occlusionAtlas, uv);
+  let emissiveTexel = sample_atlas(emissiveAtlasTexture, triangle.emissiveAtlas, uv);
+  let normalScale = clamp(triangle.textureSettings.x, 0.0, 1.0);
+  let tangentBasis = build_triangle_tangent_basis(triangle, geometricNormal);
+  let tangentNormal = safe_normalize(
+    vec3<f32>(
+      normalTexel.x * 2.0 - 1.0,
+      normalTexel.y * 2.0 - 1.0,
+      1.0 + ((normalTexel.z * 2.0 - 1.0) - 1.0) * normalScale
+    ),
+    vec3<f32>(0.0, 0.0, 1.0)
+  );
+  let mappedNormal = safe_normalize(
+    tangentBasis.tangent * tangentNormal.x +
+      tangentBasis.bitangent * tangentNormal.y +
+      shadingNormal * tangentNormal.z,
+    shadingNormal
+  );
+  let emission = vec4<f32>(
+    max(
+      triangle.emission.rgb *
+        srgb_to_linear_vec3(emissiveTexel.rgb) *
+        max(triangle.textureSettings.z, 0.0),
+      vec3<f32>(0.0)
+    ),
+    clamp(triangle.emission.a * emissiveTexel.a, 0.0, 1.0)
+  );
+  return SurfaceMaterialSample(
+    baseColor,
+    emission,
+    vec4<f32>(
+      clamp(triangle.material.x * metallicRoughnessTexel.y, 0.0, 1.0),
+      clamp(triangle.material.y * metallicRoughnessTexel.z, 0.0, 1.0),
+      clamp(triangle.material.z * baseColor.a, 0.0, 1.0),
+      clamp(triangle.material.w, 1.0, 3.0)
+    ),
+    triangle.materialResponse,
+    triangle.materialExtension,
+    triangle.specularColor,
+    repair_shading_normal(geometricNormal, mappedNormal),
+    clamp(occlusionTexel.x * max(triangle.textureSettings.y, 0.0), 0.0, 1.0)
+  );
+}
+
 fn saturate(value: f32) -> f32 {
   return clamp(value, 0.0, 1.0);
 }
 
 fn max_component(value: vec3<f32>) -> f32 {
   return max(max(value.x, value.y), value.z);
+}
+
+fn radiance_luminance(value: vec3<f32>) -> f32 {
+  return dot(value, vec3<f32>(0.2126, 0.7152, 0.0722));
 }
 
 fn environment_map_enabled() -> bool {
@@ -2487,6 +3749,321 @@ fn environment_radiance(origin: vec3<f32>, direction: vec3<f32>) -> vec3<f32> {
     select(vec3<f32>(1.0), portalScale, portalHit);
 }
 
+fn direct_environment_radiance(origin: vec3<f32>, direction: vec3<f32>) -> vec3<f32> {
+  let rayDirection = safe_normalize(direction, vec3<f32>(0.0, 1.0, 0.0));
+  let portalScale = environment_portal_radiance_scale(origin, rayDirection);
+  let portalHit = max_component(portalScale) > 0.0001;
+  if (
+    config.environmentPortalCount > 0u &&
+    config.environmentPortalMode == 2u &&
+    !portalHit
+  ) {
+    return vec3<f32>(0.0);
+  }
+  return base_environment_radiance(rayDirection) *
+    select(vec3<f32>(1.0), portalScale, portalHit);
+}
+
+fn radical_inverse_vdc(bitsValue: u32) -> f32 {
+  var bits = bitsValue;
+  bits = (bits << 16u) | (bits >> 16u);
+  bits = ((bits & 0x55555555u) << 1u) | ((bits & 0xaaaaaaaau) >> 1u);
+  bits = ((bits & 0x33333333u) << 2u) | ((bits & 0xccccccccu) >> 2u);
+  bits = ((bits & 0x0f0f0f0fu) << 4u) | ((bits & 0xf0f0f0f0u) >> 4u);
+  bits = ((bits & 0x00ff00ffu) << 8u) | ((bits & 0xff00ff00u) >> 8u);
+  return f32(bits) * 2.3283064365386963e-10;
+}
+
+fn hammersley_2d(index: u32, count: u32) -> vec2<f32> {
+  return vec2<f32>(f32(index) / max(f32(count), 1.0), radical_inverse_vdc(index));
+}
+
+fn build_basis_tangent(normal: vec3<f32>) -> vec3<f32> {
+  let tangentFallback = select(vec3<f32>(0.0, 1.0, 0.0), vec3<f32>(1.0, 0.0, 0.0), abs(normal.y) >= 0.999);
+  return safe_normalize(cross(tangentFallback, normal), vec3<f32>(1.0, 0.0, 0.0));
+}
+
+fn local_to_world(local: vec3<f32>, normal: vec3<f32>) -> vec3<f32> {
+  let tangent = build_basis_tangent(normal);
+  let bitangent = safe_normalize(cross(normal, tangent), vec3<f32>(0.0, 0.0, 1.0));
+  return safe_normalize(tangent * local.x + bitangent * local.y + normal * local.z, normal);
+}
+
+fn cosine_sample_hemisphere(sample: vec2<f32>, normal: vec3<f32>) -> vec3<f32> {
+  let phi = 6.28318530718 * sample.x;
+  let radius = sqrt(sample.y);
+  let x = cos(phi) * radius;
+  let y = sin(phi) * radius;
+  let z = sqrt(max(0.0, 1.0 - sample.y));
+  return local_to_world(vec3<f32>(x, y, z), normal);
+}
+
+fn importance_sample_ggx(sample: vec2<f32>, roughness: f32, normal: vec3<f32>) -> vec3<f32> {
+  let alpha = max(roughness * roughness, 0.0001);
+  let phi = 6.28318530718 * sample.x;
+  let cosTheta = sqrt((1.0 - sample.y) / max(1.0 + (alpha * alpha - 1.0) * sample.y, 0.0001));
+  let sinTheta = sqrt(max(0.0, 1.0 - cosTheta * cosTheta));
+  let localHalf = vec3<f32>(cos(phi) * sinTheta, sin(phi) * sinTheta, cosTheta);
+  return local_to_world(localHalf, normal);
+}
+
+fn distribution_ggx(normal: vec3<f32>, halfVector: vec3<f32>, roughness: f32) -> f32 {
+  let alpha = max(roughness * roughness, 0.0001);
+  let alpha2 = alpha * alpha;
+  let nDotH = saturate(dot(normal, halfVector));
+  let denominator = nDotH * nDotH * (alpha2 - 1.0) + 1.0;
+  return alpha2 / max(3.14159265359 * denominator * denominator, 0.000001);
+}
+
+fn geometry_schlick_ggx(nDotValue: f32, roughness: f32) -> f32 {
+  let k = ((roughness + 1.0) * (roughness + 1.0)) / 8.0;
+  return nDotValue / max(nDotValue * (1.0 - k) + k, 0.000001);
+}
+
+fn geometry_smith(normal: vec3<f32>, viewDirection: vec3<f32>, lightDirection: vec3<f32>, roughness: f32) -> f32 {
+  let nDotV = saturate(dot(normal, viewDirection));
+  let nDotL = saturate(dot(normal, lightDirection));
+  return geometry_schlick_ggx(nDotV, roughness) * geometry_schlick_ggx(nDotL, roughness);
+}
+
+fn fresnel_schlick(cosine: f32, f0: vec3<f32>) -> vec3<f32> {
+  return f0 + (vec3<f32>(1.0) - f0) * pow(1.0 - cosine, 5.0);
+}
+
+fn sample_brdf_lut(nDotV: f32, roughness: f32) -> vec2<f32> {
+  let uv = vec2<f32>(clamp(nDotV, 0.0, 1.0), clamp(roughness, 0.0, 1.0));
+  return textureSampleLevel(brdfLutTexture, brdfLutSampler, uv, 0.0).xy;
+}
+
+fn prefiltered_environment_radiance(direction: vec3<f32>, roughness: f32) -> vec3<f32> {
+  let uv = environment_map_uv(direction);
+  let maxLevel = max(config.environmentMapMeta.z - 1.0, 0.0);
+  let lod = clamp(roughness, 0.0, 1.0) * maxLevel;
+  let texel = max(textureSampleLevel(environmentMapTexture, environmentMapSampler, uv, lod).rgb, vec3<f32>(0.0));
+  return texel * max(config.environmentMapSettings.y, 0.0);
+}
+
+fn environment_pdf_dimensions() -> vec2<u32> {
+  return vec2<u32>(
+    max(u32(config.environmentMapMeta.x), 1u),
+    max(u32(config.environmentMapMeta.y), 1u)
+  );
+}
+
+fn environment_sampling_texel(x: u32, y: u32) -> vec4<f32> {
+  return textureLoad(environmentSamplingTexture, vec2<i32>(i32(x), i32(y)), 0);
+}
+
+fn environment_pdf_texel(x: u32, y: u32) -> f32 {
+  return environment_sampling_texel(x, y).x;
+}
+
+fn environment_row_cdf_texel(y: u32) -> f32 {
+  return environment_sampling_texel(0u, y).z;
+}
+
+fn environment_column_cdf_texel(x: u32, y: u32) -> f32 {
+  return environment_sampling_texel(x, y).y;
+}
+
+fn environment_direction_pdf(direction: vec3<f32>) -> f32 {
+  let rayDirection = safe_normalize(direction, vec3<f32>(0.0, 1.0, 0.0));
+  let uv = environment_map_uv(rayDirection);
+  let dimensions = environment_pdf_dimensions();
+  let width = max(f32(dimensions.x), 1.0);
+  let height = max(f32(dimensions.y), 1.0);
+  let x = min(u32(uv.x * width), dimensions.x - 1u);
+  let y = min(u32(uv.y * height), dimensions.y - 1u);
+  let discretePdf = max(environment_pdf_texel(x, y), 0.0);
+  let sinTheta = sqrt(max(1.0 - rayDirection.y * rayDirection.y, 0.0));
+  let solidAngle = max((2.0 * 3.14159265359 * 3.14159265359 * sinTheta) / (width * height), 0.000001);
+  return discretePdf / solidAngle;
+}
+
+fn sample_row_cdf(count: u32, sampleValue: f32) -> u32 {
+  if (count == 0u) {
+    return 0u;
+  }
+  var low = 0u;
+  var high = count - 1u;
+  loop {
+    if (low >= high) {
+      break;
+    }
+    let mid = (low + high) / 2u;
+    let cdfValue = environment_row_cdf_texel(mid);
+    if (sampleValue <= cdfValue) {
+      high = mid;
+    } else {
+      low = mid + 1u;
+    }
+  }
+  return min(low, count - 1u);
+}
+
+fn sample_column_cdf(row: u32, count: u32, sampleValue: f32) -> u32 {
+  if (count == 0u) {
+    return 0u;
+  }
+  var low = 0u;
+  var high = count - 1u;
+  loop {
+    if (low >= high) {
+      break;
+    }
+    let mid = (low + high) / 2u;
+    let cdfValue = environment_column_cdf_texel(mid, row);
+    if (sampleValue <= cdfValue) {
+      high = mid;
+    } else {
+      low = mid + 1u;
+    }
+  }
+  return min(low, count - 1u);
+}
+
+struct EnvironmentSample {
+  direction: vec3<f32>,
+  radiance: vec3<f32>,
+  pdf: f32,
+};
+
+fn sample_environment_importance(sample: vec2<f32>) -> EnvironmentSample {
+  let dimensions = environment_pdf_dimensions();
+  let row = sample_row_cdf(dimensions.y, sample.y);
+  let column = sample_column_cdf(row, dimensions.x, sample.x);
+  let uv = vec2<f32>(
+    (f32(column) + 0.5) / max(f32(dimensions.x), 1.0),
+    (f32(row) + 0.5) / max(f32(dimensions.y), 1.0)
+  );
+  let theta = uv.y * 3.14159265359;
+  let phi = (uv.x - 0.5 - config.environmentMapSettings.z / 6.28318530718) * 6.28318530718;
+  let sinTheta = sin(theta);
+  let direction = vec3<f32>(cos(phi) * sinTheta, cos(theta), sin(phi) * sinTheta);
+  let pdf = environment_direction_pdf(direction);
+  return EnvironmentSample(direction, base_environment_radiance(direction), pdf);
+}
+
+fn power_heuristic(pdfA: f32, pdfB: f32) -> f32 {
+  let a2 = pdfA * pdfA;
+  let b2 = pdfB * pdfB;
+  return a2 / max(a2 + b2, 0.000001);
+}
+
+fn visible_environment_radiance(origin: vec3<f32>, direction: vec3<f32>) -> vec3<f32> {
+  let rayDirection = safe_normalize(direction, vec3<f32>(0.0, 1.0, 0.0));
+  let visible = !scene_visibility_blocked(origin, rayDirection, 1000000.0);
+  return select(vec3<f32>(0.0), direct_environment_radiance(origin, rayDirection), visible);
+}
+
+fn glossy_environment_direction(
+  incidentDirection: vec3<f32>,
+  normal: vec3<f32>,
+  roughness: f32,
+  normalBlendScale: f32
+) -> vec3<f32> {
+  let reflectionDirection = reflect(incidentDirection, normal);
+  let blend = clamp(roughness * roughness * normalBlendScale, 0.0, 0.92);
+  return safe_normalize(mix(reflectionDirection, normal, blend), normal);
+}
+
+fn surface_glossiness(hit: HitRecord) -> f32 {
+  let roughness = clamp(hit.material.x, 0.0, 1.0);
+  let metallic = clamp(hit.material.y, 0.0, 1.0);
+  let sheen = clamp(max_component(hit.materialResponse.xyz), 0.0, 1.0);
+  let clearcoat = clamp(hit.materialResponse.w, 0.0, 1.0);
+  let specularWeight = clamp(hit.materialExtension.y, 0.0, 1.0);
+  let transmission = clamp(hit.materialExtension.z, 0.0, 1.0);
+  let baseGloss =
+    max(
+      clearcoat,
+      max(sheen * 0.72, max(specularWeight * (0.38 + metallic * 0.62), transmission))
+    );
+  return clamp(baseGloss * (1.0 - roughness * 0.72) + metallic * (1.0 - roughness) * 0.35, 0.0, 1.0);
+}
+
+fn surface_specular_f0(hit: HitRecord, surfaceColor: vec3<f32>) -> vec3<f32> {
+  let metallic = clamp(hit.material.y, 0.0, 1.0);
+  let specularWeight = clamp(hit.materialExtension.y, 0.0, 1.0);
+  let specularColor = clamp(hit.specularColor.xyz, vec3<f32>(0.0), vec3<f32>(1.0));
+  let dielectricF0 = vec3<f32>(0.04) * specularWeight * specularColor;
+  return mix(dielectricF0, surfaceColor, metallic);
+}
+
+fn surface_bsdf_sampling_weights(hit: HitRecord) -> vec3<f32> {
+  let metallic = clamp(hit.material.y, 0.0, 1.0);
+  let clearcoat = clamp(hit.materialResponse.w, 0.0, 1.0);
+  let specularWeight = clamp(hit.materialExtension.y, 0.0, 1.0);
+  let diffuseWeight = clamp(
+    (1.0 - metallic) * max(1.0 - specularWeight * 0.5 - clearcoat * 0.25, 0.15),
+    0.0,
+    1.0
+  );
+  let specWeight = clamp(max(metallic, specularWeight * 0.75) * (1.0 - clearcoat * 0.5), 0.0, 1.0);
+  let clearcoatWeight = clamp(clearcoat, 0.0, 1.0);
+  let totalWeight = max(diffuseWeight + specWeight + clearcoatWeight, 0.000001);
+  return vec3<f32>(
+    diffuseWeight / totalWeight,
+    specWeight / totalWeight,
+    clearcoatWeight / totalWeight
+  );
+}
+
+fn evaluate_surface_bsdf(hit: HitRecord, viewDirection: vec3<f32>, lightDirection: vec3<f32>) -> vec3<f32> {
+  let normal = safe_normalize(hit.shadingNormal.xyz, vec3<f32>(0.0, 1.0, 0.0));
+  let surfaceColor = clamp(max(hit.color.xyz, config.ambientColor.xyz * 0.35), vec3<f32>(0.0), vec3<f32>(1.0));
+  let roughness = clamp(hit.material.x, 0.0, 1.0);
+  let metallic = clamp(hit.material.y, 0.0, 1.0);
+  let clearcoat = clamp(hit.materialResponse.w, 0.0, 1.0);
+  let clearcoatRoughness = clamp(hit.materialExtension.x, 0.0, 1.0);
+  let occlusion = clamp(hit.occlusion, 0.0, 1.0);
+  let nDotV = saturate(dot(normal, viewDirection));
+  let nDotL = saturate(dot(normal, lightDirection));
+  if (nDotV <= 0.0 || nDotL <= 0.0) {
+    return vec3<f32>(0.0);
+  }
+  let halfVector = safe_normalize(viewDirection + lightDirection, normal);
+  let vDotH = saturate(dot(viewDirection, halfVector));
+  let f0 = surface_specular_f0(hit, surfaceColor);
+  let fresnel = fresnel_schlick(vDotH, f0);
+  let distribution = distribution_ggx(normal, halfVector, roughness);
+  let geometry = geometry_smith(normal, viewDirection, lightDirection, roughness);
+  let specular = (distribution * geometry * fresnel) / max(4.0 * nDotV * nDotL, 0.000001);
+  let diffuseWeight = (1.0 - metallic) * (1.0 - clearcoat * 0.24) * (1.0 - clamp(max_component(fresnel), 0.0, 0.98));
+  let diffuse = surfaceColor * diffuseWeight / 3.14159265359;
+  let clearcoatHalf = safe_normalize(viewDirection + lightDirection, normal);
+  let clearcoatDistribution = distribution_ggx(normal, clearcoatHalf, max(clearcoatRoughness, 0.02));
+  let clearcoatGeometry = geometry_smith(normal, viewDirection, lightDirection, max(clearcoatRoughness, 0.02));
+  let clearcoatFresnel = fresnel_schlick(saturate(dot(viewDirection, clearcoatHalf)), vec3<f32>(0.04));
+  let clearcoatTerm =
+    (clearcoatDistribution * clearcoatGeometry * clearcoatFresnel) /
+    max(4.0 * nDotV * nDotL, 0.000001) *
+    clearcoat;
+  return (diffuse + specular + clearcoatTerm) * mix(0.42, 1.0, occlusion);
+}
+
+fn diffuse_pdf(normal: vec3<f32>, lightDirection: vec3<f32>) -> f32 {
+  return saturate(dot(normal, lightDirection)) / 3.14159265359;
+}
+
+fn ggx_pdf(normal: vec3<f32>, viewDirection: vec3<f32>, lightDirection: vec3<f32>, roughness: f32) -> f32 {
+  let halfVector = safe_normalize(viewDirection + lightDirection, normal);
+  let nDotH = saturate(dot(normal, halfVector));
+  let vDotH = saturate(dot(viewDirection, halfVector));
+  let distribution = distribution_ggx(normal, halfVector, roughness);
+  return (distribution * nDotH) / max(4.0 * vDotH, 0.000001);
+}
+
+fn evaluate_surface_bsdf_pdf(hit: HitRecord, viewDirection: vec3<f32>, lightDirection: vec3<f32>) -> f32 {
+  let normal = safe_normalize(hit.shadingNormal.xyz, vec3<f32>(0.0, 1.0, 0.0));
+  let roughness = clamp(hit.material.x, 0.0, 1.0);
+  let weights = surface_bsdf_sampling_weights(hit);
+  let diffuseTerm = diffuse_pdf(normal, lightDirection);
+  let specTerm = ggx_pdf(normal, viewDirection, lightDirection, max(roughness, 0.02));
+  let clearcoatTerm = ggx_pdf(normal, viewDirection, lightDirection, max(clamp(hit.materialExtension.x, 0.0, 1.0), 0.02));
+  return weights.x * diffuseTerm + weights.y * specTerm + weights.z * clearcoatTerm;
+}
+
 fn gated_environment_radiance(origin: vec3<f32>, direction: vec3<f32>) -> vec3<f32> {
   let portalScale = environment_portal_radiance_scale(origin, safe_normalize(direction, vec3<f32>(0.0, 1.0, 0.0)));
   if (
@@ -2502,9 +4079,45 @@ fn gated_environment_radiance(origin: vec3<f32>, direction: vec3<f32>) -> vec3<f
 fn surface_path_response(hit: HitRecord) -> vec3<f32> {
   let color = clamp(hit.color.xyz, vec3<f32>(0.0), vec3<f32>(1.0));
   let opacity = clamp(hit.material.z, 0.0, 1.0);
+  let occlusion = clamp(hit.occlusion, 0.0, 1.0);
   let materialEnergy = select(0.68, 0.92, hit.materialKind == 1u || hit.materialKind == 2u);
   let transparentEnergy = select(materialEnergy, 0.9, hit.hitType == 3u);
-  return mix(vec3<f32>(1.0), color, max(opacity, 0.18)) * transparentEnergy;
+  return mix(vec3<f32>(1.0), color, max(opacity, 0.18)) * transparentEnergy * mix(0.55, 1.0, occlusion);
+}
+
+fn bounded_path_response_luminance(ray: RayRecord, hit: HitRecord) -> f32 {
+  let daylightFloor = max(config.pathResolveSettings.y, 0.0) * 0.08;
+  let hdriFloor = max(config.environmentMapSettings.w, 0.0) * 0.02;
+  let sceneFloor = max(daylightFloor, hdriFloor);
+  if (sceneFloor <= 0.000001) {
+    return 0.0;
+  }
+  let bounceRatio = select(
+    0.0,
+    f32(ray.bounce) / max(f32(config.maxDepth - 1u), 1.0),
+    config.maxDepth > 1u
+  );
+  let bounceScale = 1.0 - bounceRatio * 0.55;
+  let materialScale = select(1.0, 0.34, hit.materialKind == 1u || hit.materialKind == 2u);
+  let transparentScale = select(materialScale, 0.58, hit.hitType == 3u);
+  let opacityScale = mix(0.55, 1.0, clamp(hit.material.z, 0.0, 1.0));
+  return sceneFloor * bounceScale * transparentScale * opacityScale;
+}
+
+fn stabilize_surface_path_response(ray: RayRecord, hit: HitRecord, response: vec3<f32>) -> vec3<f32> {
+  let minimumLuminance = bounded_path_response_luminance(ray, hit);
+  let responseLuminance = radiance_luminance(response);
+  if (minimumLuminance <= 0.000001 || responseLuminance >= minimumLuminance) {
+    return response;
+  }
+  let tintBase = max(response, max(hit.color.xyz * 0.65, config.ambientColor.xyz * 0.35));
+  let tint = tintBase / max(max_component(tintBase), 0.0001);
+  let lifted = select(
+    tint * minimumLuminance,
+    response * (minimumLuminance / max(responseLuminance, 0.0001)),
+    responseLuminance > 0.0001
+  );
+  return clamp(lifted, vec3<f32>(0.0), vec3<f32>(0.98));
 }
 
 fn sunlit_baseline_radiance(normal: vec3<f32>) -> vec3<f32> {
@@ -2523,12 +4136,24 @@ fn sunlit_baseline_radiance(normal: vec3<f32>) -> vec3<f32> {
   return clamp_sample_radiance(sunTint * baseline * skyFacing * directionalWeight * 0.04);
 }
 
-fn terminal_surface_environment_source(hit: HitRecord) -> vec3<f32> {
+fn terminal_surface_environment_source(ray: RayRecord, hit: HitRecord) -> vec3<f32> {
   let normal = safe_normalize(hit.shadingNormal.xyz, vec3<f32>(0.0, 1.0, 0.0));
-  let normalEnvironment = gated_environment_radiance(
-    hit.position.xyz + normal * 0.003,
-    normal
+  let origin = hit.position.xyz + normal * 0.003;
+  let roughness = clamp(hit.material.x, 0.0, 1.0);
+  let glossiness = surface_glossiness(hit);
+  let normalEnvironment = gated_environment_radiance(origin, normal);
+  let viewDirection = safe_normalize(-ray.direction.xyz, normal);
+  let reflectionDirection = glossy_environment_direction(
+    ray.direction.xyz,
+    normal,
+    roughness,
+    mix(0.88, 0.38, glossiness)
   );
+  let reflectionEnvironment = prefiltered_environment_radiance(reflectionDirection, roughness);
+  let surfaceColor = clamp(max(hit.color.xyz, config.ambientColor.xyz * 0.35), vec3<f32>(0.0), vec3<f32>(1.0));
+  let f0 = surface_specular_f0(hit, surfaceColor);
+  let brdfTerm = sample_brdf_lut(saturate(dot(normal, viewDirection)), roughness);
+  let specularEnvironment = reflectionEnvironment * (f0 * brdfTerm.x + vec3<f32>(brdfTerm.y));
   let sunlitFloor = sunlit_baseline_radiance(normal);
   let ambientFloor = select(
     max(config.ambientColor.xyz, sunlitFloor * 0.82),
@@ -2540,17 +4165,23 @@ fn terminal_surface_environment_source(hit: HitRecord) -> vec3<f32> {
     max(config.environmentMapSettings.w, max(0.12, config.pathResolveSettings.y * 0.42)),
     environment_map_enabled()
   );
-  let environmentFloor = max(ambientFloor, max(sunlitFloor, normalEnvironment * environmentInfluence));
+  let glossyEnvironment = max(
+    normalEnvironment,
+    max(reflectionEnvironment * mix(0.24, 0.92, glossiness), specularEnvironment)
+  );
+  let environmentFloor = max(ambientFloor, max(sunlitFloor, glossyEnvironment * environmentInfluence));
   let materialFloor = select(0.7, 1.0, hit.materialKind == 0u || hit.materialKind == 3u);
   return clamp_sample_radiance(environmentFloor * materialFloor);
 }
 
 fn terminal_surface_environment_contribution(ray: RayRecord, hit: HitRecord) -> vec3<f32> {
   let surfaceColor = max(hit.color.xyz, config.ambientColor.xyz);
+  let occlusion = mix(0.75, 1.0, clamp(hit.occlusion, 0.0, 1.0));
   return clamp_sample_radiance(
     ray.throughput.xyz *
     surfaceColor *
-    terminal_surface_environment_source(hit)
+    terminal_surface_environment_source(ray, hit) *
+    occlusion
   );
 }
 
@@ -2583,6 +4214,10 @@ fn direct_environment_portal_irradiance(origin: vec3<f32>, normal: vec3<f32>) ->
     );
     let area = max(portal.position.w, 0.0001);
     let distanceFalloff = clamp(area / max(distanceSquared, area * 0.25), 0.0, 2.5);
+    let traceDistance = max(sqrt(distanceSquared) - 0.01, 0.01);
+    if (scene_visibility_blocked(origin, direction, traceDistance)) {
+      continue;
+    }
     irradiance = irradiance +
       portal.color.rgb *
       portal.normal.w *
@@ -2594,48 +4229,79 @@ fn direct_environment_portal_irradiance(origin: vec3<f32>, normal: vec3<f32>) ->
   return irradiance;
 }
 
+fn visibility_test_ray(origin: vec3<f32>, direction: vec3<f32>) -> RayRecord {
+  let rayDirection = safe_normalize(direction, vec3<f32>(0.0, 1.0, 0.0));
+  return RayRecord(
+    0u,
+    0u,
+    0u,
+    0u,
+    0u,
+    0u,
+    0u,
+    0u,
+    vec4<f32>(origin, 1.0),
+    vec4<f32>(rayDirection, 0.0),
+    vec4<f32>(1.0, 1.0, 1.0, 1.0)
+  );
+}
+
+fn scene_visibility_blocked(origin: vec3<f32>, direction: vec3<f32>, maxDistance: f32) -> bool {
+  let testRay = visibility_test_ray(origin, direction);
+  let nearest = max(maxDistance, 0.001);
+
+  for (var objectIndex = 0u; objectIndex < config.sceneObjectCount; objectIndex = objectIndex + 1u) {
+    let object = sceneObjects[objectIndex];
+    var current = no_candidate();
+    if (object.kind == 1u) {
+      current = intersect_sphere(testRay, object);
+    } else if (object.kind == 2u) {
+      current = intersect_box(testRay, object);
+    }
+    if (current.hit == 1u && current.distance < nearest) {
+      return true;
+    }
+  }
+
+  let meshCandidate = intersect_bvh(testRay, nearest);
+  return meshCandidate.hit == 1u && meshCandidate.distance < nearest;
+}
+
 fn surface_direct_environment_contribution(ray: RayRecord, hit: HitRecord) -> vec3<f32> {
   let normal = safe_normalize(hit.shadingNormal.xyz, vec3<f32>(0.0, 1.0, 0.0));
   let origin = hit.position.xyz + normal * 0.003;
   let viewDirection = safe_normalize(-ray.direction.xyz, normal);
-  let surfaceColor = clamp(max(hit.color.xyz, config.ambientColor.xyz * 0.35), vec3<f32>(0.0), vec3<f32>(1.0));
-  let roughness = clamp(hit.material.x, 0.0, 1.0);
-  let metallic = clamp(hit.material.y, 0.0, 1.0);
-
-  let normalEnvironment = gated_environment_radiance(origin, normal);
-  let skyVisibility = 0.35 + saturate(normal.y * 0.5 + 0.5) * 0.45;
-  let sunlitFloor = sunlit_baseline_radiance(normal);
-  let ambientIrradiance = max(
-    select(config.ambientColor.xyz * 0.72, config.ambientColor.xyz * 0.28, environment_map_enabled()),
-    sunlitFloor * select(0.72, 0.45, environment_map_enabled())
-  );
-  let environmentIrradianceScale = select(
-    max(0.16, config.pathResolveSettings.y * 0.45),
-    max(config.environmentMapSettings.w, max(0.16, config.pathResolveSettings.y * 0.45)),
-    environment_map_enabled()
-  );
-  let skyIrradiance = max(ambientIrradiance, normalEnvironment * skyVisibility * environmentIrradianceScale);
-
-  let sunDirection = safe_normalize(
-    config.environmentSunDirectionIntensity.xyz,
-    vec3<f32>(0.0, 1.0, 0.0)
-  );
-  let sunFacing = saturate(dot(normal, sunDirection));
-  let sunRadiance = gated_environment_radiance(origin, sunDirection);
-  let sunIrradiance = sunRadiance * sunFacing * 0.2;
-  let portalIrradiance = direct_environment_portal_irradiance(origin, normal);
-
-  let diffuseWeight = select(1.0 - metallic * 0.65, 0.22, hit.materialKind == 1u);
-  let diffuse = surfaceColor * (skyIrradiance + sunIrradiance + portalIrradiance) * diffuseWeight;
-
-  let halfVector = safe_normalize(sunDirection + viewDirection, normal);
-  let specularPower = 8.0 + (1.0 - roughness) * 96.0;
-  let specularFacing = pow(saturate(dot(normal, halfVector)), specularPower) * sunFacing;
-  let specularTint = mix(vec3<f32>(0.04), surfaceColor, metallic);
-  let specular = specularTint * sunRadiance * specularFacing * select(0.16, 0.48, hit.materialKind == 1u || hit.materialKind == 2u);
-
-  let bounceWeight = select(1.0, 0.38, ray.bounce > 0u);
-  return clamp_sample_radiance(ray.throughput.xyz * (diffuse + specular) * bounceWeight);
+  let lightSample = sample_environment_importance(vec2<f32>(
+    random01(mix_seed(ray.sourcePixelId, ray.sampleId, ray.bounce, config.frameIndex, 41u)),
+    random01(mix_seed(ray.sourcePixelId, ray.sampleId, ray.bounce, config.frameIndex, 43u))
+  ));
+  if (lightSample.pdf <= 0.000001) {
+    return vec3<f32>(0.0);
+  }
+  let lightDirection = safe_normalize(lightSample.direction, normal);
+  let nDotL = saturate(dot(normal, lightDirection));
+  if (nDotL <= 0.000001) {
+    return vec3<f32>(0.0);
+  }
+  if (scene_visibility_blocked(origin, lightDirection, 1000000.0)) {
+    return vec3<f32>(0.0);
+  }
+  let incidentRadiance = direct_environment_radiance(origin, lightDirection);
+  if (max_component(incidentRadiance) <= 0.000001) {
+    return vec3<f32>(0.0);
+  }
+  let bsdf = evaluate_surface_bsdf(hit, viewDirection, lightDirection);
+  if (max_component(bsdf) <= 0.000001) {
+    return vec3<f32>(0.0);
+  }
+  let bsdfPdf = evaluate_surface_bsdf_pdf(hit, viewDirection, lightDirection);
+  let misWeight = power_heuristic(lightSample.pdf, bsdfPdf);
+  let contribution =
+    ray.throughput.xyz *
+    bsdf *
+    incidentRadiance *
+    (nDotL * misWeight / max(lightSample.pdf, 0.000001));
+  return clamp_sample_radiance(contribution);
 }
 
 fn default_mesh_range() -> MeshRange {
@@ -2654,7 +4320,16 @@ fn default_mesh_range() -> MeshRange {
     0u,
     vec4<f32>(0.72, 0.72, 0.68, 1.0),
     vec4<f32>(0.0),
-    vec4<f32>(0.72, 0.0, 1.0, 1.45)
+    vec4<f32>(0.72, 0.0, 1.0, 1.45),
+    vec4<f32>(0.0, 0.0, 0.0, 0.08),
+    vec4<f32>(1.0, 1.0, 1.0, 1.0),
+    vec4<f32>(0.0, 0.0, 1.0, 1.0),
+    vec4<f32>(0.0, 0.0, 1.0, 1.0),
+    vec4<f32>(0.0, 0.0, 1.0, 1.0),
+    vec4<f32>(0.0, 0.0, 1.0, 1.0),
+    vec4<f32>(0.0, 0.0, 1.0, 1.0),
+    vec4<f32>(0.0, 0.0, 1.0, 1.0),
+    vec4<f32>(1.0, 1.0, 1.0, 0.0)
   );
 }
 
@@ -2750,7 +4425,7 @@ fn prepareMeshTrianglesAndLeaves(@builtin(global_invocation_id) globalId: vec3<u
     mesh.flags,
     mesh.materialRefId,
     mesh.mediumRefId,
-    0u,
+    mesh.materialSlot,
     0u,
     vec4<f32>(vertex0.position.xyz, 0.0),
     vec4<f32>(vertex1.position.xyz, 0.0),
@@ -2762,7 +4437,16 @@ fn prepareMeshTrianglesAndLeaves(@builtin(global_invocation_id) globalId: vec3<u
     vec4<f32>(uv2, 0.0, 0.0),
     mesh.color,
     mesh.emission,
-    mesh.material
+    mesh.material,
+    mesh.materialResponse,
+    mesh.materialExtension,
+    mesh.specularColor,
+    mesh.baseColorAtlas,
+    mesh.metallicRoughnessAtlas,
+    mesh.normalAtlas,
+    mesh.occlusionAtlas,
+    mesh.emissiveAtlas,
+    mesh.textureSettings
   );
 
   let leafBase = config.triangleCount - 1u;
@@ -2921,7 +4605,8 @@ fn make_miss(ray: RayRecord) -> HitRecord {
     0u,
     0u,
     -1.0,
-    vec3<f32>(0.0),
+    1.0,
+    vec2<f32>(0.0),
     vec4<f32>(ray.origin.xyz + ray.direction.xyz * 1000.0, 1.0),
     vec4<f32>(-ray.direction.xyz, 0.0),
     vec4<f32>(-ray.direction.xyz, 0.0),
@@ -2929,7 +4614,10 @@ fn make_miss(ray: RayRecord) -> HitRecord {
     vec4<f32>(0.0),
     vec4<f32>(radiance, 1.0),
     vec4<f32>(0.0),
-    vec4<f32>(1.0, 0.0, 1.0, 1.0)
+    vec4<f32>(1.0, 0.0, 1.0, 1.0),
+    vec4<f32>(0.0, 0.0, 0.0, 0.08),
+    vec4<f32>(0.08, 1.0, 0.0, 0.0),
+    vec4<f32>(1.0, 1.0, 1.0, 1.0)
   );
 }
 
@@ -3224,6 +4912,19 @@ fn denoise_range_space(value: vec3<f32>) -> vec3<f32> {
   return value / (vec3<f32>(1.0) + value);
 }
 
+fn denoise_sample_count() -> f32 {
+  return clamp(1.0 / max(config.projectionAndSampling.z, 0.000001), 1.0, 256.0);
+}
+
+fn denoise_strength() -> f32 {
+  let spp = denoise_sample_count();
+  return clamp(0.44 / sqrt(spp), 0.08, 0.44);
+}
+
+fn denoise_kernel_radius() -> i32 {
+  return select(1i, 2i, denoise_sample_count() < 2.5);
+}
+
 @compute @workgroup_size(64)
 fn generatePrimaryRays(@builtin(global_invocation_id) globalId: vec3<u32>) {
   let index = globalId.x;
@@ -3262,7 +4963,10 @@ fn intersectActiveQueue(@builtin(global_invocation_id) globalId: vec3<u32>) {
     vec4<f32>(0.0),
     vec4<f32>(0.0),
     vec4<f32>(0.0),
-    vec4<f32>(1.0, 0.0, 1.0, 1.0)
+    vec4<f32>(1.0, 0.0, 1.0, 1.0),
+    vec4<f32>(0.0, 0.0, 0.0, 0.08),
+    vec4<f32>(0.08, 1.0, 0.0, 0.0),
+    vec4<f32>(1.0, 1.0, 1.0, 1.0)
   );
   var candidate = no_candidate();
   var hitTriangle = TriangleRecord(
@@ -3284,7 +4988,16 @@ fn intersectActiveQueue(@builtin(global_invocation_id) globalId: vec3<u32>) {
     vec4<f32>(0.0),
     vec4<f32>(0.0),
     vec4<f32>(0.0),
-    vec4<f32>(1.0, 0.0, 1.0, 1.0)
+    vec4<f32>(1.0, 0.0, 1.0, 1.0),
+    vec4<f32>(0.0, 0.0, 0.0, 0.08),
+    vec4<f32>(0.08, 1.0, 0.0, 0.0),
+    vec4<f32>(1.0, 1.0, 1.0, 1.0),
+    vec4<f32>(0.0, 0.0, 1.0, 1.0),
+    vec4<f32>(0.0, 0.0, 1.0, 1.0),
+    vec4<f32>(0.0, 0.0, 1.0, 1.0),
+    vec4<f32>(0.0, 0.0, 1.0, 1.0),
+    vec4<f32>(0.0, 0.0, 1.0, 1.0),
+    vec4<f32>(1.0, 1.0, 1.0, 0.0)
   );
 
   for (var objectIndex = 0u; objectIndex < config.sceneObjectCount; objectIndex = objectIndex + 1u) {
@@ -3317,16 +5030,28 @@ fn intersectActiveQueue(@builtin(global_invocation_id) globalId: vec3<u32>) {
   let position = ray.origin.xyz + ray.direction.xyz * candidate.distance;
   let hitMaterialKind = select(hitObject.materialKind, hitTriangle.materialKind, candidate.triangleIndex != 0xffffffffu);
   let hitObjectId = select(hitObject.objectId, hitTriangle.meshId, candidate.triangleIndex != 0xffffffffu);
-  let hitColor = select(hitObject.color, hitTriangle.color, candidate.triangleIndex != 0xffffffffu);
-  let hitEmission = select(hitObject.emission, hitTriangle.emission, candidate.triangleIndex != 0xffffffffu);
-  let hitMaterial = select(hitObject.material, hitTriangle.material, candidate.triangleIndex != 0xffffffffu);
+  let meshSurface = sample_surface_material(
+    hitTriangle,
+    candidate.uv,
+    candidate.geometricNormal,
+    candidate.shadingNormal
+  );
+  let hitColor = select(hitObject.color, meshSurface.color, candidate.triangleIndex != 0xffffffffu);
+  let hitEmission = select(hitObject.emission, meshSurface.emission, candidate.triangleIndex != 0xffffffffu);
+  let hitMaterial = select(hitObject.material, meshSurface.material, candidate.triangleIndex != 0xffffffffu);
+  let hitMaterialResponse = select(hitObject.materialResponse, meshSurface.materialResponse, candidate.triangleIndex != 0xffffffffu);
+  let hitMaterialExtension = select(hitObject.materialExtension, meshSurface.materialExtension, candidate.triangleIndex != 0xffffffffu);
+  let hitSpecularColor = select(hitObject.specularColor, meshSurface.specularColor, candidate.triangleIndex != 0xffffffffu);
+  let hitShadingNormal = select(candidate.shadingNormal, meshSurface.shadingNormal, candidate.triangleIndex != 0xffffffffu);
   let hitPrimitiveId = select(candidate.primitiveId, hitTriangle.triangleId, candidate.triangleIndex != 0xffffffffu);
   let hitMaterialRefId = select(candidate.materialRefId, hitTriangle.materialRefId, candidate.triangleIndex != 0xffffffffu);
   let hitMediumRefId = select(candidate.mediumRefId, hitTriangle.mediumRefId, candidate.triangleIndex != 0xffffffffu);
+  let hitMaterialSlot = select(0u, hitTriangle.materialSlot, candidate.triangleIndex != 0xffffffffu);
+  let hitOcclusion = select(1.0, meshSurface.occlusion, candidate.triangleIndex != 0xffffffffu);
   var hitType = 0u;
   if (hitMaterialKind == 4u || emission_power(hitEmission) > 0.0001) {
     hitType = 1u;
-  } else if (hitMaterialKind == 3u || hitMaterial.z < 0.999) {
+  } else if (hitMaterialKind == 3u || hitMaterial.z < 0.999 || hitMaterialExtension.z > 0.001) {
     hitType = 3u;
   }
   atomicAdd(&counters.hitCount, 1u);
@@ -3340,19 +5065,23 @@ fn intersectActiveQueue(@builtin(global_invocation_id) globalId: vec3<u32>) {
     hitPrimitiveId,
     hitMaterialRefId,
     hitMediumRefId,
-    0u,
+    hitMaterialSlot,
     0u,
     0u,
     candidate.distance,
-    vec3<f32>(0.0),
+    hitOcclusion,
+    vec2<f32>(0.0),
     vec4<f32>(position, 1.0),
     vec4<f32>(candidate.geometricNormal, 0.0),
-    vec4<f32>(candidate.shadingNormal, 0.0),
+    vec4<f32>(hitShadingNormal, 0.0),
     vec4<f32>(candidate.barycentric, 0.0),
     vec4<f32>(candidate.uv, 0.0, 0.0),
     hitColor,
     hitEmission,
-    hitMaterial
+    hitMaterial,
+    hitMaterialResponse,
+    hitMaterialExtension,
+    hitSpecularColor
   );
 }
 
@@ -3421,60 +5150,81 @@ fn sample_environment_portal_direction(hit: HitRecord, seed: u32, fallback: vec3
 }
 
 fn scatter_direction(ray: RayRecord, hit: HitRecord, seed: u32) -> ScatterResult {
+  let normal = safe_normalize(hit.shadingNormal.xyz, vec3<f32>(0.0, 1.0, 0.0));
+  let viewDirection = safe_normalize(-ray.direction.xyz, normal);
   let roughness = clamp(hit.material.x, 0.0, 1.0);
-  if (hit.materialKind == 1u) {
+  let transmission = clamp(hit.materialExtension.z, 0.0, 1.0);
+  if (hit.materialKind == 1u && roughness <= 0.02) {
     return ScatterResult(
-      vec4<f32>(
-        safe_normalize(
-          reflect(ray.direction.xyz, hit.shadingNormal.xyz) + random_unit_vector(seed) * roughness,
-          hit.shadingNormal.xyz
-        ),
-        0.0
-      ),
-      0u,
-      0u,
+      vec4<f32>(reflect(ray.direction.xyz, normal), 0.0),
+      1.0,
+      RAY_FLAG_DELTA_SAMPLE,
       0u,
       0u
     );
   }
 
-  if (hit.materialKind == 2u || hit.materialKind == 3u) {
+  if (hit.materialKind == 2u || hit.materialKind == 3u || transmission > 0.001) {
     let ior = max(hit.material.w, 1.01);
     let etaRatio = select(ior, 1.0 / ior, hit.frontFace == 1u);
-    let cosTheta = min(dot(-ray.direction.xyz, hit.shadingNormal.xyz), 1.0);
+    let cosTheta = min(dot(-ray.direction.xyz, normal), 1.0);
     let sinTheta = sqrt(max(0.0, 1.0 - cosTheta * cosTheta));
     let cannotRefract = etaRatio * sinTheta > 1.0;
     let reflectChance = schlick(cosTheta, etaRatio);
-    if (cannotRefract || random01(seed + 23u) < reflectChance) {
-      return ScatterResult(vec4<f32>(reflect(ray.direction.xyz, hit.shadingNormal.xyz), 0.0), 0u, 0u, 0u, 0u);
+    let transmissionReflectChance = select(
+      reflectChance,
+      max(reflectChance, 1.0 - transmission),
+      transmission > 0.001
+    );
+    if (cannotRefract || random01(seed + 23u) < transmissionReflectChance) {
+      return ScatterResult(
+        vec4<f32>(reflect(ray.direction.xyz, normal), 0.0),
+        1.0,
+        RAY_FLAG_DELTA_SAMPLE,
+        0u,
+        0u
+      );
     }
-    return ScatterResult(vec4<f32>(refract_direction(ray.direction.xyz, hit.shadingNormal.xyz, etaRatio), 0.0), 0u, 0u, 0u, 0u);
+    return ScatterResult(
+      vec4<f32>(refract_direction(ray.direction.xyz, normal, etaRatio), 0.0),
+      1.0,
+      RAY_FLAG_DELTA_SAMPLE,
+      0u,
+      0u
+    );
   }
 
-  let randomDiffuse = safe_normalize(
-    hit.shadingNormal.xyz + random_unit_vector(seed),
-    hit.shadingNormal.xyz
-  );
-  let guidedLight = sample_emissive_triangle_direction(hit, seed, randomDiffuse);
-  let canSampleLight = dot(hit.shadingNormal.xyz, guidedLight) > -0.04;
-  let guideProbability = select(0.38, 0.72, ray.bounce == 0u);
-  let useGuidedLight = canSampleLight && random01(seed + 37u) < guideProbability;
-  let guidedPortal = sample_environment_portal_direction(hit, seed, randomDiffuse);
-  let canSamplePortal = dot(hit.shadingNormal.xyz, guidedPortal) > -0.04;
-  let useGuidedPortal =
-    !useGuidedLight &&
-    canSamplePortal &&
-    config.environmentPortalCount > 0u &&
-    config.environmentPortalMode > 0u &&
-    random01(seed + 89u) < 0.58;
-  let guidedDirection = select(randomDiffuse, guidedPortal, useGuidedPortal);
-  return ScatterResult(
-    vec4<f32>(select(guidedDirection, guidedLight, useGuidedLight), 0.0),
-    select(0u, RAY_FLAG_GUIDED_EMISSIVE, useGuidedLight),
-    0u,
-    0u,
-    0u
-  );
+  let weights = surface_bsdf_sampling_weights(hit);
+  let selector = random01(seed + 31u);
+  var lightDirection = normal;
+  if (selector < weights.x) {
+    lightDirection = cosine_sample_hemisphere(
+      vec2<f32>(random01(seed + 37u), random01(seed + 41u)),
+      normal
+    );
+  } else if (selector < weights.x + weights.y) {
+    let halfVector = importance_sample_ggx(
+      vec2<f32>(random01(seed + 47u), random01(seed + 53u)),
+      max(roughness, 0.02),
+      normal
+    );
+    lightDirection = safe_normalize(reflect(-viewDirection, halfVector), normal);
+  } else {
+    let halfVector = importance_sample_ggx(
+      vec2<f32>(random01(seed + 59u), random01(seed + 61u)),
+      max(clamp(hit.materialExtension.x, 0.0, 1.0), 0.02),
+      normal
+    );
+    lightDirection = safe_normalize(reflect(-viewDirection, halfVector), normal);
+  }
+  if (dot(normal, lightDirection) <= 0.000001) {
+    lightDirection = cosine_sample_hemisphere(
+      vec2<f32>(random01(seed + 67u), random01(seed + 71u)),
+      normal
+    );
+  }
+  let pdf = max(evaluate_surface_bsdf_pdf(hit, viewDirection, lightDirection), 0.000001);
+  return ScatterResult(vec4<f32>(lightDirection, 0.0), pdf, 0u, 0u, 0u);
 }
 
 @compute @workgroup_size(64)
@@ -3504,10 +5254,17 @@ fn resolveSurfaceRecords(@builtin(global_invocation_id) globalId: vec3<u32>) {
   }
 
   if (hit.hitType == 2u) {
+    var sourceRadiance = hit.color.xyz;
+    if ((ray.flags & RAY_FLAG_DELTA_SAMPLE) == 0u) {
+      let bsdfPdf = max(ray.throughput.w, 0.000001);
+      let lightPdf = environment_direction_pdf(ray.direction.xyz);
+      let misWeight = power_heuristic(bsdfPdf, lightPdf);
+      sourceRadiance = sourceRadiance * misWeight;
+    }
     if (deferred_path_resolve_enabled()) {
-      record_deferred_terminal_source(ray, hit.color.xyz);
+      record_deferred_terminal_source(ray, sourceRadiance);
     } else {
-      contribution = clamp_sample_radiance(ray.throughput.xyz * max(hit.color.xyz, config.ambientColor.xyz));
+      contribution = clamp_sample_radiance(ray.throughput.xyz * sourceRadiance);
       accumulation[ray.rayId] =
         accumulation[ray.rayId] + vec4<f32>(contribution * sample_weight(), 1.0);
     }
@@ -3515,13 +5272,13 @@ fn resolveSurfaceRecords(@builtin(global_invocation_id) globalId: vec3<u32>) {
     return;
   }
 
-  let response = surface_path_response(hit);
+  let response = stabilize_surface_path_response(ray, hit, surface_path_response(hit));
   record_deferred_path_response(ray, response);
 
   let shouldEstimateDirectEnvironment =
-    !deferred_path_resolve_enabled() &&
     (hit.materialKind == 0u || hit.materialKind == 1u) &&
-    hit.material.z >= 0.95;
+    hit.material.z >= 0.95 &&
+    ray.bounce < 2u;
   if (shouldEstimateDirectEnvironment) {
     let directEnvironment = surface_direct_environment_contribution(ray, hit);
     accumulation[ray.rayId] =
@@ -3530,7 +5287,7 @@ fn resolveSurfaceRecords(@builtin(global_invocation_id) globalId: vec3<u32>) {
 
   if (ray.bounce + 1u >= config.maxDepth) {
     if (deferred_path_resolve_enabled()) {
-      record_deferred_terminal_source(ray, terminal_surface_environment_source(hit));
+      record_deferred_terminal_source(ray, terminal_surface_environment_source(ray, hit));
     } else {
       let terminalEnvironment = terminal_surface_environment_contribution(ray, hit);
       accumulation[ray.rayId] =
@@ -3545,7 +5302,7 @@ fn resolveSurfaceRecords(@builtin(global_invocation_id) globalId: vec3<u32>) {
   let nextIndex = atomicAdd(&counters.nextCount, 1u);
   if (nextIndex >= config.tilePixelCount) {
     if (deferred_path_resolve_enabled()) {
-      record_deferred_terminal_source(ray, terminal_surface_environment_source(hit));
+      record_deferred_terminal_source(ray, terminal_surface_environment_source(ray, hit));
     } else {
       let overflowEnvironment = terminal_surface_environment_contribution(ray, hit);
       accumulation[ray.rayId] =
@@ -3566,7 +5323,7 @@ fn resolveSurfaceRecords(@builtin(global_invocation_id) globalId: vec3<u32>) {
     0u,
     vec4<f32>(offset_origin(hit.position.xyz, hit.shadingNormal.xyz), 1.0),
     scatter.direction,
-    vec4<f32>(throughput, ray.throughput.w)
+    vec4<f32>(throughput, scatter.pdf)
   );
 }
 
@@ -3635,8 +5392,11 @@ fn denoiseLinearRadiance(@builtin(global_invocation_id) globalId: vec3<u32>) {
 
   let pixel = vec2<i32>(i32(x), i32(y));
   let center = textureLoad(denoiseInputRadiance, pixel, 0).xyz;
-  var sum = center * 1.4;
-  var totalWeight = 1.4;
+  let strength = denoise_strength();
+  let kernelRadius = denoise_kernel_radius();
+  let centerWeight = 1.7 - strength * 0.35;
+  var sum = center * centerWeight;
+  var totalWeight = centerWeight;
   let centerRange = denoise_range_space(center);
 
   for (var oy = -2i; oy <= 2i; oy = oy + 1i) {
@@ -3644,13 +5404,16 @@ fn denoiseLinearRadiance(@builtin(global_invocation_id) globalId: vec3<u32>) {
       if (ox == 0i && oy == 0i) {
         continue;
       }
+      if (abs(ox) > kernelRadius || abs(oy) > kernelRadius) {
+        continue;
+      }
       let sx = clamp(i32(x) + ox, 0i, i32(config.canvasWidth) - 1i);
       let sy = clamp(i32(y) + oy, 0i, i32(config.canvasHeight) - 1i);
       let sampleColor = textureLoad(denoiseInputRadiance, vec2<i32>(sx, sy), 0).xyz;
       let colorDistance = length(denoise_range_space(sampleColor) - centerRange);
-      let rangeWeight = 1.0 / (1.0 + colorDistance * 7.0);
-      let distanceWeight = 1.0 / (1.0 + f32(ox * ox + oy * oy) * 0.24);
-      let diagonalWeight = select(1.0, 0.78, abs(ox) + abs(oy) > 2i);
+      let rangeWeight = 1.0 / (1.0 + colorDistance * (11.0 + strength * 6.0));
+      let distanceWeight = 1.0 / (1.0 + f32(ox * ox + oy * oy) * (0.62 + strength * 0.24));
+      let diagonalWeight = select(1.0, 0.92, abs(ox) + abs(oy) > 1i);
       let weight = rangeWeight * diagonalWeight * distanceWeight;
       sum = sum + sampleColor * weight;
       totalWeight = totalWeight + weight;
@@ -3658,8 +5421,9 @@ fn denoiseLinearRadiance(@builtin(global_invocation_id) globalId: vec3<u32>) {
   }
 
   let filtered = sum / max(totalWeight, 0.0001);
-  let outlier = saturate(length(denoise_range_space(center) - denoise_range_space(filtered)) * 2.4);
-  let color = min(mix(center, filtered, 0.52 + outlier * 0.18), vec3<f32>(16.0));
+  let outlier = saturate(length(denoise_range_space(center) - denoise_range_space(filtered)) * 2.1);
+  let blend = min(0.3, strength * (0.62 + outlier * 0.12));
+  let color = min(mix(center, filtered, blend), vec3<f32>(16.0));
   textureStore(denoisedRadianceImage, pixel, vec4<f32>(color, 1.0));
 }
 
@@ -3673,8 +5437,10 @@ fn resolveDenoisedOutputImage(@builtin(global_invocation_id) globalId: vec3<u32>
 
   let pixel = vec2<i32>(i32(x), i32(y));
   let center = textureLoad(finalDenoiseInputRadiance, pixel, 0).xyz;
-  var sum = center * 1.25;
-  var totalWeight = 1.25;
+  let strength = denoise_strength();
+  let centerWeight = 1.35 - strength * 0.25;
+  var sum = center * centerWeight;
+  var totalWeight = centerWeight;
   let centerRange = denoise_range_space(center);
 
   for (var oy = -1i; oy <= 1i; oy = oy + 1i) {
@@ -3686,8 +5452,8 @@ fn resolveDenoisedOutputImage(@builtin(global_invocation_id) globalId: vec3<u32>
       let sy = clamp(i32(y) + oy, 0i, i32(config.canvasHeight) - 1i);
       let sampleColor = textureLoad(finalDenoiseInputRadiance, vec2<i32>(sx, sy), 0).xyz;
       let colorDistance = length(denoise_range_space(sampleColor) - centerRange);
-      let rangeWeight = 1.0 / (1.0 + colorDistance * 9.0);
-      let distanceWeight = 1.0 / (1.0 + f32(ox * ox + oy * oy) * 0.4);
+      let rangeWeight = 1.0 / (1.0 + colorDistance * (12.0 + strength * 8.0));
+      let distanceWeight = 1.0 / (1.0 + f32(ox * ox + oy * oy) * (0.82 + strength * 0.28));
       let weight = rangeWeight * distanceWeight;
       sum = sum + sampleColor * weight;
       totalWeight = totalWeight + weight;
@@ -3695,8 +5461,9 @@ fn resolveDenoisedOutputImage(@builtin(global_invocation_id) globalId: vec3<u32>
   }
 
   let filtered = sum / max(totalWeight, 0.0001);
-  let outlier = saturate(length(denoise_range_space(center) - denoise_range_space(filtered)) * 2.8);
-  let radiance = min(mix(center, filtered, 0.28 + outlier * 0.12), vec3<f32>(16.0));
+  let outlier = saturate(length(denoise_range_space(center) - denoise_range_space(filtered)) * 2.2);
+  let blend = min(0.18, strength * (0.42 + outlier * 0.08));
+  let radiance = min(mix(center, filtered, blend), vec3<f32>(16.0));
   textureStore(denoisedOutputImage, pixel, vec4<f32>(tone_map_radiance(radiance), 1.0));
 }
 `;
@@ -3884,11 +5651,63 @@ function createEnvironmentMapSnapshot(environmentMap) {
     enabled: environmentMap.enabled,
     width: environmentMap.width,
     height: environmentMap.height,
+    mipLevelCount: environmentMap.mipLevelCount ?? 1,
     projection: environmentMap.projection,
     intensity: environmentMap.intensity,
     rotationRadians: environmentMap.rotationRadians,
     ambientStrength: environmentMap.ambientStrength,
   });
+}
+
+function nowMs() {
+  if (typeof performance !== "undefined" && typeof performance.now === "function") {
+    return performance.now();
+  }
+  return Date.now();
+}
+
+function createGpuWorkerJobDiagnostics(
+  parallelism,
+  commandSubmissions,
+  frameTimeMs,
+  awaitedGpuCompletion
+) {
+  const directDispatchesCompleted = Math.max(0, Number(parallelism?.directDispatches ?? 0));
+  const indirectDispatchesCompleted = Math.max(0, Number(parallelism?.indirectDispatches ?? 0));
+  const completedPerFrame = directDispatchesCompleted + indirectDispatchesCompleted;
+  const completedPerSubmission =
+    commandSubmissions > 0 ? completedPerFrame / commandSubmissions : completedPerFrame;
+  const completedPerSecond =
+    awaitedGpuCompletion && frameTimeMs > 0 ? (completedPerFrame * 1000) / frameTimeMs : null;
+  return Object.freeze({
+    completedPerFrame,
+    completedPerSecond,
+    completedPerSubmission,
+    directDispatchesCompleted,
+    indirectDispatchesCompleted,
+    frameTimeMs,
+    awaitedGpuCompletion,
+  });
+}
+
+function estimateSubmittedGpuWorkTimeoutMs(config, tileCount, overrideTimeoutMs = null) {
+  if (Number.isFinite(overrideTimeoutMs)) {
+    return Math.max(1, Math.trunc(Number(overrideTimeoutMs)));
+  }
+  const samplesPerPixel = Math.max(
+    1,
+    Number(config?.renderedSamplesPerPixel ?? config?.samplesPerPixel ?? 1)
+  );
+  const maxDepth = Math.max(1, Number(config?.maxDepth ?? 1));
+  const deferredResolvePasses = config?.deferredPathResolve ? 1 : 0;
+  const denoisePasses = config?.denoise ? (samplesPerPixel < 4 ? 2 : 1) : 0;
+  const tiles = Math.max(1, Number(tileCount ?? 1));
+  const estimatedPasses =
+    tiles * (samplesPerPixel * (maxDepth + 1 + deferredResolvePasses) + denoisePasses + 1);
+  return Math.min(
+    GPU_MAX_SUBMITTED_WORK_TIMEOUT_MS,
+    GPU_SUBMITTED_WORK_TIMEOUT_MS + estimatedPasses * 5
+  );
 }
 
 export async function createWavefrontPathTracingComputeRenderer(options = {}) {
@@ -4116,6 +5935,59 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
     config.environmentMap,
     config.environmentColor
   );
+  config = Object.freeze({
+    ...config,
+    environmentMap: Object.freeze({
+      ...config.environmentMap,
+      width: environmentMapResource.width,
+      height: environmentMapResource.height,
+      mipLevelCount: environmentMapResource.mipLevelCount,
+    }),
+  });
+  const environmentSamplingResource = createEnvironmentSamplingTextureResource(
+    device,
+    constants,
+    config.environmentMap,
+    config.environmentColor
+  );
+  const brdfLutResource = createBrdfLutResource(device, constants);
+  const baseColorAtlasResource = createAtlasTextureResource(
+    device,
+    constants,
+    config.gpuMaterialSource.baseColorAtlas,
+    "plasius.wavefront.materialAtlas.baseColor"
+  );
+  const metallicRoughnessAtlasResource = createAtlasTextureResource(
+    device,
+    constants,
+    config.gpuMaterialSource.metallicRoughnessAtlas,
+    "plasius.wavefront.materialAtlas.metallicRoughness"
+  );
+  const normalAtlasResource = createAtlasTextureResource(
+    device,
+    constants,
+    config.gpuMaterialSource.normalAtlas,
+    "plasius.wavefront.materialAtlas.normal"
+  );
+  const occlusionAtlasResource = createAtlasTextureResource(
+    device,
+    constants,
+    config.gpuMaterialSource.occlusionAtlas,
+    "plasius.wavefront.materialAtlas.occlusion"
+  );
+  const emissiveAtlasResource = createAtlasTextureResource(
+    device,
+    constants,
+    config.gpuMaterialSource.emissiveAtlas,
+    "plasius.wavefront.materialAtlas.emissive"
+  );
+  const materialAtlasSampler = device.createSampler({
+    label: "plasius.wavefront.materialAtlasSampler",
+    addressModeU: "clamp-to-edge",
+    addressModeV: "clamp-to-edge",
+    magFilter: "linear",
+    minFilter: "linear",
+  });
 
   const traceBindGroupLayout = device.createBindGroupLayout({
     label: "plasius.wavefront.traceBindGroupLayout",
@@ -4147,6 +6019,15 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
       { binding: 20, visibility: constants.shader.COMPUTE, texture: { sampleType: "float" } },
       { binding: 21, visibility: constants.shader.COMPUTE, sampler: { type: "filtering" } },
       { binding: 22, visibility: constants.shader.COMPUTE, buffer: { type: "storage" } },
+      { binding: 23, visibility: constants.shader.COMPUTE, texture: { sampleType: "float" } },
+      { binding: 24, visibility: constants.shader.COMPUTE, texture: { sampleType: "float" } },
+      { binding: 25, visibility: constants.shader.COMPUTE, texture: { sampleType: "float" } },
+      { binding: 26, visibility: constants.shader.COMPUTE, texture: { sampleType: "float" } },
+      { binding: 27, visibility: constants.shader.COMPUTE, texture: { sampleType: "float" } },
+      { binding: 28, visibility: constants.shader.COMPUTE, sampler: { type: "filtering" } },
+      { binding: 29, visibility: constants.shader.COMPUTE, texture: { sampleType: "float" } },
+      { binding: 30, visibility: constants.shader.COMPUTE, sampler: { type: "filtering" } },
+      { binding: 31, visibility: constants.shader.COMPUTE, texture: { sampleType: "float" } },
     ],
   });
   const accelerationBindGroupLayout = device.createBindGroupLayout({
@@ -4225,6 +6106,7 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
     label: "plasius.wavefront.computeShader",
     code: WAVEFRONT_COMPUTE_WGSL,
   });
+  await assertShaderModuleCompiles(computeShader, "plasius.wavefront.computeShader");
 
   const pipelines = {
     prepareMeshTrianglesAndLeaves: await createComputePipeline(
@@ -4326,6 +6208,15 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
         { binding: 20, resource: environmentMapResource.view },
         { binding: 21, resource: environmentMapResource.sampler },
         { binding: 22, resource: { buffer: pathVertexBuffer } },
+        { binding: 23, resource: baseColorAtlasResource.view },
+        { binding: 24, resource: metallicRoughnessAtlasResource.view },
+        { binding: 25, resource: normalAtlasResource.view },
+        { binding: 26, resource: occlusionAtlasResource.view },
+        { binding: 27, resource: emissiveAtlasResource.view },
+        { binding: 28, resource: materialAtlasSampler },
+        { binding: 29, resource: brdfLutResource.view },
+        { binding: 30, resource: brdfLutResource.sampler },
+        { binding: 31, resource: environmentSamplingResource.view },
       ],
     });
   }
@@ -4381,6 +6272,11 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
     outputView,
     "plasius.wavefront.bind.denoise.scratchToOutput"
   );
+  const denoiseDirectResolveBindGroup = createDenoiseResolveBindGroup(
+    radianceView,
+    outputView,
+    "plasius.wavefront.bind.denoise.radianceToOutput"
+  );
 
   const presentBindGroupLayout = device.createBindGroupLayout({
     label: "plasius.wavefront.presentBindGroupLayout",
@@ -4420,24 +6316,137 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
   let accelerationBuilt = !config.gpuAccelerationBuildRequired;
   let accelerationBuildCount = 0;
   let activeCameraOptions = options.camera ?? DEFAULT_CAMERA;
+  let lastCompletedFrameTimeMs = null;
+  let lastCompletedSamplesPerPixel = Math.max(1, config.samplesPerPixel);
   let lastGpuParallelism = createGpuParallelismDiagnostics(
     gpuAdapterParallelism,
     createGpuParallelismCounters()
   );
 
+  function resolveRenderedSamplesPerPixel(renderOptions = {}, awaitGPUCompletion = true) {
+    const targetSamplesPerPixel = clamp(
+      readPositiveInteger(
+        "samplesPerPixel",
+        renderOptions.samplesPerPixel,
+        config.samplesPerPixel
+      ),
+      1,
+      config.samplesPerPixel
+    );
+    const frameTimeBudgetMs = Number.isFinite(renderOptions.frameTimeBudgetMs)
+      ? Math.max(0, Number(renderOptions.frameTimeBudgetMs))
+      : null;
+    const minimumSamplesPerPixel = clamp(
+      readPositiveInteger(
+        "minimumSamplesPerPixel",
+        renderOptions.minimumSamplesPerPixel,
+        frameTimeBudgetMs !== null && targetSamplesPerPixel > 1 ? 1 : targetSamplesPerPixel
+      ),
+      1,
+      targetSamplesPerPixel
+    );
+    if (frameTimeBudgetMs === null || !awaitGPUCompletion || targetSamplesPerPixel <= minimumSamplesPerPixel) {
+      return Object.freeze({
+        renderedSamplesPerPixel: targetSamplesPerPixel,
+        targetSamplesPerPixel,
+        minimumSamplesPerPixel,
+        frameTimeBudgetMs,
+        budgetConstrained: false,
+      });
+    }
+    const estimatedSampleTimeMs =
+      Number.isFinite(lastCompletedFrameTimeMs) && lastCompletedFrameTimeMs > 0
+        ? lastCompletedFrameTimeMs / Math.max(1, lastCompletedSamplesPerPixel)
+        : null;
+    if (!Number.isFinite(estimatedSampleTimeMs) || estimatedSampleTimeMs <= 0) {
+      return Object.freeze({
+        renderedSamplesPerPixel: minimumSamplesPerPixel,
+        targetSamplesPerPixel,
+        minimumSamplesPerPixel,
+        frameTimeBudgetMs,
+        budgetConstrained: minimumSamplesPerPixel < targetSamplesPerPixel,
+      });
+    }
+    const budgetLimitedSamples = clamp(
+      Math.floor(frameTimeBudgetMs / estimatedSampleTimeMs),
+      minimumSamplesPerPixel,
+      targetSamplesPerPixel
+    );
+    return Object.freeze({
+      renderedSamplesPerPixel: budgetLimitedSamples,
+      targetSamplesPerPixel,
+      minimumSamplesPerPixel,
+      frameTimeBudgetMs,
+      budgetConstrained: budgetLimitedSamples < targetSamplesPerPixel,
+    });
+  }
+
+  function createFrameStats({
+    frameIndex,
+    accelerationBuildSubmitted,
+    frameSubmissionCount,
+    parallelismCounters,
+    renderedSamplesPerPixel,
+    targetSamplesPerPixel,
+    frameTimeBudgetMs,
+    budgetConstrained,
+  }) {
+    lastGpuParallelism = createGpuParallelismDiagnostics(gpuAdapterParallelism, parallelismCounters);
+    const commandSubmissions = frameSubmissionCount + (accelerationBuildSubmitted ? 1 : 0);
+    return Object.freeze({
+      frame,
+      frameIndex,
+      width: config.width,
+      height: config.height,
+      maxDepth: config.maxDepth,
+      tiles: tiles.length,
+      tileSize: config.tileSize,
+      samplesPerPixel: targetSamplesPerPixel,
+      renderedSamplesPerPixel,
+      frameTimeBudgetMs,
+      budgetConstrained,
+      maxFramePassesPerSubmission: config.maxFramePassesPerSubmission,
+      screenRays: config.width * config.height,
+      primaryRays: config.width * config.height * renderedSamplesPerPixel,
+      sceneObjectCount: config.sceneObjectCount,
+      triangleCount: config.triangleCount,
+      emissiveTriangleCount: config.emissiveTriangleCount,
+      environmentPortalCount: config.environmentPortalCount,
+      environmentPortalMode: config.environmentPortalMode,
+      environmentMap: createEnvironmentMapSnapshot(config.environmentMap),
+      deferredPathResolve: config.deferredPathResolve,
+      bvhNodeCount: config.bvhNodeCount,
+      displayQuality: config.displayQuality,
+      accelerationBuildMode: config.accelerationBuildMode,
+      gpuAccelerationBuildRequired: config.gpuAccelerationBuildRequired,
+      accelerationBuildSubmitted,
+      accelerationBuilt,
+      accelerationBuildCount,
+      commandSubmissions,
+      frameConfigSlots: frameConfigSlotCount,
+      gpuParallelism: lastGpuParallelism,
+      memory: config.memory,
+    });
+  }
+
+  function writeFrameConfigSlot(slot, tile, frameIndex, buildRange = {}) {
+    if (slot >= frameConfigSlotCount) {
+      throw new Error("Wavefront frame config slot capacity exceeded.");
+    }
+    const offset = slot * configBufferStride;
+    device.queue.writeBuffer(
+      configBuffer,
+      offset,
+      createConfigPayload(config, tile, frameIndex, buildRange)
+    );
+    return offset;
+  }
+
   function createFrameConfigWriter(frameIndex) {
     let slot = 0;
     return (tile, buildRange = {}) => {
-      if (slot >= frameConfigSlotCount) {
-        throw new Error("Wavefront frame config slot capacity exceeded.");
-      }
-      const offset = slot * configBufferStride;
+      const offset = writeFrameConfigSlot(slot, tile, frameIndex, buildRange);
       slot += 1;
-      device.queue.writeBuffer(
-        configBuffer,
-        offset,
-        createConfigPayload(config, tile, frameIndex, buildRange)
-      );
       return offset;
     };
   }
@@ -4565,25 +6574,32 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
     passEncoder.end();
   }
 
-  function encodeDenoise(encoder, configOffset, parallelism) {
+  function encodeDenoise(encoder, configOffset, parallelism, renderedSamplesPerPixel = config.samplesPerPixel) {
     if (!config.denoise) {
       return;
     }
     const denoiseWorkgroupsX = Math.ceil(config.width / 8);
     const denoiseWorkgroupsY = Math.ceil(config.height / 8);
-    const radiancePass = encoder.beginComputePass({
-      label: "plasius.wavefront.denoiseRadiancePass",
-    });
-    radiancePass.setBindGroup(0, denoiseRadianceBindGroup, [configOffset]);
-    radiancePass.setPipeline(pipelines.denoiseLinearRadiance);
-    radiancePass.dispatchWorkgroups(denoiseWorkgroupsX, denoiseWorkgroupsY);
-    recordDirectDispatch(parallelism, [denoiseWorkgroupsX, denoiseWorkgroupsY]);
-    radiancePass.end();
+    const useTwoPassDenoise = renderedSamplesPerPixel < 4;
+    if (useTwoPassDenoise) {
+      const radiancePass = encoder.beginComputePass({
+        label: "plasius.wavefront.denoiseRadiancePass",
+      });
+      radiancePass.setBindGroup(0, denoiseRadianceBindGroup, [configOffset]);
+      radiancePass.setPipeline(pipelines.denoiseLinearRadiance);
+      radiancePass.dispatchWorkgroups(denoiseWorkgroupsX, denoiseWorkgroupsY);
+      recordDirectDispatch(parallelism, [denoiseWorkgroupsX, denoiseWorkgroupsY]);
+      radiancePass.end();
+    }
 
     const resolvePass = encoder.beginComputePass({
       label: "plasius.wavefront.denoiseResolvePass",
     });
-    resolvePass.setBindGroup(0, denoiseResolveBindGroup, [configOffset]);
+    resolvePass.setBindGroup(
+      0,
+      useTwoPassDenoise ? denoiseResolveBindGroup : denoiseDirectResolveBindGroup,
+      [configOffset]
+    );
     resolvePass.setPipeline(pipelines.resolveDenoisedOutputImage);
     resolvePass.dispatchWorkgroups(denoiseWorkgroupsX, denoiseWorkgroupsY);
     recordDirectDispatch(parallelism, [denoiseWorkgroupsX, denoiseWorkgroupsY]);
@@ -4609,7 +6625,7 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
     passEncoder.end();
   }
 
-  function dispatchFrame(frameIndex, parallelism) {
+  function dispatchFrame(frameIndex, parallelism, renderedSamplesPerPixel = config.samplesPerPixel) {
     const writeFrameConfig = createFrameConfigWriter(frameIndex);
     let submissionCount = 0;
     let encodedFramePasses = 0;
@@ -4641,73 +6657,250 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
     }
 
     for (const tile of tiles) {
-      for (let sampleIndex = 0; sampleIndex < config.samplesPerPixel; sampleIndex += 1) {
+      for (let sampleIndex = 0; sampleIndex < renderedSamplesPerPixel; sampleIndex += 1) {
         const configOffset = writeFrameConfig(tile, {
           sampleIndex,
-          sampleWeight: 1 / config.samplesPerPixel,
+          sampleWeight: 1 / renderedSamplesPerPixel,
         });
-        encodeTileSample(reserveEncoder(), tile, configOffset, parallelism);
+        encodeTileSample(
+          reserveEncoder(config.maxDepth + 1),
+          tile,
+          configOffset,
+          parallelism
+        );
         if (config.deferredPathResolve) {
-          encodeTileOutput(reserveEncoder(), tile, configOffset, parallelism);
+          encodeTileOutput(reserveEncoder(1), tile, configOffset, parallelism);
         }
       }
       if (!config.deferredPathResolve) {
         const outputConfigOffset = writeFrameConfig(tile, {
           sampleIndex: 0,
-          sampleWeight: 1 / config.samplesPerPixel,
+          sampleWeight: 1 / renderedSamplesPerPixel,
         });
-        encodeTileOutput(reserveEncoder(), tile, outputConfigOffset, parallelism);
+        encodeTileOutput(reserveEncoder(1), tile, outputConfigOffset, parallelism);
       }
     }
     if (config.denoise) {
       const denoiseConfigOffset = writeFrameConfig(
         { x: 0, y: 0, width: config.width, height: config.height },
-        { sampleIndex: 0, sampleWeight: 1 / config.samplesPerPixel }
+        { sampleIndex: 0, sampleWeight: 1 / renderedSamplesPerPixel }
       );
-      encodeDenoise(reserveEncoder(), denoiseConfigOffset, parallelism);
+      const denoisePassCount = renderedSamplesPerPixel < 4 ? 2 : 1;
+      encodeDenoise(
+        reserveEncoder(denoisePassCount),
+        denoiseConfigOffset,
+        parallelism,
+        renderedSamplesPerPixel
+      );
     }
-    encodePresent(reserveEncoder());
+    encodePresent(reserveEncoder(1));
     submitCurrentEncoder();
     return submissionCount;
   }
 
-  function renderOnce() {
+  function renderOnce(renderOptions = {}, resolvedSamplingPlan = null) {
+    const frameStartTimeMs = nowMs();
     frame += 1;
     const frameIndex = frame + config.frameIndex;
+    const samplingPlan = resolvedSamplingPlan ?? resolveRenderedSamplesPerPixel(renderOptions, false);
     const parallelismCounters = createGpuParallelismCounters();
     const accelerationBuildSubmitted = dispatchGpuAccelerationBuild(frameIndex, parallelismCounters);
-    const frameSubmissionCount = dispatchFrame(frameIndex, parallelismCounters);
-    lastGpuParallelism = createGpuParallelismDiagnostics(gpuAdapterParallelism, parallelismCounters);
+    const frameSubmissionCount = dispatchFrame(
+      frameIndex,
+      parallelismCounters,
+      samplingPlan.renderedSamplesPerPixel
+    );
+    const frameTimeMs = Math.max(0, nowMs() - frameStartTimeMs);
     return Object.freeze({
-      frame,
-      width: config.width,
-      height: config.height,
-      maxDepth: config.maxDepth,
-      tiles: tiles.length,
-      tileSize: config.tileSize,
-      samplesPerPixel: config.samplesPerPixel,
-      maxFramePassesPerSubmission: config.maxFramePassesPerSubmission,
-      screenRays: config.width * config.height,
-      primaryRays: config.width * config.height * config.samplesPerPixel,
-      sceneObjectCount: config.sceneObjectCount,
-      triangleCount: config.triangleCount,
-      emissiveTriangleCount: config.emissiveTriangleCount,
-      environmentPortalCount: config.environmentPortalCount,
-      environmentPortalMode: config.environmentPortalMode,
-      environmentMap: createEnvironmentMapSnapshot(config.environmentMap),
-      deferredPathResolve: config.deferredPathResolve,
-      bvhNodeCount: config.bvhNodeCount,
-      displayQuality: config.displayQuality,
-      accelerationBuildMode: config.accelerationBuildMode,
-      gpuAccelerationBuildRequired: config.gpuAccelerationBuildRequired,
-      accelerationBuildSubmitted,
-      accelerationBuilt,
-      accelerationBuildCount,
-      commandSubmissions: frameSubmissionCount + (accelerationBuildSubmitted ? 1 : 0),
-      frameConfigSlots: frameConfigSlotCount,
-      gpuParallelism: lastGpuParallelism,
-      memory: config.memory,
+      ...createFrameStats({
+        frameIndex,
+        accelerationBuildSubmitted,
+        frameSubmissionCount,
+        parallelismCounters,
+        renderedSamplesPerPixel: samplingPlan.renderedSamplesPerPixel,
+        targetSamplesPerPixel: samplingPlan.targetSamplesPerPixel,
+        frameTimeBudgetMs: samplingPlan.frameTimeBudgetMs,
+        budgetConstrained: samplingPlan.budgetConstrained,
+      }),
+      gpuWorkerJobs: createGpuWorkerJobDiagnostics(
+        lastGpuParallelism,
+        frameSubmissionCount + (accelerationBuildSubmitted ? 1 : 0),
+        frameTimeMs,
+        false
+      ),
     });
+  }
+
+  async function waitForSubmittedGpuWork(options = {}) {
+    if (typeof device.queue.onSubmittedWorkDone !== "function") {
+      return true;
+    }
+    const timeoutMs = Math.max(
+      1,
+      Number.isFinite(options.timeoutMs)
+        ? Number(options.timeoutMs)
+        : GPU_SUBMITTED_WORK_TIMEOUT_MS
+    );
+    const allowTimeout = options.allowTimeout !== false;
+    const completionPromise = device.queue.onSubmittedWorkDone().then(
+      () => ({ status: "done" }),
+      (error) => {
+        throw error;
+      }
+    );
+    const lossPromise =
+      typeof device.lost?.then === "function"
+        ? device.lost.then((info) => {
+            throw new Error(
+              `WebGPU device lost while waiting for submitted work (${info?.reason ?? "unknown"}).`
+            );
+          })
+        : null;
+    let timeoutHandle = null;
+    let resolveTimeoutPromise = null;
+    let timeoutSettled = false;
+    const settleTimeoutPromise = (value) => {
+      if (timeoutSettled) {
+        return;
+      }
+      timeoutSettled = true;
+      resolveTimeoutPromise?.(value);
+    };
+    const timeoutPromise = new Promise((resolve) => {
+      resolveTimeoutPromise = resolve;
+      timeoutHandle = setTimeout(() => settleTimeoutPromise({ status: "timeout" }), timeoutMs);
+    });
+    let result;
+    try {
+      result = await Promise.race(
+        [completionPromise, timeoutPromise, lossPromise].filter(Boolean)
+      );
+    } finally {
+      if (timeoutHandle !== null) {
+        clearTimeout(timeoutHandle);
+        timeoutHandle = null;
+        settleTimeoutPromise({ status: "cancelled" });
+      }
+    }
+    if (result?.status === "timeout") {
+      if (!allowTimeout) {
+        throw new Error(`Timed out after ${timeoutMs} ms waiting for submitted GPU work.`);
+      }
+      console.warn(
+        `[plasius.wavefront] Submitted GPU work did not report completion within ${timeoutMs} ms; continuing.`
+      );
+      return false;
+    }
+    return true;
+  }
+
+  function dispatchFrameAwaitingGpu(
+    frameIndex,
+    parallelism,
+    renderedSamplesPerPixel = config.samplesPerPixel
+  ) {
+    const samplePassesPerSample = config.maxDepth + 1 + (config.deferredPathResolve ? 1 : 0);
+    const denoisePassCount = config.denoise ? (renderedSamplesPerPixel < 4 ? 2 : 1) : 0;
+    const tailPassCount = denoisePassCount + 1;
+    const sampleBatchSize = Math.max(
+      1,
+      Math.floor(
+        Math.max(config.maxFramePassesPerSubmission - tailPassCount, 1) /
+          Math.max(samplePassesPerSample, 1)
+      )
+    );
+    let submissionCount = 0;
+
+    function createSubmissionController() {
+      let encodedFramePasses = 0;
+      let localSubmissions = 0;
+      let encoder = device.createCommandEncoder({
+        label: `plasius.wavefront.frame.${frameIndex}.batched.${submissionCount + localSubmissions + 1}`,
+      });
+
+      return {
+        reserve(passCount = 1) {
+          if (
+            encodedFramePasses > 0 &&
+            encodedFramePasses + passCount > config.maxFramePassesPerSubmission
+          ) {
+            const finished = encoder.finish();
+            device.queue.submit([finished]);
+            localSubmissions += 1;
+            encodedFramePasses = 0;
+            encoder = device.createCommandEncoder({
+              label: `plasius.wavefront.frame.${frameIndex}.batched.${submissionCount + localSubmissions + 1}`,
+            });
+          }
+          encodedFramePasses += passCount;
+          return encoder;
+        },
+        flush() {
+          if (encodedFramePasses <= 0) {
+            return 0;
+          }
+          device.queue.submit([encoder.finish()]);
+          localSubmissions += 1;
+          encodedFramePasses = 0;
+          return localSubmissions;
+        },
+      };
+    }
+
+    for (const tile of tiles) {
+      for (
+        let sampleStart = 0;
+        sampleStart < renderedSamplesPerPixel;
+        sampleStart += sampleBatchSize
+      ) {
+        const sampleEnd = Math.min(renderedSamplesPerPixel, sampleStart + sampleBatchSize);
+        const batch = createSubmissionController();
+        let slot = 0;
+        for (let sampleIndex = sampleStart; sampleIndex < sampleEnd; sampleIndex += 1) {
+          const configOffset = writeFrameConfigSlot(slot, tile, frameIndex, {
+            sampleIndex,
+            sampleWeight: 1 / renderedSamplesPerPixel,
+          });
+          slot += 1;
+          encodeTileSample(
+            batch.reserve(config.maxDepth + 1),
+            tile,
+            configOffset,
+            parallelism
+          );
+          if (config.deferredPathResolve) {
+            encodeTileOutput(batch.reserve(1), tile, configOffset, parallelism);
+          }
+        }
+        if (!config.deferredPathResolve && sampleEnd >= renderedSamplesPerPixel) {
+          const outputConfigOffset = writeFrameConfigSlot(slot, tile, frameIndex, {
+            sampleIndex: 0,
+            sampleWeight: 1 / renderedSamplesPerPixel,
+          });
+          encodeTileOutput(batch.reserve(1), tile, outputConfigOffset, parallelism);
+        }
+        submissionCount += batch.flush();
+      }
+    }
+
+    const tail = createSubmissionController();
+    if (config.denoise) {
+      const denoiseConfigOffset = writeFrameConfigSlot(
+        0,
+        { x: 0, y: 0, width: config.width, height: config.height },
+        frameIndex,
+        { sampleIndex: 0, sampleWeight: 1 / renderedSamplesPerPixel }
+      );
+      encodeDenoise(
+        tail.reserve(denoisePassCount),
+        denoiseConfigOffset,
+        parallelism,
+        renderedSamplesPerPixel
+      );
+    }
+    encodePresent(tail.reserve(1));
+    submissionCount += tail.flush();
+    return submissionCount;
   }
 
   async function readOutputProbe(optionsForProbe = {}) {
@@ -4722,6 +6915,10 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
       size: 256,
       usage: constants.buffer.COPY_DST | constants.buffer.MAP_READ,
     });
+    await waitForSubmittedGpuWork({
+      timeoutMs: GPU_READBACK_COMPLETION_TIMEOUT_MS,
+      allowTimeout: false,
+    });
     const encoder = device.createCommandEncoder({
       label: "plasius.wavefront.outputProbe.copy",
     });
@@ -4731,6 +6928,10 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
       { width: 1, height: 1, depthOrArrayLayers: 1 }
     );
     device.queue.submit([encoder.finish()]);
+    await waitForSubmittedGpuWork({
+      timeoutMs: GPU_READBACK_COMPLETION_TIMEOUT_MS,
+      allowTimeout: false,
+    });
     await readback.mapAsync(mapMode.READ);
     const bytes = new Uint8Array(readback.getMappedRange()).slice(0, 4);
     readback.unmap();
@@ -4744,7 +6945,60 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
   }
 
   async function renderFrame(renderOptions = {}) {
-    const frameStats = renderOnce();
+    const awaitGPUCompletion = renderOptions.awaitGPUCompletion !== false;
+    const samplingPlan = resolveRenderedSamplesPerPixel(renderOptions, awaitGPUCompletion);
+    const useThrottledHighSamplePath =
+      awaitGPUCompletion && samplingPlan.renderedSamplesPerPixel >= 8;
+    const submittedWorkTimeoutMs = estimateSubmittedGpuWorkTimeoutMs(
+      { ...config, renderedSamplesPerPixel: samplingPlan.renderedSamplesPerPixel },
+      tiles.length,
+      renderOptions.submittedWorkTimeoutMs
+    );
+    const frameStartTimeMs = nowMs();
+    const submissionWaitOptions = awaitGPUCompletion
+      ? { timeoutMs: submittedWorkTimeoutMs, allowTimeout: false }
+      : { timeoutMs: submittedWorkTimeoutMs };
+    let frameStats;
+    if (useThrottledHighSamplePath) {
+      frame += 1;
+      const frameIndex = frame + config.frameIndex;
+      const parallelismCounters = createGpuParallelismCounters();
+      const accelerationBuildSubmitted = dispatchGpuAccelerationBuild(frameIndex, parallelismCounters);
+      const frameSubmissionCount = dispatchFrameAwaitingGpu(
+        frameIndex,
+        parallelismCounters,
+        samplingPlan.renderedSamplesPerPixel
+      );
+      frameStats = createFrameStats({
+        frameIndex,
+        accelerationBuildSubmitted,
+        frameSubmissionCount,
+        parallelismCounters,
+        renderedSamplesPerPixel: samplingPlan.renderedSamplesPerPixel,
+        targetSamplesPerPixel: samplingPlan.targetSamplesPerPixel,
+        frameTimeBudgetMs: samplingPlan.frameTimeBudgetMs,
+        budgetConstrained: samplingPlan.budgetConstrained,
+      });
+    } else {
+      frameStats = renderOnce(renderOptions, samplingPlan);
+    }
+    if (awaitGPUCompletion) {
+      await waitForSubmittedGpuWork(submissionWaitOptions);
+    }
+    const frameTimeMs = Math.max(0, nowMs() - frameStartTimeMs);
+    if (awaitGPUCompletion) {
+      lastCompletedFrameTimeMs = frameTimeMs;
+      lastCompletedSamplesPerPixel = frameStats.renderedSamplesPerPixel ?? frameStats.samplesPerPixel;
+    }
+    frameStats = Object.freeze({
+      ...frameStats,
+      gpuWorkerJobs: createGpuWorkerJobDiagnostics(
+        frameStats.gpuParallelism,
+        frameStats.commandSubmissions,
+        frameTimeMs,
+        awaitGPUCompletion
+      ),
+    });
     const probe =
       renderOptions.readOutputProbe === false ? null : await readOutputProbe(renderOptions.probe);
     const maxChannel = probe ? Math.max(...probe.rgba.slice(0, 3)) : 0;
@@ -4856,9 +7110,28 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
     activeDispatchBuffer.destroy?.();
     radianceTexture.destroy?.();
     denoiseScratchTexture.destroy?.();
-    outputTexture.destroy?.();
-    if (environmentMapResource.ownsTexture) {
-      environmentMapResource.texture?.destroy?.();
+        outputTexture.destroy?.();
+        if (environmentMapResource.ownsTexture) {
+          environmentMapResource.texture?.destroy?.();
+        }
+        if (environmentSamplingResource.ownsTexture) {
+          environmentSamplingResource.texture?.destroy?.();
+        }
+        brdfLutResource.texture?.destroy?.();
+        if (baseColorAtlasResource.ownsTexture) {
+          baseColorAtlasResource.texture?.destroy?.();
+        }
+    if (metallicRoughnessAtlasResource.ownsTexture) {
+      metallicRoughnessAtlasResource.texture?.destroy?.();
+    }
+    if (normalAtlasResource.ownsTexture) {
+      normalAtlasResource.texture?.destroy?.();
+    }
+    if (occlusionAtlasResource.ownsTexture) {
+      occlusionAtlasResource.texture?.destroy?.();
+    }
+    if (emissiveAtlasResource.ownsTexture) {
+      emissiveAtlasResource.texture?.destroy?.();
     }
     context.unconfigure?.();
   }

--- a/src/wavefront-compute.js
+++ b/src/wavefront-compute.js
@@ -21,11 +21,12 @@ const BVH_LEAF_REF_RECORD_BYTES = 16;
 const EMISSIVE_TRIANGLE_INDEX_BYTES = 4;
 const ENVIRONMENT_PORTAL_RECORD_BYTES = 96;
 const ACCUMULATION_RECORD_BYTES = 16;
-const CONFIG_BUFFER_BYTES = 272;
+const PATH_VERTEX_RECORD_BYTES = 16;
+const CONFIG_BUFFER_BYTES = 304;
 const COUNTER_DISPATCH_ARGS_OFFSET = 16;
 const INDIRECT_DISPATCH_ARGS_BYTES = 12;
 const COUNTER_BUFFER_BYTES = 32;
-const TRACE_STORAGE_BUFFER_BINDINGS = 9;
+const TRACE_STORAGE_BUFFER_BINDINGS = 10;
 const HIT_TYPE_SURFACE = 0;
 const HIT_TYPE_EMISSIVE = 1;
 const MATERIAL_DIFFUSE = 0;
@@ -53,6 +54,7 @@ const DEFAULT_ENVIRONMENT_LIGHTING = Object.freeze({
   intensity: 1,
   mode: 0,
   exposure: 1,
+  sunlitBaseline: 0.16,
 });
 
 export const wavefrontPathTracingComputeLimits = Object.freeze({
@@ -70,6 +72,7 @@ export const wavefrontPathTracingComputeLimits = Object.freeze({
   emissiveTriangleMetadataRecordBytes: BVH_NODE_RECORD_BYTES,
   environmentPortalRecordBytes: ENVIRONMENT_PORTAL_RECORD_BYTES,
   accumulationRecordBytes: ACCUMULATION_RECORD_BYTES,
+  pathVertexRecordBytes: PATH_VERTEX_RECORD_BYTES,
   counterRecordBytes: COUNTER_BUFFER_BYTES,
   indirectDispatchRecordBytes: INDIRECT_DISPATCH_ARGS_BYTES,
 });
@@ -159,6 +162,39 @@ function asColor(value, fallback = [1, 1, 1, 1]) {
     clamp(readFiniteNumber("color[2]", value[2], fallback[2]), 0, 64),
     clamp(readFiniteNumber("color[3]", value[3], fallback[3] ?? 1), 0, 1),
   ];
+}
+
+function resolveEnvironmentMap(input = null) {
+  const source = input && typeof input === "object" ? input : null;
+  const hasTexture = Boolean(source?.view || source?.texture || source?.data);
+  const width = readPositiveInteger("environmentMap.width", source?.width, 1);
+  const height = readPositiveInteger("environmentMap.height", source?.height, 1);
+  return Object.freeze({
+    enabled: hasTexture && source?.enabled !== false,
+    width,
+    height,
+    format: typeof source?.format === "string" ? source.format : "rgba16float",
+    projection: typeof source?.projection === "string" ? source.projection : "equirectangular",
+    texture: source?.texture ?? null,
+    view: source?.view ?? null,
+    sampler: source?.sampler ?? null,
+    data: source?.data ?? null,
+    intensity: Math.max(0, readFiniteNumber("environmentMap.intensity", source?.intensity ?? source?.radianceScale, 1)),
+    rotationRadians: readFiniteNumber("environmentMap.rotationRadians", source?.rotationRadians ?? source?.rotation, 0),
+    ambientStrength: Math.max(
+      0,
+      readFiniteNumber("environmentMap.ambientStrength", source?.ambientStrength, 0.32)
+    ),
+  });
+}
+
+function resolveDeferredPathResolve(options = {}) {
+  const value =
+    options.deferredPathResolve ??
+    options.deferredResolve ??
+    options.pathResolve?.deferred ??
+    true;
+  return value !== false;
 }
 
 function emissionPower(emission) {
@@ -914,6 +950,14 @@ function resolveEnvironmentLighting(input, environmentColor, ambientColor) {
     intensity: Math.max(0.0001, readFiniteNumber("environmentLighting.intensity", source.intensity, DEFAULT_ENVIRONMENT_LIGHTING.intensity)),
     mode: readNonNegativeInteger("environmentLighting.mode", source.mode, DEFAULT_ENVIRONMENT_LIGHTING.mode),
     exposure: Math.max(0.0001, readFiniteNumber("environmentLighting.exposure", source.exposure, DEFAULT_ENVIRONMENT_LIGHTING.exposure)),
+    sunlitBaseline: Math.max(
+      0,
+      readFiniteNumber(
+        "environmentLighting.sunlitBaseline",
+        source.sunlitBaseline ?? source.daylightBaseline,
+        DEFAULT_ENVIRONMENT_LIGHTING.sunlitBaseline
+      )
+    ),
   });
 }
 
@@ -1117,6 +1161,11 @@ export function estimateWavefrontPathTracingMemory(options = {}) {
     options.tilePixelCapacity,
     DEFAULT_TILE_SIZE * DEFAULT_TILE_SIZE
   );
+  const maxDepth = clamp(
+    readPositiveInteger("maxDepth", options.maxDepth, DEFAULT_MAX_DEPTH),
+    1,
+    16
+  );
   const sceneObjectCapacity = readPositiveInteger(
     "sceneObjectCapacity",
     options.sceneObjectCapacity,
@@ -1142,6 +1191,7 @@ export function estimateWavefrontPathTracingMemory(options = {}) {
   const queueBytes = tilePixelCapacity * RAY_RECORD_BYTES;
   const hitBytes = tilePixelCapacity * HIT_RECORD_BYTES;
   const accumulationBytes = tilePixelCapacity * ACCUMULATION_RECORD_BYTES;
+  const pathVertexBytes = tilePixelCapacity * (maxDepth + 1) * PATH_VERTEX_RECORD_BYTES;
   const sceneObjectBytes = sceneObjectCapacity * SCENE_OBJECT_RECORD_BYTES;
   const triangleBytes = triangleCapacity * TRIANGLE_RECORD_BYTES;
   const bvhNodeBytes = bvhNodeCapacity * BVH_NODE_RECORD_BYTES;
@@ -1156,6 +1206,7 @@ export function estimateWavefrontPathTracingMemory(options = {}) {
     queuePairBytes: queueBytes * 2,
     hitBytes,
     accumulationBytes,
+    pathVertexBytes,
     sceneObjectBytes,
     triangleBytes,
     bvhNodeBytes,
@@ -1169,6 +1220,7 @@ export function estimateWavefrontPathTracingMemory(options = {}) {
       queueBytes * 2 +
       hitBytes +
       accumulationBytes +
+      pathVertexBytes +
       sceneObjectBytes +
       triangleBytes +
       bvhNodeBytes +
@@ -1286,6 +1338,12 @@ export function createWavefrontPathTracingComputeConfig(options = {}) {
       options.environmentLighting?.environmentPortalMode,
     environmentPortals.length > 0
   );
+  const environmentMap = resolveEnvironmentMap(
+    options.environmentMap ??
+      options.environmentTexture ??
+      options.environmentLighting?.environmentMap
+  );
+  const deferredPathResolve = resolveDeferredPathResolve(options);
 
   return Object.freeze({
     mode: rendererWavefrontComputeMode,
@@ -1321,12 +1379,15 @@ export function createWavefrontPathTracingComputeConfig(options = {}) {
     environmentPortalCount: environmentPortals.length,
     environmentPortalCapacity,
     environmentPortalMode,
+    environmentMap,
+    deferredPathResolve,
     displayQuality: options.displayQuality === true,
     requiresMeshBvhForDisplayQuality: true,
     denoise: options.denoise !== false,
     frameIndex: readNonNegativeInteger("frameIndex", options.frameIndex, 0),
     memory: estimateWavefrontPathTracingMemory({
       tilePixelCapacity,
+      maxDepth,
       sceneObjectCapacity,
       triangleCapacity,
       bvhNodeCapacity,
@@ -1550,6 +1611,18 @@ function createConfigPayload(config, tile, frameIndex, buildRange = {}) {
   data.setUint32(260, config.environmentPortalMode ?? 0, true);
   data.setUint32(264, 0, true);
   data.setUint32(268, 0, true);
+  writeVec4(floatView, 272, [
+    config.environmentMap.enabled ? 1 : 0,
+    config.environmentMap.intensity,
+    config.environmentMap.rotationRadians,
+    config.environmentMap.ambientStrength,
+  ]);
+  writeVec4(floatView, 288, [
+    config.deferredPathResolve ? 1 : 0,
+    config.environmentLighting.sunlitBaseline,
+    0,
+    0,
+  ]);
   return bytes;
 }
 
@@ -1822,6 +1895,129 @@ function alignTo(value, alignment) {
   return Math.ceil(value / resolvedAlignment) * resolvedAlignment;
 }
 
+function float32ToFloat16Bits(value) {
+  const floatView = new Float32Array(1);
+  const intView = new Uint32Array(floatView.buffer);
+  floatView[0] = Number.isFinite(value) ? value : 0;
+  const x = intView[0];
+  const sign = (x >> 16) & 0x8000;
+  let mantissa = x & 0x7fffff;
+  let exponent = (x >> 23) & 0xff;
+
+  if (exponent === 0xff) {
+    return sign | (mantissa ? 0x7e00 : 0x7c00);
+  }
+
+  exponent = exponent - 127 + 15;
+  if (exponent >= 0x1f) {
+    return sign | 0x7c00;
+  }
+  if (exponent <= 0) {
+    if (exponent < -10) {
+      return sign;
+    }
+    mantissa = (mantissa | 0x800000) >> (1 - exponent);
+    return sign | ((mantissa + 0x1000) >> 13);
+  }
+  return sign | (exponent << 10) | ((mantissa + 0x1000) >> 13);
+}
+
+function readEnvironmentMapComponent(data, index, fallback) {
+  if (!data || index >= data.length) {
+    return fallback;
+  }
+  const value = Number(data[index]);
+  return Number.isFinite(value) ? Math.max(0, value) : fallback;
+}
+
+function createEnvironmentMapUploadBytes(environmentMap, fallbackColor) {
+  const width = Math.max(1, environmentMap.width);
+  const height = Math.max(1, environmentMap.height);
+  const rowBytes = width * 8;
+  const bytesPerRow = alignTo(rowBytes, 256);
+  const bytes = new Uint8Array(bytesPerRow * height);
+  const data = environmentMap.data;
+  const view = new DataView(bytes.buffer);
+
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      const sourceOffset = (y * width + x) * 4;
+      const targetOffset = y * bytesPerRow + x * 8;
+      view.setUint16(targetOffset, float32ToFloat16Bits(readEnvironmentMapComponent(data, sourceOffset, fallbackColor[0])), true);
+      view.setUint16(targetOffset + 2, float32ToFloat16Bits(readEnvironmentMapComponent(data, sourceOffset + 1, fallbackColor[1])), true);
+      view.setUint16(targetOffset + 4, float32ToFloat16Bits(readEnvironmentMapComponent(data, sourceOffset + 2, fallbackColor[2])), true);
+      view.setUint16(targetOffset + 6, float32ToFloat16Bits(readEnvironmentMapComponent(data, sourceOffset + 3, fallbackColor[3] ?? 1)), true);
+    }
+  }
+
+  return Object.freeze({
+    bytes,
+    bytesPerRow,
+    width,
+    height,
+  });
+}
+
+function createEnvironmentMapResource(device, constants, environmentMap, fallbackColor) {
+  if (environmentMap.view) {
+    return Object.freeze({
+      view: environmentMap.view,
+      sampler: environmentMap.sampler ?? device.createSampler({
+        label: "plasius.wavefront.environmentMapSampler",
+        addressModeU: "repeat",
+        addressModeV: "clamp-to-edge",
+        magFilter: "linear",
+        minFilter: "linear",
+      }),
+      texture: null,
+      ownsTexture: false,
+    });
+  }
+
+  if (environmentMap.texture && typeof environmentMap.texture.createView === "function") {
+    return Object.freeze({
+      view: environmentMap.texture.createView(),
+      sampler: environmentMap.sampler ?? device.createSampler({
+        label: "plasius.wavefront.environmentMapSampler",
+        addressModeU: "repeat",
+        addressModeV: "clamp-to-edge",
+        magFilter: "linear",
+        minFilter: "linear",
+      }),
+      texture: environmentMap.texture,
+      ownsTexture: false,
+    });
+  }
+
+  const upload = createEnvironmentMapUploadBytes(environmentMap, fallbackColor);
+  const texture = device.createTexture({
+    label: environmentMap.enabled
+      ? "plasius.wavefront.environmentMap"
+      : "plasius.wavefront.environmentMapFallback",
+    size: { width: upload.width, height: upload.height },
+    format: "rgba16float",
+    usage: constants.texture.TEXTURE_BINDING | constants.texture.COPY_DST,
+  });
+  device.queue.writeTexture(
+    { texture },
+    upload.bytes,
+    { bytesPerRow: upload.bytesPerRow, rowsPerImage: upload.height },
+    { width: upload.width, height: upload.height, depthOrArrayLayers: 1 }
+  );
+  return Object.freeze({
+    view: texture.createView(),
+    sampler: environmentMap.sampler ?? device.createSampler({
+      label: "plasius.wavefront.environmentMapSampler",
+      addressModeU: "repeat",
+      addressModeV: "clamp-to-edge",
+      magFilter: "linear",
+      minFilter: "linear",
+    }),
+    texture,
+    ownsTexture: true,
+  });
+}
+
 async function getPipelineDiagnostics(shaderModule) {
   if (typeof shaderModule?.compilationInfo !== "function") {
     return "";
@@ -2035,6 +2231,8 @@ struct FrameConfig {
   environmentPortalMode: u32,
   _portalPad0: u32,
   _portalPad1: u32,
+  environmentMapSettings: vec4<f32>,
+  pathResolveSettings: vec4<f32>,
 };
 
 struct Counters {
@@ -2094,6 +2292,9 @@ struct EnvironmentPortal {
 @group(0) @binding(17) var finalDenoiseInputRadiance: texture_2d<f32>;
 @group(0) @binding(18) var denoisedOutputImage: texture_storage_2d<rgba8unorm, write>;
 @group(0) @binding(19) var<storage, read> environmentPortals: array<EnvironmentPortal>;
+@group(0) @binding(20) var environmentMapTexture: texture_2d<f32>;
+@group(0) @binding(21) var environmentMapSampler: sampler;
+@group(0) @binding(22) var<storage, read_write> pathVertices: array<vec4<f32>>;
 
 fn hash_u32(value: u32) -> u32 {
   var x = value;
@@ -2138,6 +2339,89 @@ fn max_component(value: vec3<f32>) -> f32 {
   return max(max(value.x, value.y), value.z);
 }
 
+fn environment_map_enabled() -> bool {
+  return config.environmentMapSettings.x > 0.5;
+}
+
+fn deferred_path_resolve_enabled() -> bool {
+  return config.pathResolveSettings.x > 0.5;
+}
+
+fn path_vertex_count_per_ray() -> u32 {
+  return config.maxDepth + 1u;
+}
+
+fn path_vertex_index(rayId: u32, depth: u32) -> u32 {
+  return rayId * path_vertex_count_per_ray() + min(depth, config.maxDepth);
+}
+
+fn clear_deferred_path(rayId: u32) {
+  if (!deferred_path_resolve_enabled()) {
+    return;
+  }
+
+  for (var depth = 0u; depth <= config.maxDepth; depth = depth + 1u) {
+    pathVertices[path_vertex_index(rayId, depth)] = vec4<f32>(0.0);
+    if (depth == config.maxDepth) {
+      break;
+    }
+  }
+}
+
+fn record_deferred_path_response(ray: RayRecord, response: vec3<f32>) {
+  if (!deferred_path_resolve_enabled() || ray.rayId >= config.tilePixelCount || ray.bounce >= config.maxDepth) {
+    return;
+  }
+  pathVertices[path_vertex_index(ray.rayId, ray.bounce)] =
+    vec4<f32>(max(response, vec3<f32>(0.0)), 1.0);
+}
+
+fn record_deferred_terminal_source(ray: RayRecord, sourceRadiance: vec3<f32>) {
+  if (!deferred_path_resolve_enabled() || ray.rayId >= config.tilePixelCount) {
+    return;
+  }
+  pathVertices[path_vertex_index(ray.rayId, config.maxDepth)] =
+    vec4<f32>(clamp_sample_radiance(sourceRadiance), 1.0);
+}
+
+fn environment_map_uv(direction: vec3<f32>) -> vec2<f32> {
+  let rayDirection = safe_normalize(direction, vec3<f32>(0.0, 1.0, 0.0));
+  let rotationTurns = config.environmentMapSettings.z / 6.28318530718;
+  let u = fract(atan2(rayDirection.z, rayDirection.x) / 6.28318530718 + 0.5 + rotationTurns);
+  let v = acos(clamp(rayDirection.y, -1.0, 1.0)) / 3.14159265359;
+  return vec2<f32>(u, clamp(v, 0.0, 1.0));
+}
+
+fn environment_map_radiance(direction: vec3<f32>) -> vec3<f32> {
+  let uv = environment_map_uv(direction);
+  let texel = max(textureSampleLevel(environmentMapTexture, environmentMapSampler, uv, 0.0).rgb, vec3<f32>(0.0));
+  return texel * max(config.environmentMapSettings.y, 0.0);
+}
+
+fn procedural_environment_radiance(direction: vec3<f32>) -> vec3<f32> {
+  let rayDirection = safe_normalize(direction, vec3<f32>(0.0, 1.0, 0.0));
+  let upFactor = saturate(rayDirection.y * 0.5 + 0.5);
+  let sunDirection = safe_normalize(
+    config.environmentSunDirectionIntensity.xyz,
+    vec3<f32>(0.0, 1.0, 0.0)
+  );
+  let sunGlow = pow(saturate(dot(rayDirection, sunDirection)), 192.0);
+  let gradient =
+    config.environmentHorizonColor.xyz * (1.0 - upFactor) +
+    config.environmentZenithColor.xyz * upFactor;
+  return (
+    gradient +
+    config.environmentSunColor.xyz * sunGlow
+  ) * max(config.environmentSunDirectionIntensity.w, 0.0001);
+}
+
+fn base_environment_radiance(direction: vec3<f32>) -> vec3<f32> {
+  if (environment_map_enabled()) {
+    return environment_map_radiance(direction);
+  }
+  return procedural_environment_radiance(direction);
+}
+
 fn environment_portal_radiance_scale(origin: vec3<f32>, direction: vec3<f32>) -> vec3<f32> {
   if (config.environmentPortalCount == 0u || config.environmentPortalMode == 0u) {
     return vec3<f32>(1.0);
@@ -2177,22 +2461,9 @@ fn environment_portal_radiance_scale(origin: vec3<f32>, direction: vec3<f32>) ->
 
 fn environment_radiance(origin: vec3<f32>, direction: vec3<f32>) -> vec3<f32> {
   let rayDirection = safe_normalize(direction, vec3<f32>(0.0, 1.0, 0.0));
-  let upFactor = saturate(rayDirection.y * 0.5 + 0.5);
-  let sunDirection = safe_normalize(
-    config.environmentSunDirectionIntensity.xyz,
-    vec3<f32>(0.0, 1.0, 0.0)
-  );
-  let sunGlow = pow(saturate(dot(rayDirection, sunDirection)), 192.0);
-  let gradient =
-    config.environmentHorizonColor.xyz * (1.0 - upFactor) +
-    config.environmentZenithColor.xyz * upFactor;
   let portalScale = environment_portal_radiance_scale(origin, rayDirection);
   let portalHit = max_component(portalScale) > 0.0001;
-  return (
-    gradient +
-    config.environmentSunColor.xyz * sunGlow
-  ) *
-    max(config.environmentSunDirectionIntensity.w, 0.0001) *
+  return base_environment_radiance(rayDirection) *
     select(vec3<f32>(1.0), portalScale, portalHit);
 }
 
@@ -2208,16 +2479,59 @@ fn gated_environment_radiance(origin: vec3<f32>, direction: vec3<f32>) -> vec3<f
   return environment_radiance(origin, direction);
 }
 
-fn terminal_surface_environment_contribution(ray: RayRecord, hit: HitRecord) -> vec3<f32> {
+fn surface_path_response(hit: HitRecord) -> vec3<f32> {
+  let color = clamp(hit.color.xyz, vec3<f32>(0.0), vec3<f32>(1.0));
+  let opacity = clamp(hit.material.z, 0.0, 1.0);
+  let materialEnergy = select(0.68, 0.92, hit.materialKind == 1u || hit.materialKind == 2u);
+  let transparentEnergy = select(materialEnergy, 0.9, hit.hitType == 3u);
+  return mix(vec3<f32>(1.0), color, max(opacity, 0.18)) * transparentEnergy;
+}
+
+fn sunlit_baseline_radiance(normal: vec3<f32>) -> vec3<f32> {
+  let baseline = max(config.pathResolveSettings.y, 0.0);
+  if (baseline <= 0.000001) {
+    return vec3<f32>(0.0);
+  }
+  let sunDirection = safe_normalize(
+    config.environmentSunDirectionIntensity.xyz,
+    vec3<f32>(0.0, 1.0, 0.0)
+  );
+  let sunFacing = saturate(dot(normal, sunDirection));
+  let skyFacing = 0.35 + saturate(normal.y * 0.5 + 0.5) * 0.65;
+  let directionalWeight = 0.38 + sunFacing * 0.62;
+  let sunTint = max(config.environmentSunColor.xyz, vec3<f32>(0.0));
+  return clamp_sample_radiance(sunTint * baseline * skyFacing * directionalWeight * 0.04);
+}
+
+fn terminal_surface_environment_source(hit: HitRecord) -> vec3<f32> {
   let normal = safe_normalize(hit.shadingNormal.xyz, vec3<f32>(0.0, 1.0, 0.0));
-  let surfaceColor = max(hit.color.xyz, config.ambientColor.xyz);
   let normalEnvironment = gated_environment_radiance(
     hit.position.xyz + normal * 0.003,
     normal
   );
-  let environmentFloor = max(config.ambientColor.xyz, normalEnvironment * 0.12);
+  let sunlitFloor = sunlit_baseline_radiance(normal);
+  let ambientFloor = select(
+    max(config.ambientColor.xyz, sunlitFloor * 0.82),
+    max(config.ambientColor.xyz * 0.35, sunlitFloor * 0.58),
+    environment_map_enabled()
+  );
+  let environmentInfluence = select(
+    max(0.12, config.pathResolveSettings.y * 0.42),
+    max(config.environmentMapSettings.w, max(0.12, config.pathResolveSettings.y * 0.42)),
+    environment_map_enabled()
+  );
+  let environmentFloor = max(ambientFloor, max(sunlitFloor, normalEnvironment * environmentInfluence));
   let materialFloor = select(0.7, 1.0, hit.materialKind == 0u || hit.materialKind == 3u);
-  return clamp_sample_radiance(ray.throughput.xyz * surfaceColor * environmentFloor * materialFloor);
+  return clamp_sample_radiance(environmentFloor * materialFloor);
+}
+
+fn terminal_surface_environment_contribution(ray: RayRecord, hit: HitRecord) -> vec3<f32> {
+  let surfaceColor = max(hit.color.xyz, config.ambientColor.xyz);
+  return clamp_sample_radiance(
+    ray.throughput.xyz *
+    surfaceColor *
+    terminal_surface_environment_source(hit)
+  );
 }
 
 fn direct_environment_portal_irradiance(origin: vec3<f32>, normal: vec3<f32>) -> vec3<f32> {
@@ -2270,7 +2584,17 @@ fn surface_direct_environment_contribution(ray: RayRecord, hit: HitRecord) -> ve
 
   let normalEnvironment = gated_environment_radiance(origin, normal);
   let skyVisibility = 0.35 + saturate(normal.y * 0.5 + 0.5) * 0.45;
-  let skyIrradiance = max(config.ambientColor.xyz * 0.72, normalEnvironment * skyVisibility * 0.16);
+  let sunlitFloor = sunlit_baseline_radiance(normal);
+  let ambientIrradiance = max(
+    select(config.ambientColor.xyz * 0.72, config.ambientColor.xyz * 0.28, environment_map_enabled()),
+    sunlitFloor * select(0.72, 0.45, environment_map_enabled())
+  );
+  let environmentIrradianceScale = select(
+    max(0.16, config.pathResolveSettings.y * 0.45),
+    max(config.environmentMapSettings.w, max(0.16, config.pathResolveSettings.y * 0.45)),
+    environment_map_enabled()
+  );
+  let skyIrradiance = max(ambientIrradiance, normalEnvironment * skyVisibility * environmentIrradianceScale);
 
   let sunDirection = safe_normalize(
     config.environmentSunDirectionIntensity.xyz,
@@ -2894,6 +3218,7 @@ fn generatePrimaryRays(@builtin(global_invocation_id) globalId: vec3<u32>) {
     return;
   }
   activeQueue[index] = make_ray(index);
+  clear_deferred_path(index);
   if (u32(config.projectionAndSampling.w) == 0u) {
     accumulation[index] = vec4<f32>(0.0);
   }
@@ -3146,25 +3471,37 @@ fn resolveSurfaceRecords(@builtin(global_invocation_id) globalId: vec3<u32>) {
 
   if (hit.hitType == 1u) {
     let guidedLightWeight = select(1.0, 0.24, (ray.flags & RAY_FLAG_GUIDED_EMISSIVE) != 0u);
-    contribution = clamp_sample_radiance(
-      ray.throughput.xyz * max(hit.emission.xyz, hit.color.xyz) * guidedLightWeight
-    );
-    accumulation[ray.rayId] =
-      accumulation[ray.rayId] + vec4<f32>(contribution * sample_weight(), 1.0);
+    let sourceRadiance = max(hit.emission.xyz, hit.color.xyz) * guidedLightWeight;
+    if (deferred_path_resolve_enabled()) {
+      record_deferred_terminal_source(ray, sourceRadiance);
+    } else {
+      contribution = clamp_sample_radiance(ray.throughput.xyz * sourceRadiance);
+      accumulation[ray.rayId] =
+        accumulation[ray.rayId] + vec4<f32>(contribution * sample_weight(), 1.0);
+    }
     atomicAdd(&counters.terminatedCount, 1u);
     return;
   }
 
   if (hit.hitType == 2u) {
-    contribution = clamp_sample_radiance(ray.throughput.xyz * max(hit.color.xyz, config.ambientColor.xyz));
-    accumulation[ray.rayId] =
-      accumulation[ray.rayId] + vec4<f32>(contribution * sample_weight(), 1.0);
+    if (deferred_path_resolve_enabled()) {
+      record_deferred_terminal_source(ray, hit.color.xyz);
+    } else {
+      contribution = clamp_sample_radiance(ray.throughput.xyz * max(hit.color.xyz, config.ambientColor.xyz));
+      accumulation[ray.rayId] =
+        accumulation[ray.rayId] + vec4<f32>(contribution * sample_weight(), 1.0);
+    }
     atomicAdd(&counters.terminatedCount, 1u);
     return;
   }
 
+  let response = surface_path_response(hit);
+  record_deferred_path_response(ray, response);
+
   let shouldEstimateDirectEnvironment =
-    (hit.materialKind == 0u || hit.materialKind == 1u) && hit.material.z >= 0.95;
+    !deferred_path_resolve_enabled() &&
+    (hit.materialKind == 0u || hit.materialKind == 1u) &&
+    hit.material.z >= 0.95;
   if (shouldEstimateDirectEnvironment) {
     let directEnvironment = surface_direct_environment_contribution(ray, hit);
     accumulation[ray.rayId] =
@@ -3172,9 +3509,13 @@ fn resolveSurfaceRecords(@builtin(global_invocation_id) globalId: vec3<u32>) {
   }
 
   if (ray.bounce + 1u >= config.maxDepth) {
-    let terminalEnvironment = terminal_surface_environment_contribution(ray, hit);
-    accumulation[ray.rayId] =
-      accumulation[ray.rayId] + vec4<f32>(terminalEnvironment * sample_weight(), 1.0);
+    if (deferred_path_resolve_enabled()) {
+      record_deferred_terminal_source(ray, terminal_surface_environment_source(hit));
+    } else {
+      let terminalEnvironment = terminal_surface_environment_contribution(ray, hit);
+      accumulation[ray.rayId] =
+        accumulation[ray.rayId] + vec4<f32>(terminalEnvironment * sample_weight(), 1.0);
+    }
     atomicAdd(&counters.terminatedCount, 1u);
     return;
   }
@@ -3183,17 +3524,17 @@ fn resolveSurfaceRecords(@builtin(global_invocation_id) globalId: vec3<u32>) {
   let scatter = scatter_direction(ray, hit, seed);
   let nextIndex = atomicAdd(&counters.nextCount, 1u);
   if (nextIndex >= config.tilePixelCount) {
-    let overflowEnvironment = terminal_surface_environment_contribution(ray, hit);
-    accumulation[ray.rayId] =
-      accumulation[ray.rayId] + vec4<f32>(overflowEnvironment * sample_weight(), 1.0);
+    if (deferred_path_resolve_enabled()) {
+      record_deferred_terminal_source(ray, terminal_surface_environment_source(hit));
+    } else {
+      let overflowEnvironment = terminal_surface_environment_contribution(ray, hit);
+      accumulation[ray.rayId] =
+        accumulation[ray.rayId] + vec4<f32>(overflowEnvironment * sample_weight(), 1.0);
+    }
     atomicAdd(&counters.terminatedCount, 1u);
     return;
   }
-  let color = clamp(hit.color.xyz, vec3<f32>(0.0), vec3<f32>(1.0));
-  let opacity = clamp(hit.material.z, 0.0, 1.0);
-  let materialEnergy = select(0.68, 0.92, hit.materialKind == 1u || hit.materialKind == 2u);
-  let transparentEnergy = select(materialEnergy, 0.9, hit.hitType == 3u);
-  let throughput = ray.throughput.xyz * mix(vec3<f32>(1.0), color, max(opacity, 0.18)) * transparentEnergy;
+  let throughput = ray.throughput.xyz * response;
   nextQueue[nextIndex] = RayRecord(
     ray.rayId,
     ray.rayId,
@@ -3221,6 +3562,27 @@ fn compactAndSwapQueues(@builtin(global_invocation_id) globalId: vec3<u32>) {
   write_active_dispatch_args(activeCount);
 }
 
+fn resolve_deferred_path_radiance(rayId: u32) -> vec3<f32> {
+  let terminal = pathVertices[path_vertex_index(rayId, config.maxDepth)];
+  if (terminal.w <= 0.0) {
+    return vec3<f32>(0.0);
+  }
+
+  var radiance = terminal.xyz;
+  var depth = config.maxDepth;
+  loop {
+    if (depth == 0u) {
+      break;
+    }
+    depth = depth - 1u;
+    let response = pathVertices[path_vertex_index(rayId, depth)];
+    if (response.w > 0.0) {
+      radiance = radiance * response.xyz;
+    }
+  }
+  return clamp_sample_radiance(radiance);
+}
+
 @compute @workgroup_size(64)
 fn accumulateTerminalRadiance(@builtin(global_invocation_id) globalId: vec3<u32>) {
   let index = globalId.x;
@@ -3230,7 +3592,12 @@ fn accumulateTerminalRadiance(@builtin(global_invocation_id) globalId: vec3<u32>
   let localX = index % config.tileWidth;
   let localY = index / config.tileWidth;
   let pixel = vec2<i32>(i32(config.tileX + localX), i32(config.tileY + localY));
-  let radiance = max(accumulation[index].xyz, vec3<f32>(0.0));
+  var radiance = max(accumulation[index].xyz, vec3<f32>(0.0));
+  if (deferred_path_resolve_enabled()) {
+    let resolved = resolve_deferred_path_radiance(index) * sample_weight();
+    radiance = clamp_sample_radiance(radiance + resolved);
+    accumulation[index] = vec4<f32>(radiance, 1.0);
+  }
 
   textureStore(radianceImage, pixel, vec4<f32>(radiance, 1.0));
   if (config.denoise == 0u) {
@@ -3373,6 +3740,137 @@ function createWavefrontDeviceDescriptor(adapter, options = {}) {
   return Object.keys(descriptor).length > 0 ? descriptor : undefined;
 }
 
+function readGpuLimit(adapter, device, name) {
+  const adapterValue = Number(adapter?.limits?.[name]);
+  if (Number.isFinite(adapterValue)) {
+    return adapterValue;
+  }
+  const deviceValue = Number(device?.limits?.[name]);
+  return Number.isFinite(deviceValue) ? deviceValue : null;
+}
+
+function createAdapterInfoSnapshot(adapter) {
+  const info = adapter?.info;
+  if (!info || typeof info !== "object") {
+    return null;
+  }
+  return Object.freeze({
+    vendor: typeof info.vendor === "string" ? info.vendor : "",
+    architecture: typeof info.architecture === "string" ? info.architecture : "",
+    device: typeof info.device === "string" ? info.device : "",
+    description: typeof info.description === "string" ? info.description : "",
+  });
+}
+
+function createGpuAdapterParallelismDiagnostics(adapter, device) {
+  return Object.freeze({
+    physicalCoreCount: null,
+    physicalCoreCountAvailable: false,
+    physicalCoreCountUnavailableReason: "WebGPU does not expose physical GPU core counts.",
+    adapterInfo: createAdapterInfoSnapshot(adapter),
+    adapterLimits: Object.freeze({
+      maxComputeInvocationsPerWorkgroup: readGpuLimit(adapter, device, "maxComputeInvocationsPerWorkgroup"),
+      maxComputeWorkgroupSizeX: readGpuLimit(adapter, device, "maxComputeWorkgroupSizeX"),
+      maxComputeWorkgroupSizeY: readGpuLimit(adapter, device, "maxComputeWorkgroupSizeY"),
+      maxComputeWorkgroupSizeZ: readGpuLimit(adapter, device, "maxComputeWorkgroupSizeZ"),
+      maxComputeWorkgroupsPerDimension: readGpuLimit(adapter, device, "maxComputeWorkgroupsPerDimension"),
+      maxStorageBuffersPerShaderStage: readGpuLimit(adapter, device, "maxStorageBuffersPerShaderStage"),
+      maxStorageBufferBindingSize: readGpuLimit(adapter, device, "maxStorageBufferBindingSize"),
+    }),
+    configuredWorkgroupSize: WORKGROUP_SIZE,
+  });
+}
+
+function createGpuParallelismCounters() {
+  return {
+    directDispatches: 0,
+    directWorkgroups: 0,
+    directShaderInvocations: 0,
+    multiWorkgroupDispatches: 0,
+    largestDirectWorkgroupsPerDispatch: 0,
+    indirectDispatches: 0,
+    estimatedIndirectWorkgroupsUpperBound: 0,
+    estimatedIndirectShaderInvocationsUpperBound: 0,
+    indirectDispatchesWithMultiWorkgroupCapacity: 0,
+    largestEstimatedIndirectWorkgroupsPerDispatch: 0,
+  };
+}
+
+function countDispatchWorkgroups(groups) {
+  return groups.reduce((product, value) => {
+    const numeric = Number(value ?? 1);
+    const count = Number.isFinite(numeric) ? Math.max(1, Math.trunc(numeric)) : 1;
+    return product * count;
+  }, 1);
+}
+
+function recordDirectDispatch(parallelism, groups, invocationsPerWorkgroup = WORKGROUP_SIZE) {
+  const workgroups = countDispatchWorkgroups(groups);
+  parallelism.directDispatches += 1;
+  parallelism.directWorkgroups += workgroups;
+  parallelism.directShaderInvocations += workgroups * invocationsPerWorkgroup;
+  parallelism.largestDirectWorkgroupsPerDispatch = Math.max(
+    parallelism.largestDirectWorkgroupsPerDispatch,
+    workgroups
+  );
+  if (workgroups > 1) {
+    parallelism.multiWorkgroupDispatches += 1;
+  }
+}
+
+function recordIndirectDispatch(parallelism, estimatedWorkgroupsUpperBound, invocationsPerWorkgroup = WORKGROUP_SIZE) {
+  const workgroups = Math.max(1, Math.trunc(Number(estimatedWorkgroupsUpperBound) || 1));
+  parallelism.indirectDispatches += 1;
+  parallelism.estimatedIndirectWorkgroupsUpperBound += workgroups;
+  parallelism.estimatedIndirectShaderInvocationsUpperBound += workgroups * invocationsPerWorkgroup;
+  parallelism.largestEstimatedIndirectWorkgroupsPerDispatch = Math.max(
+    parallelism.largestEstimatedIndirectWorkgroupsPerDispatch,
+    workgroups
+  );
+  if (workgroups > 1) {
+    parallelism.indirectDispatchesWithMultiWorkgroupCapacity += 1;
+  }
+}
+
+function createGpuParallelismDiagnostics(adapterDiagnostics, counters) {
+  const totalEstimatedWorkgroupsUpperBound =
+    counters.directWorkgroups + counters.estimatedIndirectWorkgroupsUpperBound;
+  const totalEstimatedShaderInvocationsUpperBound =
+    counters.directShaderInvocations + counters.estimatedIndirectShaderInvocationsUpperBound;
+  const exposesMultiWorkgroupParallelism =
+    counters.multiWorkgroupDispatches > 0 || counters.indirectDispatchesWithMultiWorkgroupCapacity > 0;
+  return Object.freeze({
+    ...adapterDiagnostics,
+    directDispatches: counters.directDispatches,
+    directWorkgroups: counters.directWorkgroups,
+    directShaderInvocations: counters.directShaderInvocations,
+    multiWorkgroupDispatches: counters.multiWorkgroupDispatches,
+    largestDirectWorkgroupsPerDispatch: counters.largestDirectWorkgroupsPerDispatch,
+    indirectDispatches: counters.indirectDispatches,
+    estimatedIndirectWorkgroupsUpperBound: counters.estimatedIndirectWorkgroupsUpperBound,
+    estimatedIndirectShaderInvocationsUpperBound: counters.estimatedIndirectShaderInvocationsUpperBound,
+    indirectDispatchesWithMultiWorkgroupCapacity: counters.indirectDispatchesWithMultiWorkgroupCapacity,
+    largestEstimatedIndirectWorkgroupsPerDispatch: counters.largestEstimatedIndirectWorkgroupsPerDispatch,
+    totalEstimatedWorkgroupsUpperBound,
+    totalEstimatedShaderInvocationsUpperBound,
+    exposesMultiWorkgroupParallelism,
+    likelyUsesMoreThanOnePhysicalGpuCore: null,
+    coreUtilizationStatus: "not-exposed-by-webgpu",
+  });
+}
+
+function createEnvironmentMapSnapshot(environmentMap) {
+  return Object.freeze({
+    enabled: environmentMap.enabled,
+    width: environmentMap.width,
+    height: environmentMap.height,
+    projection: environmentMap.projection,
+    intensity: environmentMap.intensity,
+    rotationRadians: environmentMap.rotationRadians,
+    ambientStrength: environmentMap.ambientStrength,
+  });
+}
+
 export async function createWavefrontPathTracingComputeRenderer(options = {}) {
   assertAnalyticDisplayQualityPolicy(options);
   const constants = getGpuUsageConstants();
@@ -3394,6 +3892,7 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
   }
 
   const device = await adapter.requestDevice(createWavefrontDeviceDescriptor(adapter, options));
+  const gpuAdapterParallelism = createGpuAdapterParallelismDiagnostics(adapter, device);
   const context = canvas.getContext("webgpu");
   if (!context || typeof context.configure !== "function") {
     throw new Error("Canvas WebGPU context does not support configure().");
@@ -3427,6 +3926,7 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
   const rayQueueBytes = config.tilePixelCapacity * RAY_RECORD_BYTES;
   const hitBytes = config.tilePixelCapacity * HIT_RECORD_BYTES;
   const accumulationBytes = config.tilePixelCapacity * ACCUMULATION_RECORD_BYTES;
+  const pathVertexBytes = config.tilePixelCapacity * (config.maxDepth + 1) * PATH_VERTEX_RECORD_BYTES;
   const activeQueue = createBuffer(device, bufferUsage, rayQueueBytes, "plasius.wavefront.activeQueue");
   const nextQueue = createBuffer(device, bufferUsage, rayQueueBytes, "plasius.wavefront.nextQueue");
   const hitBuffer = createBuffer(device, bufferUsage, hitBytes, "plasius.wavefront.hitBuffer");
@@ -3435,6 +3935,12 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
     bufferUsage,
     accumulationBytes,
     "plasius.wavefront.accumulation"
+  );
+  const pathVertexBuffer = createBuffer(
+    device,
+    bufferUsage,
+    pathVertexBytes,
+    "plasius.wavefront.pathVertices"
   );
   const sceneObjectBuffer = createBuffer(
     device,
@@ -3493,9 +3999,10 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
       ? uniformOffsetAlignment
       : CONFIG_BUFFER_BYTES
   );
+  const outputConfigSlotCount = config.deferredPathResolve ? 0 : tiles.length;
   const frameConfigSlotCount = Math.max(
     1,
-    tiles.length * config.samplesPerPixel + tiles.length + (config.denoise ? 1 : 0)
+    tiles.length * config.samplesPerPixel + outputConfigSlotCount + (config.denoise ? 1 : 0)
   );
   const configBuffer = createBuffer(
     device,
@@ -3583,6 +4090,12 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
     magFilter: "nearest",
     minFilter: "nearest",
   });
+  const environmentMapResource = createEnvironmentMapResource(
+    device,
+    constants,
+    config.environmentMap,
+    config.environmentColor
+  );
 
   const traceBindGroupLayout = device.createBindGroupLayout({
     label: "plasius.wavefront.traceBindGroupLayout",
@@ -3611,6 +4124,9 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
         storageTexture: { access: "write-only", format: "rgba16float" },
       },
       { binding: 19, visibility: constants.shader.COMPUTE, buffer: { type: "read-only-storage" } },
+      { binding: 20, visibility: constants.shader.COMPUTE, texture: { sampleType: "float" } },
+      { binding: 21, visibility: constants.shader.COMPUTE, sampler: { type: "filtering" } },
+      { binding: 22, visibility: constants.shader.COMPUTE, buffer: { type: "storage" } },
     ],
   });
   const accelerationBindGroupLayout = device.createBindGroupLayout({
@@ -3787,6 +4303,9 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
         { binding: 9, resource: { buffer: bvhNodeBuffer } },
         { binding: 16, resource: radianceView },
         { binding: 19, resource: { buffer: environmentPortalBuffer } },
+        { binding: 20, resource: environmentMapResource.view },
+        { binding: 21, resource: environmentMapResource.sampler },
+        { binding: 22, resource: { buffer: pathVertexBuffer } },
       ],
     });
   }
@@ -3881,6 +4400,10 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
   let accelerationBuilt = !config.gpuAccelerationBuildRequired;
   let accelerationBuildCount = 0;
   let activeCameraOptions = options.camera ?? DEFAULT_CAMERA;
+  let lastGpuParallelism = createGpuParallelismDiagnostics(
+    gpuAdapterParallelism,
+    createGpuParallelismCounters()
+  );
 
   function createFrameConfigWriter(frameIndex) {
     let slot = 0;
@@ -3899,7 +4422,7 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
     };
   }
 
-  function dispatchGpuAccelerationBuild(frameIndex) {
+  function dispatchGpuAccelerationBuild(frameIndex, parallelism) {
     if (!config.gpuAccelerationBuildRequired || accelerationBuilt) {
       return false;
     }
@@ -3938,24 +4461,32 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
     });
     passEncoder.setBindGroup(0, bvhBuildBindGroup, [0]);
     passEncoder.setPipeline(pipelines.prepareMeshTrianglesAndLeaves);
-    passEncoder.dispatchWorkgroups(Math.ceil(config.bvhLeafSortCapacity / WORKGROUP_SIZE));
+    const prepareWorkgroups = Math.ceil(config.bvhLeafSortCapacity / WORKGROUP_SIZE);
+    passEncoder.dispatchWorkgroups(prepareWorkgroups);
+    recordDirectDispatch(parallelism, [prepareWorkgroups]);
     passEncoder.setPipeline(pipelines.sortBvhLeafRefs);
     for (let stageIndex = 0; stageIndex < config.bvhSortStages.length; stageIndex += 1) {
       passEncoder.setBindGroup(0, bvhBuildBindGroup, [
         (stageIndex + 1) * configBufferStride,
       ]);
-      passEncoder.dispatchWorkgroups(Math.ceil(config.bvhLeafSortCapacity / WORKGROUP_SIZE));
+      const sortWorkgroups = Math.ceil(config.bvhLeafSortCapacity / WORKGROUP_SIZE);
+      passEncoder.dispatchWorkgroups(sortWorkgroups);
+      recordDirectDispatch(parallelism, [sortWorkgroups]);
     }
     passEncoder.setBindGroup(0, bvhBuildBindGroup, [0]);
     passEncoder.setPipeline(pipelines.writeSortedBvhLeaves);
-    passEncoder.dispatchWorkgroups(Math.ceil(config.triangleCount / WORKGROUP_SIZE));
+    const leafWriteWorkgroups = Math.ceil(config.triangleCount / WORKGROUP_SIZE);
+    passEncoder.dispatchWorkgroups(leafWriteWorkgroups);
+    recordDirectDispatch(parallelism, [leafWriteWorkgroups]);
     passEncoder.setPipeline(pipelines.buildBvhInternalLevel);
     for (let levelIndex = 0; levelIndex < config.bvhBuildLevels.length; levelIndex += 1) {
       const buildLevel = config.bvhBuildLevels[levelIndex];
       passEncoder.setBindGroup(0, bvhBuildBindGroup, [
         (buildLevelConfigStart + levelIndex) * configBufferStride,
       ]);
-      passEncoder.dispatchWorkgroups(Math.ceil(buildLevel.count / WORKGROUP_SIZE));
+      const levelWorkgroups = Math.ceil(buildLevel.count / WORKGROUP_SIZE);
+      passEncoder.dispatchWorkgroups(levelWorkgroups);
+      recordDirectDispatch(parallelism, [levelWorkgroups]);
     }
     passEncoder.end();
     device.queue.submit([encoder.finish()]);
@@ -3964,7 +4495,7 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
     return true;
   }
 
-  function encodeTileSample(encoder, tile, configOffset) {
+  function encodeTileSample(encoder, tile, configOffset, parallelism) {
     const generatePass = encoder.beginComputePass({
       label: "plasius.wavefront.generatePrimaryRaysPass",
     });
@@ -3973,6 +4504,7 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
     generatePass.setBindGroup(0, bindGroups[0], [configOffset]);
     generatePass.setPipeline(pipelines.generatePrimaryRays);
     generatePass.dispatchWorkgroups(tileWorkgroups);
+    recordDirectDispatch(parallelism, [tileWorkgroups]);
     generatePass.end();
 
     for (let bounceIndex = 0; bounceIndex < config.maxDepth; bounceIndex += 1) {
@@ -3989,15 +4521,18 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
       passEncoder.setBindGroup(0, bindGroups[bounceIndex % 2], [configOffset]);
       passEncoder.setPipeline(pipelines.intersectActiveQueue);
       passEncoder.dispatchWorkgroupsIndirect(activeDispatchBuffer, 0);
+      recordIndirectDispatch(parallelism, tileWorkgroups);
       passEncoder.setPipeline(pipelines.resolveSurfaceRecords);
       passEncoder.dispatchWorkgroupsIndirect(activeDispatchBuffer, 0);
+      recordIndirectDispatch(parallelism, tileWorkgroups);
       passEncoder.setPipeline(pipelines.compactAndSwapQueues);
       passEncoder.dispatchWorkgroups(1);
+      recordDirectDispatch(parallelism, [1], 1);
       passEncoder.end();
     }
   }
 
-  function encodeTileOutput(encoder, tile, configOffset) {
+  function encodeTileOutput(encoder, tile, configOffset, parallelism) {
     const passEncoder = encoder.beginComputePass({
       label: "plasius.wavefront.outputPass",
     });
@@ -4006,19 +4541,23 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
     passEncoder.setBindGroup(0, bindGroups[0], [configOffset]);
     passEncoder.setPipeline(pipelines.accumulateTerminalRadiance);
     passEncoder.dispatchWorkgroups(tileWorkgroups);
+    recordDirectDispatch(parallelism, [tileWorkgroups]);
     passEncoder.end();
   }
 
-  function encodeDenoise(encoder, configOffset) {
+  function encodeDenoise(encoder, configOffset, parallelism) {
     if (!config.denoise) {
       return;
     }
+    const denoiseWorkgroupsX = Math.ceil(config.width / 8);
+    const denoiseWorkgroupsY = Math.ceil(config.height / 8);
     const radiancePass = encoder.beginComputePass({
       label: "plasius.wavefront.denoiseRadiancePass",
     });
     radiancePass.setBindGroup(0, denoiseRadianceBindGroup, [configOffset]);
     radiancePass.setPipeline(pipelines.denoiseLinearRadiance);
-    radiancePass.dispatchWorkgroups(Math.ceil(config.width / 8), Math.ceil(config.height / 8));
+    radiancePass.dispatchWorkgroups(denoiseWorkgroupsX, denoiseWorkgroupsY);
+    recordDirectDispatch(parallelism, [denoiseWorkgroupsX, denoiseWorkgroupsY]);
     radiancePass.end();
 
     const resolvePass = encoder.beginComputePass({
@@ -4026,7 +4565,8 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
     });
     resolvePass.setBindGroup(0, denoiseResolveBindGroup, [configOffset]);
     resolvePass.setPipeline(pipelines.resolveDenoisedOutputImage);
-    resolvePass.dispatchWorkgroups(Math.ceil(config.width / 8), Math.ceil(config.height / 8));
+    resolvePass.dispatchWorkgroups(denoiseWorkgroupsX, denoiseWorkgroupsY);
+    recordDirectDispatch(parallelism, [denoiseWorkgroupsX, denoiseWorkgroupsY]);
     resolvePass.end();
   }
 
@@ -4049,7 +4589,7 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
     passEncoder.end();
   }
 
-  function dispatchFrame(frameIndex) {
+  function dispatchFrame(frameIndex, parallelism) {
     const writeFrameConfig = createFrameConfigWriter(frameIndex);
     let submissionCount = 0;
     let encodedFramePasses = 0;
@@ -4086,20 +4626,25 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
           sampleIndex,
           sampleWeight: 1 / config.samplesPerPixel,
         });
-        encodeTileSample(reserveEncoder(), tile, configOffset);
+        encodeTileSample(reserveEncoder(), tile, configOffset, parallelism);
+        if (config.deferredPathResolve) {
+          encodeTileOutput(reserveEncoder(), tile, configOffset, parallelism);
+        }
       }
-      const outputConfigOffset = writeFrameConfig(tile, {
-        sampleIndex: 0,
-        sampleWeight: 1 / config.samplesPerPixel,
-      });
-      encodeTileOutput(reserveEncoder(), tile, outputConfigOffset);
+      if (!config.deferredPathResolve) {
+        const outputConfigOffset = writeFrameConfig(tile, {
+          sampleIndex: 0,
+          sampleWeight: 1 / config.samplesPerPixel,
+        });
+        encodeTileOutput(reserveEncoder(), tile, outputConfigOffset, parallelism);
+      }
     }
     if (config.denoise) {
       const denoiseConfigOffset = writeFrameConfig(
         { x: 0, y: 0, width: config.width, height: config.height },
         { sampleIndex: 0, sampleWeight: 1 / config.samplesPerPixel }
       );
-      encodeDenoise(reserveEncoder(), denoiseConfigOffset);
+      encodeDenoise(reserveEncoder(), denoiseConfigOffset, parallelism);
     }
     encodePresent(reserveEncoder());
     submitCurrentEncoder();
@@ -4109,8 +4654,10 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
   function renderOnce() {
     frame += 1;
     const frameIndex = frame + config.frameIndex;
-    const accelerationBuildSubmitted = dispatchGpuAccelerationBuild(frameIndex);
-    const frameSubmissionCount = dispatchFrame(frameIndex);
+    const parallelismCounters = createGpuParallelismCounters();
+    const accelerationBuildSubmitted = dispatchGpuAccelerationBuild(frameIndex, parallelismCounters);
+    const frameSubmissionCount = dispatchFrame(frameIndex, parallelismCounters);
+    lastGpuParallelism = createGpuParallelismDiagnostics(gpuAdapterParallelism, parallelismCounters);
     return Object.freeze({
       frame,
       width: config.width,
@@ -4127,6 +4674,8 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
       emissiveTriangleCount: config.emissiveTriangleCount,
       environmentPortalCount: config.environmentPortalCount,
       environmentPortalMode: config.environmentPortalMode,
+      environmentMap: createEnvironmentMapSnapshot(config.environmentMap),
+      deferredPathResolve: config.deferredPathResolve,
       bvhNodeCount: config.bvhNodeCount,
       displayQuality: config.displayQuality,
       accelerationBuildMode: config.accelerationBuildMode,
@@ -4136,6 +4685,7 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
       accelerationBuildCount,
       commandSubmissions: frameSubmissionCount + (accelerationBuildSubmitted ? 1 : 0),
       frameConfigSlots: frameConfigSlotCount,
+      gpuParallelism: lastGpuParallelism,
       memory: config.memory,
     });
   }
@@ -4252,6 +4802,8 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
       emissiveTriangleCount: config.emissiveTriangleCount,
       environmentPortalCount: config.environmentPortalCount,
       environmentPortalMode: config.environmentPortalMode,
+      environmentMap: createEnvironmentMapSnapshot(config.environmentMap),
+      deferredPathResolve: config.deferredPathResolve,
       bvhNodeCount: config.bvhNodeCount,
       displayQuality: config.displayQuality,
       accelerationBuildMode: config.accelerationBuildMode,
@@ -4259,6 +4811,7 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
       accelerationBuilt,
       accelerationBuildCount,
       frameConfigSlots: frameConfigSlotCount,
+      gpuParallelism: lastGpuParallelism,
       memory: config.memory,
     });
   }
@@ -4268,6 +4821,7 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
     nextQueue.destroy?.();
     hitBuffer.destroy?.();
     accumulationBuffer.destroy?.();
+    pathVertexBuffer.destroy?.();
     sceneObjectBuffer.destroy?.();
     triangleBuffer.destroy?.();
     bvhNodeBuffer.destroy?.();
@@ -4283,6 +4837,9 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
     radianceTexture.destroy?.();
     denoiseScratchTexture.destroy?.();
     outputTexture.destroy?.();
+    if (environmentMapResource.ownsTexture) {
+      environmentMapResource.texture?.destroy?.();
+    }
     context.unconfigure?.();
   }
 

--- a/src/wavefront-compute.js
+++ b/src/wavefront-compute.js
@@ -1922,12 +1922,22 @@ function float32ToFloat16Bits(value) {
   return sign | (exponent << 10) | ((mantissa + 0x1000) >> 13);
 }
 
-function readEnvironmentMapComponent(data, index, fallback) {
+function environmentMapIntegerScale(data) {
+  if (data instanceof Uint8Array) {
+    return 1 / 255;
+  }
+  if (data instanceof Uint16Array) {
+    return 1 / 65535;
+  }
+  return 1;
+}
+
+function readEnvironmentMapComponent(data, index, fallback, integerScale = 1) {
   if (!data || index >= data.length) {
     return fallback;
   }
   const value = Number(data[index]);
-  return Number.isFinite(value) ? Math.max(0, value) : fallback;
+  return Number.isFinite(value) ? Math.max(0, value) * integerScale : fallback;
 }
 
 function createEnvironmentMapUploadBytes(environmentMap, fallbackColor) {
@@ -1937,16 +1947,26 @@ function createEnvironmentMapUploadBytes(environmentMap, fallbackColor) {
   const bytesPerRow = alignTo(rowBytes, 256);
   const bytes = new Uint8Array(bytesPerRow * height);
   const data = environmentMap.data;
+  const integerScale = environmentMapIntegerScale(data);
   const view = new DataView(bytes.buffer);
+  const writeComponent = (targetOffset, sourceOffset, fallback) => {
+    view.setUint16(
+      targetOffset,
+      float32ToFloat16Bits(
+        readEnvironmentMapComponent(data, sourceOffset, fallback, integerScale)
+      ),
+      true
+    );
+  };
 
   for (let y = 0; y < height; y += 1) {
     for (let x = 0; x < width; x += 1) {
       const sourceOffset = (y * width + x) * 4;
       const targetOffset = y * bytesPerRow + x * 8;
-      view.setUint16(targetOffset, float32ToFloat16Bits(readEnvironmentMapComponent(data, sourceOffset, fallbackColor[0])), true);
-      view.setUint16(targetOffset + 2, float32ToFloat16Bits(readEnvironmentMapComponent(data, sourceOffset + 1, fallbackColor[1])), true);
-      view.setUint16(targetOffset + 4, float32ToFloat16Bits(readEnvironmentMapComponent(data, sourceOffset + 2, fallbackColor[2])), true);
-      view.setUint16(targetOffset + 6, float32ToFloat16Bits(readEnvironmentMapComponent(data, sourceOffset + 3, fallbackColor[3] ?? 1)), true);
+      writeComponent(targetOffset, sourceOffset, fallbackColor[0]);
+      writeComponent(targetOffset + 2, sourceOffset + 1, fallbackColor[1]);
+      writeComponent(targetOffset + 4, sourceOffset + 2, fallbackColor[2]);
+      writeComponent(targetOffset + 6, sourceOffset + 3, fallbackColor[3] ?? 1);
     }
   }
 

--- a/src/wavefront-compute.js
+++ b/src/wavefront-compute.js
@@ -222,6 +222,11 @@ function resolveEnvironmentMap(input = null) {
     enabled: hasTexture && source?.enabled !== false,
     width,
     height,
+    mipLevelCount: readPositiveInteger(
+      "environmentMap.mipLevelCount",
+      source?.mipLevelCount,
+      1
+    ),
     format: typeof source?.format === "string" ? source.format : "rgba16float",
     projection: typeof source?.projection === "string" ? source.projection : "equirectangular",
     texture: source?.texture ?? null,
@@ -234,6 +239,7 @@ function resolveEnvironmentMap(input = null) {
       0,
       readFiniteNumber("environmentMap.ambientStrength", source?.ambientStrength, 0.32)
     ),
+    hasImportanceData: source?.hasImportanceData === true,
   });
 }
 
@@ -701,16 +707,31 @@ function sampleTextureRgba(texture, uv = [0, 0], colorSpace = "linear") {
   const y = Math.min(texture.height - 1, Math.max(0, Math.round((1 - v) * (texture.height - 1))));
   const offset = (y * texture.width + x) * 4;
   const data = texture.data;
+  const scale = resolveTextureSampleScale(data);
+  const defaultChannel = scale === 1 ? 1 : Math.round(1 / scale);
   const color = [
-    (data[offset] ?? 255) / 255,
-    (data[offset + 1] ?? 255) / 255,
-    (data[offset + 2] ?? 255) / 255,
-    (data[offset + 3] ?? 255) / 255,
+    (data[offset] ?? defaultChannel) * scale,
+    (data[offset + 1] ?? defaultChannel) * scale,
+    (data[offset + 2] ?? defaultChannel) * scale,
+    (data[offset + 3] ?? defaultChannel) * scale,
   ];
   if (colorSpace === "srgb") {
     return [srgbToLinear(color[0]), srgbToLinear(color[1]), srgbToLinear(color[2]), color[3]];
   }
   return color;
+}
+
+function resolveTextureSampleScale(data) {
+  if (data instanceof Uint8Array || data instanceof Uint8ClampedArray) {
+    return 1 / 255;
+  }
+  if (data instanceof Uint16Array) {
+    return 1 / 65535;
+  }
+  if (Array.isArray(data) && data.some((value) => Number(value) > 1)) {
+    return 1 / 255;
+  }
+  return 1;
 }
 
 function normalizeVectorOrFallback(vector, fallback) {
@@ -757,8 +778,8 @@ function applyNormalMap(normal, tangent, bitangent, normalTexture, uv) {
   const strength = clampUnit(normalTexture.scale ?? 1);
   const tangentNormal = normalize(
     [
-      sample[0] * 2 - 1,
-      sample[1] * 2 - 1,
+      (sample[0] * 2 - 1) * strength,
+      (sample[1] * 2 - 1) * strength,
       1 + (sample[2] * 2 - 1 - 1) * strength,
     ],
     [0, 0, 1]
@@ -2249,7 +2270,7 @@ function createConfigPayload(config, tile, frameIndex, buildRange = {}) {
     config.environmentMap.width ?? 1,
     config.environmentMap.height ?? 1,
     config.environmentMap.mipLevelCount ?? 1,
-    0,
+    config.environmentMap.hasImportanceData ? 1 : 0,
   ]);
   return bytes;
 }
@@ -2441,6 +2462,7 @@ export function intersectWavefrontReferenceTriangle(ray, triangle, options = {})
     color: triangle.color,
     emission: triangle.emission,
     material: triangle.material,
+    materialResponse: triangle.materialResponse,
   });
 }
 
@@ -2468,6 +2490,7 @@ function createWavefrontReferenceEnvironmentHit(config, ray) {
     color: Object.freeze([0, 0, 0, 0]),
     emission: radiance,
     material: Object.freeze([1, 0, 1, 1]),
+    materialResponse: Object.freeze([0, 0, 0, 0]),
   });
 }
 
@@ -2558,6 +2581,15 @@ function environmentMapIntegerScale(data) {
     return 1 / 65535;
   }
   return 1;
+}
+
+function environmentMapHasSamplingData(environmentMap) {
+  if (!environmentMap || !environmentMap.data) {
+    return false;
+  }
+  const width = Math.max(1, environmentMap.width ?? 1);
+  const height = Math.max(1, environmentMap.height ?? 1);
+  return environmentMap.data.length >= width * height * 4;
 }
 
 function createRgba8TextureUpload(source) {
@@ -2702,7 +2734,9 @@ function createBrdfLutUploadBytes(size = DEFAULT_BRDF_LUT_SIZE, sampleCount = 10
       view.setUint16(offset + 6, float32ToFloat16Bits(1), true);
     }
   }
-  return Object.freeze({ bytes, bytesPerRow, width, height });
+  const upload = Object.freeze({ bytes, bytesPerRow, width, height });
+  BRDF_LUT_UPLOAD_CACHE.set(cacheKey, upload);
+  return upload;
 }
 
 function createLinearEnvironmentPixels(environmentMap, fallbackColor) {
@@ -2861,6 +2895,16 @@ function createPrefilteredEnvironmentLevels(environmentMap, fallbackColor) {
 }
 
 function createEnvironmentSamplingTables(environmentMap, fallbackColor) {
+  if (!environmentMapHasSamplingData(environmentMap)) {
+    return Object.freeze({
+      width: 1,
+      height: 1,
+      pdf: new Float32Array([1]),
+      marginalCdf: new Float32Array([1]),
+      conditionalCdf: new Float32Array([1]),
+      hasImportanceData: false,
+    });
+  }
   const pixels = createLinearEnvironmentPixels(environmentMap, fallbackColor);
   const width = Math.max(1, environmentMap.width);
   const height = Math.max(1, environmentMap.height);
@@ -2906,6 +2950,7 @@ function createEnvironmentSamplingTables(environmentMap, fallbackColor) {
     pdf,
     marginalCdf,
     conditionalCdf,
+    hasImportanceData: true,
   });
 }
 
@@ -2964,7 +3009,7 @@ function createEnvironmentMapResource(device, constants, environmentMap, fallbac
       ownsTexture: false,
       width: Math.max(1, environmentMap.width),
       height: Math.max(1, environmentMap.height),
-      mipLevelCount: 1,
+      mipLevelCount: Math.max(1, environmentMap.mipLevelCount ?? 1),
     });
   }
 
@@ -2983,7 +3028,7 @@ function createEnvironmentMapResource(device, constants, environmentMap, fallbac
       ownsTexture: false,
       width: Math.max(1, environmentMap.width),
       height: Math.max(1, environmentMap.height),
-      mipLevelCount: 1,
+      mipLevelCount: Math.max(1, environmentMap.mipLevelCount ?? 1),
     });
   }
 
@@ -3058,6 +3103,7 @@ function createEnvironmentSamplingTextureResource(device, constants, environment
     view: texture.createView(),
     texture,
     ownsTexture: true,
+    hasImportanceData: tables.hasImportanceData,
   });
 }
 
@@ -3579,8 +3625,8 @@ fn sample_surface_material(
   let tangentBasis = build_triangle_tangent_basis(triangle, geometricNormal);
   let tangentNormal = safe_normalize(
     vec3<f32>(
-      normalTexel.x * 2.0 - 1.0,
-      normalTexel.y * 2.0 - 1.0,
+      (normalTexel.x * 2.0 - 1.0) * normalScale,
+      (normalTexel.y * 2.0 - 1.0) * normalScale,
       1.0 + ((normalTexel.z * 2.0 - 1.0) - 1.0) * normalScale
     ),
     vec3<f32>(0.0, 0.0, 1.0)
@@ -3613,7 +3659,11 @@ fn sample_surface_material(
     triangle.materialExtension,
     triangle.specularColor,
     repair_shading_normal(geometricNormal, mappedNormal),
-    clamp(occlusionTexel.x * max(triangle.textureSettings.y, 0.0), 0.0, 1.0)
+    clamp(
+      mix(1.0, occlusionTexel.x, clamp(triangle.textureSettings.y, 0.0, 1.0)),
+      0.0,
+      1.0
+    )
   );
 }
 
@@ -3858,6 +3908,21 @@ fn environment_pdf_dimensions() -> vec2<u32> {
   );
 }
 
+fn environment_importance_sampling_enabled() -> bool {
+  return config.environmentMapMeta.w > 0.5;
+}
+
+fn uniform_sphere_pdf() -> f32 {
+  return 1.0 / (4.0 * 3.14159265359);
+}
+
+fn sample_uniform_sphere_direction(sample: vec2<f32>) -> vec3<f32> {
+  let z = 1.0 - 2.0 * sample.y;
+  let radial = sqrt(max(1.0 - z * z, 0.0));
+  let phi = sample.x * 6.28318530718;
+  return vec3<f32>(cos(phi) * radial, z, sin(phi) * radial);
+}
+
 fn environment_sampling_texel(x: u32, y: u32) -> vec4<f32> {
   return textureLoad(environmentSamplingTexture, vec2<i32>(i32(x), i32(y)), 0);
 }
@@ -3875,6 +3940,9 @@ fn environment_column_cdf_texel(x: u32, y: u32) -> f32 {
 }
 
 fn environment_direction_pdf(direction: vec3<f32>) -> f32 {
+  if (!environment_importance_sampling_enabled()) {
+    return uniform_sphere_pdf();
+  }
   let rayDirection = safe_normalize(direction, vec3<f32>(0.0, 1.0, 0.0));
   let uv = environment_map_uv(rayDirection);
   let dimensions = environment_pdf_dimensions();
@@ -3937,6 +4005,10 @@ struct EnvironmentSample {
 };
 
 fn sample_environment_importance(sample: vec2<f32>) -> EnvironmentSample {
+  if (!environment_importance_sampling_enabled()) {
+    let direction = sample_uniform_sphere_direction(sample);
+    return EnvironmentSample(direction, base_environment_radiance(direction), uniform_sphere_pdf());
+  }
   let dimensions = environment_pdf_dimensions();
   let row = sample_row_cdf(dimensions.y, sample.y);
   let column = sample_column_cdf(row, dimensions.x, sample.x);
@@ -5202,6 +5274,31 @@ fn scatter_direction(ray: RayRecord, hit: HitRecord, seed: u32) -> ScatterResult
     );
   }
 
+  let guidedEmissiveAvailable = config.emissiveTriangleCount > 0u;
+  let guidedPortalAvailable =
+    config.environmentPortalCount > 0u && config.environmentPortalMode != 0u;
+  let guidedSelector = random01(seed + 17u);
+  if (guidedEmissiveAvailable && guidedSelector < 0.18) {
+    let guidedDirection = sample_emissive_triangle_direction(hit, seed + 101u, normal);
+    if (dot(normal, guidedDirection) > 0.000001) {
+      let guidedPdf = max(evaluate_surface_bsdf_pdf(hit, viewDirection, guidedDirection), 0.000001);
+      return ScatterResult(
+        vec4<f32>(guidedDirection, 0.0),
+        guidedPdf,
+        RAY_FLAG_GUIDED_EMISSIVE,
+        0u,
+        0u
+      );
+    }
+  }
+  if (guidedPortalAvailable && guidedSelector < 0.32) {
+    let guidedDirection = sample_environment_portal_direction(hit, seed + 131u, normal);
+    if (dot(normal, guidedDirection) > 0.000001) {
+      let guidedPdf = max(evaluate_surface_bsdf_pdf(hit, viewDirection, guidedDirection), 0.000001);
+      return ScatterResult(vec4<f32>(guidedDirection, 0.0), guidedPdf, 0u, 0u, 0u);
+    }
+  }
+
   let weights = surface_bsdf_sampling_weights(hit);
   let selector = random01(seed + 31u);
   var lightDirection = normal;
@@ -5586,6 +5683,7 @@ function createEnvironmentMapSnapshot(environmentMap) {
     intensity: environmentMap.intensity,
     rotationRadians: environmentMap.rotationRadians,
     ambientStrength: environmentMap.ambientStrength,
+    hasImportanceData: environmentMap.hasImportanceData === true,
   });
 }
 
@@ -5841,6 +5939,12 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
     config.environmentMap,
     config.environmentColor
   );
+  const environmentSamplingResource = createEnvironmentSamplingTextureResource(
+    device,
+    constants,
+    config.environmentMap,
+    config.environmentColor
+  );
   config = Object.freeze({
     ...config,
     environmentMap: Object.freeze({
@@ -5848,14 +5952,9 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
       width: environmentMapResource.width,
       height: environmentMapResource.height,
       mipLevelCount: environmentMapResource.mipLevelCount,
+      hasImportanceData: environmentSamplingResource.hasImportanceData,
     }),
   });
-  const environmentSamplingResource = createEnvironmentSamplingTextureResource(
-    device,
-    constants,
-    config.environmentMap,
-    config.environmentColor
-  );
   const brdfLutResource = createBrdfLutResource(device, constants);
   const baseColorAtlasResource = createAtlasTextureResource(
     device,
@@ -6888,10 +6987,8 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
     });
   }
 
-  function updateSceneObjects(sceneObjects) {
-    const nextPackedScene = packWavefrontSceneObjects(sceneObjects, config.sceneObjectCapacity);
-    packedScene = nextPackedScene;
-    config = createWavefrontPathTracingComputeConfig({
+  function rebuildLiveConfig(overrides = {}) {
+    return createWavefrontPathTracingComputeConfig({
       ...options,
       canvas,
       width: config.width,
@@ -6902,27 +6999,25 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
       sceneObjectCapacity: config.sceneObjectCapacity,
       sceneObjects: packedScene.objects,
       camera: activeCameraOptions,
+      environmentMap: {
+        ...config.environmentMap,
+      },
       frameIndex: config.frameIndex,
+      ...overrides,
     });
+  }
+
+  function updateSceneObjects(sceneObjects) {
+    const nextPackedScene = packWavefrontSceneObjects(sceneObjects, config.sceneObjectCapacity);
+    packedScene = nextPackedScene;
+    config = rebuildLiveConfig();
     device.queue.writeBuffer(sceneObjectBuffer, 0, packedScene.buffer);
     return config;
   }
 
   function updateCamera(cameraOptions = {}) {
     activeCameraOptions = cameraOptions;
-    config = createWavefrontPathTracingComputeConfig({
-      ...options,
-      canvas,
-      width: config.width,
-      height: config.height,
-      maxDepth: config.maxDepth,
-      tileSize: config.tileSize,
-      samplesPerPixel: config.samplesPerPixel,
-      sceneObjectCapacity: config.sceneObjectCapacity,
-      sceneObjects: packedScene.objects,
-      camera: activeCameraOptions,
-      frameIndex: config.frameIndex,
-    });
+    config = rebuildLiveConfig();
     return config;
   }
 

--- a/src/wavefront-compute.js
+++ b/src/wavefront-compute.js
@@ -1,3 +1,12 @@
+import {
+  createGpuParallelismCounters,
+  createGpuParallelismDiagnostics,
+  createGpuSubmissionBatcher,
+  createGpuWorkerJobDiagnostics,
+  recordDirectDispatch,
+  recordIndirectDispatch,
+} from "./wavefront-frame-runtime.js"
+
 const DEFAULT_WIDTH = 1280;
 const DEFAULT_HEIGHT = 720;
 const DEFAULT_MAX_DEPTH = 6;
@@ -5567,84 +5576,6 @@ function createGpuAdapterParallelismDiagnostics(adapter, device) {
   });
 }
 
-function createGpuParallelismCounters() {
-  return {
-    directDispatches: 0,
-    directWorkgroups: 0,
-    directShaderInvocations: 0,
-    multiWorkgroupDispatches: 0,
-    largestDirectWorkgroupsPerDispatch: 0,
-    indirectDispatches: 0,
-    estimatedIndirectWorkgroupsUpperBound: 0,
-    estimatedIndirectShaderInvocationsUpperBound: 0,
-    indirectDispatchesWithMultiWorkgroupCapacity: 0,
-    largestEstimatedIndirectWorkgroupsPerDispatch: 0,
-  };
-}
-
-function countDispatchWorkgroups(groups) {
-  return groups.reduce((product, value) => {
-    const numeric = Number(value ?? 1);
-    const count = Number.isFinite(numeric) ? Math.max(1, Math.trunc(numeric)) : 1;
-    return product * count;
-  }, 1);
-}
-
-function recordDirectDispatch(parallelism, groups, invocationsPerWorkgroup = WORKGROUP_SIZE) {
-  const workgroups = countDispatchWorkgroups(groups);
-  parallelism.directDispatches += 1;
-  parallelism.directWorkgroups += workgroups;
-  parallelism.directShaderInvocations += workgroups * invocationsPerWorkgroup;
-  parallelism.largestDirectWorkgroupsPerDispatch = Math.max(
-    parallelism.largestDirectWorkgroupsPerDispatch,
-    workgroups
-  );
-  if (workgroups > 1) {
-    parallelism.multiWorkgroupDispatches += 1;
-  }
-}
-
-function recordIndirectDispatch(parallelism, estimatedWorkgroupsUpperBound, invocationsPerWorkgroup = WORKGROUP_SIZE) {
-  const workgroups = Math.max(1, Math.trunc(Number(estimatedWorkgroupsUpperBound) || 1));
-  parallelism.indirectDispatches += 1;
-  parallelism.estimatedIndirectWorkgroupsUpperBound += workgroups;
-  parallelism.estimatedIndirectShaderInvocationsUpperBound += workgroups * invocationsPerWorkgroup;
-  parallelism.largestEstimatedIndirectWorkgroupsPerDispatch = Math.max(
-    parallelism.largestEstimatedIndirectWorkgroupsPerDispatch,
-    workgroups
-  );
-  if (workgroups > 1) {
-    parallelism.indirectDispatchesWithMultiWorkgroupCapacity += 1;
-  }
-}
-
-function createGpuParallelismDiagnostics(adapterDiagnostics, counters) {
-  const totalEstimatedWorkgroupsUpperBound =
-    counters.directWorkgroups + counters.estimatedIndirectWorkgroupsUpperBound;
-  const totalEstimatedShaderInvocationsUpperBound =
-    counters.directShaderInvocations + counters.estimatedIndirectShaderInvocationsUpperBound;
-  const exposesMultiWorkgroupParallelism =
-    counters.multiWorkgroupDispatches > 0 || counters.indirectDispatchesWithMultiWorkgroupCapacity > 0;
-  return Object.freeze({
-    ...adapterDiagnostics,
-    directDispatches: counters.directDispatches,
-    directWorkgroups: counters.directWorkgroups,
-    directShaderInvocations: counters.directShaderInvocations,
-    multiWorkgroupDispatches: counters.multiWorkgroupDispatches,
-    largestDirectWorkgroupsPerDispatch: counters.largestDirectWorkgroupsPerDispatch,
-    indirectDispatches: counters.indirectDispatches,
-    estimatedIndirectWorkgroupsUpperBound: counters.estimatedIndirectWorkgroupsUpperBound,
-    estimatedIndirectShaderInvocationsUpperBound: counters.estimatedIndirectShaderInvocationsUpperBound,
-    indirectDispatchesWithMultiWorkgroupCapacity: counters.indirectDispatchesWithMultiWorkgroupCapacity,
-    largestEstimatedIndirectWorkgroupsPerDispatch: counters.largestEstimatedIndirectWorkgroupsPerDispatch,
-    totalEstimatedWorkgroupsUpperBound,
-    totalEstimatedShaderInvocationsUpperBound,
-    exposesMultiWorkgroupParallelism,
-    likelyUsesMoreThanOnePhysicalGpuCore: null,
-    coreUtilizationStatus: "not-exposed-by-webgpu",
-  });
-}
-
 function createEnvironmentMapSnapshot(environmentMap) {
   return Object.freeze({
     enabled: environmentMap.enabled,
@@ -5663,30 +5594,6 @@ function nowMs() {
     return performance.now();
   }
   return Date.now();
-}
-
-function createGpuWorkerJobDiagnostics(
-  parallelism,
-  commandSubmissions,
-  frameTimeMs,
-  awaitedGpuCompletion
-) {
-  const directDispatchesCompleted = Math.max(0, Number(parallelism?.directDispatches ?? 0));
-  const indirectDispatchesCompleted = Math.max(0, Number(parallelism?.indirectDispatches ?? 0));
-  const completedPerFrame = directDispatchesCompleted + indirectDispatchesCompleted;
-  const completedPerSubmission =
-    commandSubmissions > 0 ? completedPerFrame / commandSubmissions : completedPerFrame;
-  const completedPerSecond =
-    awaitedGpuCompletion && frameTimeMs > 0 ? (completedPerFrame * 1000) / frameTimeMs : null;
-  return Object.freeze({
-    completedPerFrame,
-    completedPerSecond,
-    completedPerSubmission,
-    directDispatchesCompleted,
-    indirectDispatchesCompleted,
-    frameTimeMs,
-    awaitedGpuCompletion,
-  });
 }
 
 function estimateSubmittedGpuWorkTimeoutMs(config, tileCount, overrideTimeoutMs = null) {
@@ -6491,7 +6398,7 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
     passEncoder.setPipeline(pipelines.prepareMeshTrianglesAndLeaves);
     const prepareWorkgroups = Math.ceil(config.bvhLeafSortCapacity / WORKGROUP_SIZE);
     passEncoder.dispatchWorkgroups(prepareWorkgroups);
-    recordDirectDispatch(parallelism, [prepareWorkgroups]);
+    recordDirectDispatch(parallelism, [prepareWorkgroups], WORKGROUP_SIZE);
     passEncoder.setPipeline(pipelines.sortBvhLeafRefs);
     for (let stageIndex = 0; stageIndex < config.bvhSortStages.length; stageIndex += 1) {
       passEncoder.setBindGroup(0, bvhBuildBindGroup, [
@@ -6499,13 +6406,13 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
       ]);
       const sortWorkgroups = Math.ceil(config.bvhLeafSortCapacity / WORKGROUP_SIZE);
       passEncoder.dispatchWorkgroups(sortWorkgroups);
-      recordDirectDispatch(parallelism, [sortWorkgroups]);
+      recordDirectDispatch(parallelism, [sortWorkgroups], WORKGROUP_SIZE);
     }
     passEncoder.setBindGroup(0, bvhBuildBindGroup, [0]);
     passEncoder.setPipeline(pipelines.writeSortedBvhLeaves);
     const leafWriteWorkgroups = Math.ceil(config.triangleCount / WORKGROUP_SIZE);
     passEncoder.dispatchWorkgroups(leafWriteWorkgroups);
-    recordDirectDispatch(parallelism, [leafWriteWorkgroups]);
+    recordDirectDispatch(parallelism, [leafWriteWorkgroups], WORKGROUP_SIZE);
     passEncoder.setPipeline(pipelines.buildBvhInternalLevel);
     for (let levelIndex = 0; levelIndex < config.bvhBuildLevels.length; levelIndex += 1) {
       const buildLevel = config.bvhBuildLevels[levelIndex];
@@ -6514,7 +6421,7 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
       ]);
       const levelWorkgroups = Math.ceil(buildLevel.count / WORKGROUP_SIZE);
       passEncoder.dispatchWorkgroups(levelWorkgroups);
-      recordDirectDispatch(parallelism, [levelWorkgroups]);
+      recordDirectDispatch(parallelism, [levelWorkgroups], WORKGROUP_SIZE);
     }
     passEncoder.end();
     device.queue.submit([encoder.finish()]);
@@ -6532,7 +6439,7 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
     generatePass.setBindGroup(0, bindGroups[0], [configOffset]);
     generatePass.setPipeline(pipelines.generatePrimaryRays);
     generatePass.dispatchWorkgroups(tileWorkgroups);
-    recordDirectDispatch(parallelism, [tileWorkgroups]);
+    recordDirectDispatch(parallelism, [tileWorkgroups], WORKGROUP_SIZE);
     generatePass.end();
 
     for (let bounceIndex = 0; bounceIndex < config.maxDepth; bounceIndex += 1) {
@@ -6549,10 +6456,10 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
       passEncoder.setBindGroup(0, bindGroups[bounceIndex % 2], [configOffset]);
       passEncoder.setPipeline(pipelines.intersectActiveQueue);
       passEncoder.dispatchWorkgroupsIndirect(activeDispatchBuffer, 0);
-      recordIndirectDispatch(parallelism, tileWorkgroups);
+      recordIndirectDispatch(parallelism, tileWorkgroups, WORKGROUP_SIZE);
       passEncoder.setPipeline(pipelines.resolveSurfaceRecords);
       passEncoder.dispatchWorkgroupsIndirect(activeDispatchBuffer, 0);
-      recordIndirectDispatch(parallelism, tileWorkgroups);
+      recordIndirectDispatch(parallelism, tileWorkgroups, WORKGROUP_SIZE);
       passEncoder.setPipeline(pipelines.compactAndSwapQueues);
       passEncoder.dispatchWorkgroups(1);
       recordDirectDispatch(parallelism, [1], 1);
@@ -6569,7 +6476,7 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
     passEncoder.setBindGroup(0, bindGroups[0], [configOffset]);
     passEncoder.setPipeline(pipelines.accumulateTerminalRadiance);
     passEncoder.dispatchWorkgroups(tileWorkgroups);
-    recordDirectDispatch(parallelism, [tileWorkgroups]);
+    recordDirectDispatch(parallelism, [tileWorkgroups], WORKGROUP_SIZE);
     passEncoder.end();
   }
 
@@ -6587,7 +6494,11 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
       radiancePass.setBindGroup(0, denoiseRadianceBindGroup, [configOffset]);
       radiancePass.setPipeline(pipelines.denoiseLinearRadiance);
       radiancePass.dispatchWorkgroups(denoiseWorkgroupsX, denoiseWorkgroupsY);
-      recordDirectDispatch(parallelism, [denoiseWorkgroupsX, denoiseWorkgroupsY]);
+      recordDirectDispatch(
+        parallelism,
+        [denoiseWorkgroupsX, denoiseWorkgroupsY],
+        WORKGROUP_SIZE
+      );
       radiancePass.end();
     }
 
@@ -6601,7 +6512,11 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
     );
     resolvePass.setPipeline(pipelines.resolveDenoisedOutputImage);
     resolvePass.dispatchWorkgroups(denoiseWorkgroupsX, denoiseWorkgroupsY);
-    recordDirectDispatch(parallelism, [denoiseWorkgroupsX, denoiseWorkgroupsY]);
+    recordDirectDispatch(
+      parallelism,
+      [denoiseWorkgroupsX, denoiseWorkgroupsY],
+      WORKGROUP_SIZE
+    );
     resolvePass.end();
   }
 
@@ -6626,34 +6541,11 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
 
   function dispatchFrame(frameIndex, parallelism, renderedSamplesPerPixel = config.samplesPerPixel) {
     const writeFrameConfig = createFrameConfigWriter(frameIndex);
-    let submissionCount = 0;
-    let encodedFramePasses = 0;
-    let encoder = device.createCommandEncoder({
-      label: `plasius.wavefront.frame.${frameIndex}.batched.${submissionCount + 1}`,
+    const batch = createGpuSubmissionBatcher({
+      device,
+      frameIndex,
+      maxFramePassesPerSubmission: config.maxFramePassesPerSubmission,
     });
-
-    function submitCurrentEncoder() {
-      if (encodedFramePasses <= 0) {
-        return;
-      }
-      device.queue.submit([encoder.finish()]);
-      submissionCount += 1;
-      encodedFramePasses = 0;
-      encoder = device.createCommandEncoder({
-        label: `plasius.wavefront.frame.${frameIndex}.batched.${submissionCount + 1}`,
-      });
-    }
-
-    function reserveEncoder(passCount = 1) {
-      if (
-        encodedFramePasses > 0 &&
-        encodedFramePasses + passCount > config.maxFramePassesPerSubmission
-      ) {
-        submitCurrentEncoder();
-      }
-      encodedFramePasses += passCount;
-      return encoder;
-    }
 
     for (const tile of tiles) {
       for (let sampleIndex = 0; sampleIndex < renderedSamplesPerPixel; sampleIndex += 1) {
@@ -6662,13 +6554,13 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
           sampleWeight: 1 / renderedSamplesPerPixel,
         });
         encodeTileSample(
-          reserveEncoder(config.maxDepth + 1),
+          batch.reserve(config.maxDepth + 1),
           tile,
           configOffset,
           parallelism
         );
         if (config.deferredPathResolve) {
-          encodeTileOutput(reserveEncoder(1), tile, configOffset, parallelism);
+          encodeTileOutput(batch.reserve(1), tile, configOffset, parallelism);
         }
       }
       if (!config.deferredPathResolve) {
@@ -6676,7 +6568,7 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
           sampleIndex: 0,
           sampleWeight: 1 / renderedSamplesPerPixel,
         });
-        encodeTileOutput(reserveEncoder(1), tile, outputConfigOffset, parallelism);
+        encodeTileOutput(batch.reserve(1), tile, outputConfigOffset, parallelism);
       }
     }
     if (config.denoise) {
@@ -6686,15 +6578,14 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
       );
       const denoisePassCount = renderedSamplesPerPixel < 4 ? 2 : 1;
       encodeDenoise(
-        reserveEncoder(denoisePassCount),
+        batch.reserve(denoisePassCount),
         denoiseConfigOffset,
         parallelism,
         renderedSamplesPerPixel
       );
     }
-    encodePresent(reserveEncoder(1));
-    submitCurrentEncoder();
-    return submissionCount;
+    encodePresent(batch.reserve(1));
+    return batch.flush();
   }
 
   function renderOnce(renderOptions = {}, resolvedSamplingPlan = null) {
@@ -6809,42 +6700,6 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
     );
     let submissionCount = 0;
 
-    function createSubmissionController() {
-      let encodedFramePasses = 0;
-      let localSubmissions = 0;
-      let encoder = device.createCommandEncoder({
-        label: `plasius.wavefront.frame.${frameIndex}.batched.${submissionCount + localSubmissions + 1}`,
-      });
-
-      return {
-        reserve(passCount = 1) {
-          if (
-            encodedFramePasses > 0 &&
-            encodedFramePasses + passCount > config.maxFramePassesPerSubmission
-          ) {
-            const finished = encoder.finish();
-            device.queue.submit([finished]);
-            localSubmissions += 1;
-            encodedFramePasses = 0;
-            encoder = device.createCommandEncoder({
-              label: `plasius.wavefront.frame.${frameIndex}.batched.${submissionCount + localSubmissions + 1}`,
-            });
-          }
-          encodedFramePasses += passCount;
-          return encoder;
-        },
-        flush() {
-          if (encodedFramePasses <= 0) {
-            return 0;
-          }
-          device.queue.submit([encoder.finish()]);
-          localSubmissions += 1;
-          encodedFramePasses = 0;
-          return localSubmissions;
-        },
-      };
-    }
-
     for (const tile of tiles) {
       for (
         let sampleStart = 0;
@@ -6852,7 +6707,12 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
         sampleStart += sampleBatchSize
       ) {
         const sampleEnd = Math.min(renderedSamplesPerPixel, sampleStart + sampleBatchSize);
-        const batch = createSubmissionController();
+        const batch = createGpuSubmissionBatcher({
+          device,
+          frameIndex,
+          maxFramePassesPerSubmission: config.maxFramePassesPerSubmission,
+          startingSubmissionCount: submissionCount,
+        });
         let slot = 0;
         for (let sampleIndex = sampleStart; sampleIndex < sampleEnd; sampleIndex += 1) {
           const configOffset = writeFrameConfigSlot(slot, tile, frameIndex, {
@@ -6877,11 +6737,17 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
           });
           encodeTileOutput(batch.reserve(1), tile, outputConfigOffset, parallelism);
         }
-        submissionCount += batch.flush();
+        batch.flush();
+        submissionCount += batch.getSubmissionCount();
       }
     }
 
-    const tail = createSubmissionController();
+    const tail = createGpuSubmissionBatcher({
+      device,
+      frameIndex,
+      maxFramePassesPerSubmission: config.maxFramePassesPerSubmission,
+      startingSubmissionCount: submissionCount,
+    });
     if (config.denoise) {
       const denoiseConfigOffset = writeFrameConfigSlot(
         0,
@@ -6897,7 +6763,8 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
       );
     }
     encodePresent(tail.reserve(1));
-    submissionCount += tail.flush();
+    tail.flush();
+    submissionCount += tail.getSubmissionCount();
     return submissionCount;
   }
 

--- a/src/wavefront-frame-runtime.js
+++ b/src/wavefront-frame-runtime.js
@@ -1,0 +1,167 @@
+export function createGpuParallelismCounters() {
+  return {
+    directDispatches: 0,
+    directWorkgroups: 0,
+    directShaderInvocations: 0,
+    multiWorkgroupDispatches: 0,
+    largestDirectWorkgroupsPerDispatch: 0,
+    indirectDispatches: 0,
+    estimatedIndirectWorkgroupsUpperBound: 0,
+    estimatedIndirectShaderInvocationsUpperBound: 0,
+    indirectDispatchesWithMultiWorkgroupCapacity: 0,
+    largestEstimatedIndirectWorkgroupsPerDispatch: 0,
+  }
+}
+
+function countDispatchWorkgroups(groups) {
+  return groups.reduce((product, value) => {
+    const numeric = Number(value ?? 1)
+    const count = Number.isFinite(numeric) ? Math.max(1, Math.trunc(numeric)) : 1
+    return product * count
+  }, 1)
+}
+
+export function recordDirectDispatch(
+  parallelism,
+  groups,
+  invocationsPerWorkgroup = 1
+) {
+  const workgroups = countDispatchWorkgroups(groups)
+  parallelism.directDispatches += 1
+  parallelism.directWorkgroups += workgroups
+  parallelism.directShaderInvocations += workgroups * invocationsPerWorkgroup
+  parallelism.largestDirectWorkgroupsPerDispatch = Math.max(
+    parallelism.largestDirectWorkgroupsPerDispatch,
+    workgroups
+  )
+  if (workgroups > 1) {
+    parallelism.multiWorkgroupDispatches += 1
+  }
+}
+
+export function recordIndirectDispatch(
+  parallelism,
+  estimatedWorkgroupsUpperBound,
+  invocationsPerWorkgroup = 1
+) {
+  const workgroups = Math.max(1, Math.trunc(Number(estimatedWorkgroupsUpperBound) || 1))
+  parallelism.indirectDispatches += 1
+  parallelism.estimatedIndirectWorkgroupsUpperBound += workgroups
+  parallelism.estimatedIndirectShaderInvocationsUpperBound +=
+    workgroups * invocationsPerWorkgroup
+  parallelism.largestEstimatedIndirectWorkgroupsPerDispatch = Math.max(
+    parallelism.largestEstimatedIndirectWorkgroupsPerDispatch,
+    workgroups
+  )
+  if (workgroups > 1) {
+    parallelism.indirectDispatchesWithMultiWorkgroupCapacity += 1
+  }
+}
+
+export function createGpuParallelismDiagnostics(adapterDiagnostics, counters) {
+  const totalEstimatedWorkgroupsUpperBound =
+    counters.directWorkgroups + counters.estimatedIndirectWorkgroupsUpperBound
+  const totalEstimatedShaderInvocationsUpperBound =
+    counters.directShaderInvocations +
+    counters.estimatedIndirectShaderInvocationsUpperBound
+  const exposesMultiWorkgroupParallelism =
+    counters.multiWorkgroupDispatches > 0 ||
+    counters.indirectDispatchesWithMultiWorkgroupCapacity > 0
+  return Object.freeze({
+    ...adapterDiagnostics,
+    directDispatches: counters.directDispatches,
+    directWorkgroups: counters.directWorkgroups,
+    directShaderInvocations: counters.directShaderInvocations,
+    multiWorkgroupDispatches: counters.multiWorkgroupDispatches,
+    largestDirectWorkgroupsPerDispatch: counters.largestDirectWorkgroupsPerDispatch,
+    indirectDispatches: counters.indirectDispatches,
+    estimatedIndirectWorkgroupsUpperBound: counters.estimatedIndirectWorkgroupsUpperBound,
+    estimatedIndirectShaderInvocationsUpperBound:
+      counters.estimatedIndirectShaderInvocationsUpperBound,
+    indirectDispatchesWithMultiWorkgroupCapacity:
+      counters.indirectDispatchesWithMultiWorkgroupCapacity,
+    largestEstimatedIndirectWorkgroupsPerDispatch:
+      counters.largestEstimatedIndirectWorkgroupsPerDispatch,
+    totalEstimatedWorkgroupsUpperBound,
+    totalEstimatedShaderInvocationsUpperBound,
+    exposesMultiWorkgroupParallelism,
+    likelyUsesMoreThanOnePhysicalGpuCore: null,
+    coreUtilizationStatus: "not-exposed-by-webgpu",
+  })
+}
+
+export function createGpuWorkerJobDiagnostics(
+  parallelism,
+  commandSubmissions,
+  frameTimeMs,
+  awaitedGpuCompletion
+) {
+  const directDispatchesCompleted = Math.max(0, Number(parallelism?.directDispatches ?? 0))
+  const indirectDispatchesCompleted = Math.max(
+    0,
+    Number(parallelism?.indirectDispatches ?? 0)
+  )
+  const completedPerFrame = directDispatchesCompleted + indirectDispatchesCompleted
+  const completedPerSubmission =
+    commandSubmissions > 0 ? completedPerFrame / commandSubmissions : completedPerFrame
+  const completedPerSecond =
+    awaitedGpuCompletion && frameTimeMs > 0 ? (completedPerFrame * 1000) / frameTimeMs : null
+  return Object.freeze({
+    completedPerFrame,
+    completedPerSecond,
+    completedPerSubmission,
+    directDispatchesCompleted,
+    indirectDispatchesCompleted,
+    frameTimeMs,
+    awaitedGpuCompletion,
+  })
+}
+
+export function createGpuSubmissionBatcher({
+  device,
+  frameIndex,
+  maxFramePassesPerSubmission,
+  startingSubmissionCount = 0,
+  labelPrefix = "plasius.wavefront.frame",
+}) {
+  let encodedFramePasses = 0
+  let submissionCount = 0
+  let encoder = createCommandEncoder()
+
+  function createCommandEncoder() {
+    return device.createCommandEncoder({
+      label: `${labelPrefix}.${frameIndex}.batched.${startingSubmissionCount + submissionCount + 1}`,
+    })
+  }
+
+  function submitCurrentEncoder() {
+    if (encodedFramePasses <= 0) {
+      return false
+    }
+    device.queue.submit([encoder.finish()])
+    submissionCount += 1
+    encodedFramePasses = 0
+    encoder = createCommandEncoder()
+    return true
+  }
+
+  return Object.freeze({
+    reserve(passCount = 1) {
+      if (
+        encodedFramePasses > 0 &&
+        encodedFramePasses + passCount > maxFramePassesPerSubmission
+      ) {
+        submitCurrentEncoder()
+      }
+      encodedFramePasses += passCount
+      return encoder
+    },
+    flush() {
+      submitCurrentEncoder()
+      return submissionCount
+    },
+    getSubmissionCount() {
+      return submissionCount
+    },
+  })
+}

--- a/tests/package.test.js
+++ b/tests/package.test.js
@@ -3,8 +3,8 @@ import assert from "node:assert/strict";
 import {
   bindRendererToXrManager,
   createGpuRenderer,
-  createWavefrontAdaptiveSamplingLevels,
   createRendererDebugHooks,
+  createWavefrontAdaptiveSamplingLevels,
   defaultRendererWorkerProfile,
   defaultRendererClearColor,
   getRendererWorkerManifest,
@@ -16,6 +16,13 @@ import {
   rendererWorkerQueueClass,
   supportsWebGpu,
 } from "../src/index.js";
+import {
+  createGpuParallelismCounters,
+  createGpuSubmissionBatcher,
+  createGpuWorkerJobDiagnostics,
+  recordDirectDispatch,
+  recordIndirectDispatch,
+} from "../src/wavefront-frame-runtime.js";
 
 class FakeRenderPass {
   constructor() {
@@ -262,6 +269,76 @@ test("createRendererDebugHooks records frame samples against a debug session", (
       frameTimeMs: 13.8,
       targetFrameTimeMs: 1000 / 72,
     },
+  ]);
+});
+
+test("wavefront frame runtime tracks dispatch diagnostics without renderer state", () => {
+  const counters = createGpuParallelismCounters();
+
+  recordDirectDispatch(counters, [8], 64);
+  recordIndirectDispatch(counters, 5, 64);
+
+  const diagnostics = createGpuWorkerJobDiagnostics(
+    {
+      directDispatches: counters.directDispatches,
+      indirectDispatches: counters.indirectDispatches,
+    },
+    2,
+    10,
+    true
+  );
+
+  assert.equal(counters.directDispatches, 1);
+  assert.equal(counters.directWorkgroups, 8);
+  assert.equal(counters.directShaderInvocations, 512);
+  assert.equal(counters.indirectDispatches, 1);
+  assert.equal(counters.estimatedIndirectWorkgroupsUpperBound, 5);
+  assert.equal(diagnostics.completedPerFrame, 2);
+  assert.equal(diagnostics.completedPerSubmission, 1);
+  assert.equal(diagnostics.completedPerSecond, 200);
+});
+
+test("wavefront frame runtime batches submissions against a per-submit pass ceiling", () => {
+  const labels = [];
+  const submits = [];
+  const device = {
+    createCommandEncoder({ label }) {
+      labels.push(label);
+      return {
+        finish() {
+          return { label };
+        },
+      };
+    },
+    queue: {
+      submit(commandBuffers) {
+        submits.push(commandBuffers.map((buffer) => buffer.label));
+      },
+    },
+  };
+
+  const batch = createGpuSubmissionBatcher({
+    device,
+    frameIndex: 9,
+    maxFramePassesPerSubmission: 3,
+    startingSubmissionCount: 2,
+  });
+
+  const first = batch.reserve(2);
+  const second = batch.reserve(2);
+  batch.reserve(1);
+  const flushed = batch.flush();
+
+  assert.notEqual(first, second);
+  assert.equal(flushed, 2);
+  assert.deepEqual(submits, [
+    ["plasius.wavefront.frame.9.batched.3"],
+    ["plasius.wavefront.frame.9.batched.4"],
+  ]);
+  assert.deepEqual(labels, [
+    "plasius.wavefront.frame.9.batched.3",
+    "plasius.wavefront.frame.9.batched.4",
+    "plasius.wavefront.frame.9.batched.5",
   ]);
 });
 

--- a/tests/package.test.js
+++ b/tests/package.test.js
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import {
   bindRendererToXrManager,
   createGpuRenderer,
+  createWavefrontAdaptiveSamplingLevels,
   createRendererDebugHooks,
   defaultRendererWorkerProfile,
   defaultRendererClearColor,
@@ -330,6 +331,22 @@ test("renderer worker profiles expose realtime and xr frame-stage DAGs", () => {
       "Frame-stage DAG for XR rendering with late-latch coordination before main encode and submit.",
     jobs: ["acquire", "visibility", "lateLatch", "mainEncode", "submit"],
   });
+});
+
+test("wavefront adaptive sampling levels expose bounded power-of-two ladders", () => {
+  const plan = createWavefrontAdaptiveSamplingLevels({
+    samplesPerPixel: 32,
+    frameTimeBudgetMs: 16,
+    minimumSamplesPerPixel: 1,
+  });
+
+  assert.equal(plan.requestedSamplesPerPixel, 32);
+  assert.equal(plan.minimumSamplesPerPixel, 1);
+  assert.equal(plan.frameTimeBudgetMs, 16);
+  assert.deepEqual(
+    plan.levels.map((level) => level.config.samplesPerPixel),
+    [1, 2, 4, 8, 16, 32]
+  );
 });
 
 test("renderer worker manifests publish queue, priority, and dependency metadata", () => {

--- a/tests/wavefront-compute.test.js
+++ b/tests/wavefront-compute.test.js
@@ -790,7 +790,8 @@ test("wavefront compute defers visible colour until terminal path resolve", () =
     /accumulation\[ray\.rayId\] =\s+accumulation\[ray\.rayId\] \+\s+vec4<f32>\(directEnvironment \* sample_weight\(\), 0\.0\);/
   );
   assert.match(source, /if \(config\.deferredPathResolve\) \{/);
-  assert.match(source, /encodeTileOutput\(reserveEncoder\(1\), tile, configOffset, parallelism\);/);
+  assert.match(source, /createGpuSubmissionBatcher\(\{/);
+  assert.match(source, /encodeTileOutput\(batch\.reserve\(1\), tile, configOffset, parallelism\);/);
 });
 
 test("analytic wavefront renderer rejects display-quality requests", () => {

--- a/tests/wavefront-compute.test.js
+++ b/tests/wavefront-compute.test.js
@@ -7,6 +7,7 @@ import {
   createWavefrontBvhBuildLevels,
   createWavefrontBvhSortStages,
   createWavefrontEmissiveTriangleIndexSource,
+  createWavefrontGpuMaterialSource,
   createWavefrontGpuMeshSource,
   createWavefrontMeshAcceleration,
   createWavefrontPathTracingComputeConfig,
@@ -87,15 +88,27 @@ async function withWebGpuConstants(callback) {
   }
 }
 
+function serialWebGpuTest(name, fn) {
+  return test(name, { concurrency: false }, fn);
+}
+
 class FakeWavefrontBuffer {
-  constructor(descriptor) {
+  constructor(device, descriptor) {
+    this.device = device;
     this.descriptor = descriptor;
     this.destroyed = false;
     this.readback = new Uint8Array(256);
     this.readback.set([32, 64, 128, 255]);
   }
 
-  async mapAsync() {}
+  async mapAsync() {
+    if (
+      this.device.requireSubmittedWorkDoneBeforeMapAsync === true &&
+      this.device.queue.submittedWorkDone !== true
+    ) {
+      throw new Error("mapAsync called before queue work completion.");
+    }
+  }
 
   getMappedRange() {
     return this.readback.buffer;
@@ -234,8 +247,15 @@ class FakeWavefrontDevice {
       submissions: [],
       writes: [],
       textureWrites: [],
+      submittedWorkDone: false,
+      submittedWorkDoneCalls: 0,
       submit: (buffers) => {
         this.queue.submissions.push(buffers);
+        this.queue.submittedWorkDone = false;
+      },
+      onSubmittedWorkDone: async () => {
+        this.queue.submittedWorkDoneCalls += 1;
+        this.queue.submittedWorkDone = true;
       },
       writeBuffer: (buffer, offset, data) => {
         this.queue.writes.push({ buffer, offset, byteLength: data.byteLength ?? data.length ?? 0 });
@@ -256,7 +276,7 @@ class FakeWavefrontDevice {
   }
 
   createBuffer(descriptor) {
-    const buffer = new FakeWavefrontBuffer(descriptor);
+    const buffer = new FakeWavefrontBuffer(this, descriptor);
     this.buffers.push(buffer);
     return buffer;
   }
@@ -367,13 +387,13 @@ test("wavefront compute config keeps 4K queues tile-bounded", () => {
   assert.equal(config.displayQuality, false);
   assert.equal(config.requiresMeshBvhForDisplayQuality, true);
   assert.equal(config.tilePixelCapacity, 128 * 128);
-  assert.equal(wavefrontPathTracingComputeLimits.hitRecordBytes, 208);
+  assert.equal(wavefrontPathTracingComputeLimits.hitRecordBytes, 256);
   assert.equal(wavefrontPathTracingComputeLimits.workgroupSize, rendererWavefrontComputeWorkgroupSize);
   assert.equal(rendererWavefrontComputeStatsStride, 8);
   assert.equal(config.memory.queueBytes, 128 * 128 * wavefrontPathTracingComputeLimits.rayRecordBytes);
   assert.equal(config.memory.hitBytes, 128 * 128 * wavefrontPathTracingComputeLimits.hitRecordBytes);
   assert.equal(config.memory.pathVertexBytes, 128 * 128 * 9 * wavefrontPathTracingComputeLimits.pathVertexRecordBytes);
-  assert.equal(config.memory.configBytes, 304);
+  assert.equal(config.memory.configBytes, 320);
   assert.equal(config.memory.counterBytes, wavefrontPathTracingComputeLimits.counterRecordBytes);
   assert.equal(
     config.memory.indirectDispatchBytes,
@@ -410,12 +430,12 @@ test("wavefront compute config exposes bounded samples per pixel", () => {
   const clamped = createWavefrontPathTracingComputeConfig({
     width: 640,
     height: 360,
-    samplesPerPixel: 128,
+    samplesPerPixel: 512,
   });
 
   assert.equal(config.samplesPerPixel, 8);
   assert.equal(config.maxFramePassesPerSubmission, 32);
-  assert.equal(clamped.samplesPerPixel, 64);
+  assert.equal(clamped.samplesPerPixel, 256);
   assert.throws(
     () =>
       createWavefrontPathTracingComputeConfig({
@@ -590,7 +610,7 @@ test("wavefront reference triangle intersection rejects hits past max distance",
   assert.equal(tracedHit.distance, -1);
 });
 
-test("wavefront compute denoise remains a two-pass GPU post process", () => {
+test("wavefront compute denoise adapts filter cost and strength to spp", () => {
   const source = readRendererSource();
 
   assert.match(source, /rgba16float/);
@@ -598,8 +618,15 @@ test("wavefront compute denoise remains a two-pass GPU post process", () => {
   assert.match(source, /denoiseScratchTexture/);
   assert.match(source, /radianceToScratch/);
   assert.match(source, /scratchToOutput/);
+  assert.match(source, /radianceToOutput/);
   assert.match(source, /denoiseLinearRadiance/);
   assert.match(source, /resolveDenoisedOutputImage/);
+  assert.match(source, /fn denoise_sample_count\(\) -> f32/);
+  assert.match(source, /fn denoise_strength\(\) -> f32/);
+  assert.match(source, /fn denoise_kernel_radius\(\) -> i32/);
+  assert.match(source, /function encodeDenoise\(encoder, configOffset, parallelism, renderedSamplesPerPixel = config\.samplesPerPixel\)/);
+  assert.match(source, /const useTwoPassDenoise = renderedSamplesPerPixel < 4;/);
+  assert.match(source, /const denoisePassCount = renderedSamplesPerPixel < 4 \? 2 : 1;/);
   assert.match(source, /tone_map_radiance/);
   assert.doesNotMatch(source, /getImageData|putImageData|Uint8ClampedArray/);
 });
@@ -643,16 +670,26 @@ test("wavefront compute applies environment ambient on terminal surface collisio
   assert.match(source, /fn terminal_surface_environment_source/);
   assert.match(source, /fn terminal_surface_environment_contribution/);
   assert.match(source, /fn surface_path_response/);
+  assert.match(source, /fn bounded_path_response_luminance/);
+  assert.match(source, /fn stabilize_surface_path_response/);
   assert.match(source, /fn sunlit_baseline_radiance/);
   assert.match(source, /let baseline = max\(config\.pathResolveSettings\.y, 0\.0\);/);
+  assert.match(source, /let daylightFloor = max\(config\.pathResolveSettings\.y, 0\.0\) \* 0\.08;/);
+  assert.match(source, /let hdriFloor = max\(config\.environmentMapSettings\.w, 0\.0\) \* 0\.02;/);
+  assert.match(source, /let response = stabilize_surface_path_response\(ray, hit, surface_path_response\(hit\)\);/);
   assert.match(source, /let surfaceColor = max\(hit\.color\.xyz, config\.ambientColor\.xyz\);/);
   assert.match(source, /let sunlitFloor = sunlit_baseline_radiance\(normal\);/);
+  assert.match(source, /let glossiness = surface_glossiness\(hit\);/);
   assert.match(source, /max\(config\.ambientColor\.xyz, sunlitFloor \* 0\.82\)/);
   assert.match(source, /max\(config\.ambientColor\.xyz \* 0\.35, sunlitFloor \* 0\.58\)/);
   assert.match(source, /max\(0\.12, config\.pathResolveSettings\.y \* 0\.42\)/);
-  assert.match(source, /let environmentFloor = max\(ambientFloor, max\(sunlitFloor, normalEnvironment \* environmentInfluence\)\);/);
+  assert.match(source, /let reflectionEnvironment = prefiltered_environment_radiance\(reflectionDirection, roughness\);/);
+  assert.match(source, /let brdfTerm = sample_brdf_lut\(saturate\(dot\(normal, viewDirection\)\), roughness\);/);
+  assert.match(source, /let specularEnvironment = reflectionEnvironment \* \(f0 \* brdfTerm\.x \+ vec3<f32>\(brdfTerm\.y\)\);/);
+  assert.match(source, /let glossyEnvironment = max\(/);
+  assert.match(source, /let environmentFloor = max\(ambientFloor, max\(sunlitFloor, glossyEnvironment \* environmentInfluence\)\);/);
   assert.match(source, /record_deferred_path_response\(ray, response\);/);
-  assert.match(source, /record_deferred_terminal_source\(ray, terminal_surface_environment_source\(hit\)\);/);
+  assert.match(source, /record_deferred_terminal_source\(ray, terminal_surface_environment_source\(ray, hit\)\);/);
   assert.match(
     source,
     /let terminalEnvironment = terminal_surface_environment_contribution\(ray, hit\);/
@@ -670,17 +707,29 @@ test("wavefront compute applies environment ambient on terminal surface collisio
 test("wavefront compute estimates direct environment light before random continuation", () => {
   const source = readRendererSource();
 
+  assert.match(source, /fn direct_environment_radiance/);
+  assert.match(source, /fn sample_environment_importance/);
+  assert.match(source, /u32\(config\.environmentMapMeta\.x\)/);
+  assert.match(source, /u32\(config\.environmentMapMeta\.y\)/);
+  assert.match(source, /if \(count == 0u\) \{\s+return 0u;\s+\}/);
+  assert.match(source, /fn power_heuristic/);
+  assert.match(source, /fn evaluate_surface_bsdf/);
+  assert.match(source, /fn evaluate_surface_bsdf_pdf/);
+  assert.match(source, /fn visibility_test_ray/);
+  assert.match(source, /fn scene_visibility_blocked/);
   assert.match(source, /fn surface_direct_environment_contribution/);
-  assert.match(source, /fn direct_environment_portal_irradiance/);
-  assert.match(source, /let surfaceColor = clamp\(max\(hit\.color\.xyz, config\.ambientColor\.xyz \* 0\.35\)/);
-  assert.match(source, /sunlitFloor \* select\(0\.72, 0\.45, environment_map_enabled\(\)\)/);
-  assert.match(source, /max\(0\.16, config\.pathResolveSettings\.y \* 0\.45\)/);
-  assert.match(source, /let skyIrradiance = max\(ambientIrradiance, normalEnvironment \* skyVisibility \* environmentIrradianceScale\);/);
-  assert.match(source, /let sunIrradiance = sunRadiance \* sunFacing \* 0\.2;/);
-  assert.match(source, /let portalIrradiance = direct_environment_portal_irradiance\(origin, normal\);/);
+  assert.match(source, /let lightSample = sample_environment_importance\(vec2<f32>\(/);
+  assert.match(source, /if \(scene_visibility_blocked\(origin, lightDirection, 1000000\.0\)\) \{/);
+  assert.match(source, /let incidentRadiance = direct_environment_radiance\(origin, lightDirection\);/);
+  assert.match(source, /let bsdf = evaluate_surface_bsdf\(hit, viewDirection, lightDirection\);/);
+  assert.match(source, /let bsdfPdf = evaluate_surface_bsdf_pdf\(hit, viewDirection, lightDirection\);/);
+  assert.match(source, /let misWeight = power_heuristic\(lightSample\.pdf, bsdfPdf\);/);
+  assert.match(source, /nDotL \* misWeight \/ max\(lightSample\.pdf, 0\.000001\)/);
+  assert.match(source, /let transmissionReflectChance = select\(/);
+  assert.doesNotMatch(source, /mix\(reflectChance, max\(reflectChance, 1\.0 - transmission\), transmission > 0\.001\)/);
   assert.match(
     source,
-    /let shouldEstimateDirectEnvironment =\s+!deferred_path_resolve_enabled\(\) &&\s+\(hit\.materialKind == 0u \|\| hit\.materialKind == 1u\) &&\s+hit\.material\.z >= 0\.95;/
+    /let shouldEstimateDirectEnvironment =\s+\(hit\.materialKind == 0u \|\| hit\.materialKind == 1u\) &&\s+hit\.material\.z >= 0\.95 &&\s+ray\.bounce < 2u;/
   );
   assert.match(
     source,
@@ -700,6 +749,23 @@ test("wavefront compute estimates direct environment light before random continu
   );
 });
 
+test("wavefront compute samples material textures on the GPU at the resolved hit UV", () => {
+  const source = readRendererSource();
+
+  assert.match(source, /const GPU_MATERIAL_RECORD_BYTES = 192/);
+  assert.match(source, /const TRIANGLE_RECORD_BYTES = 352/);
+  assert.match(source, /@group\(0\) @binding\(23\) var baseColorAtlasTexture: texture_2d<f32>/);
+  assert.match(source, /@group\(0\) @binding\(28\) var materialAtlasSampler: sampler/);
+  assert.match(source, /fn sample_surface_material\(/);
+  assert.match(source, /let meshSurface = sample_surface_material\(/);
+  assert.match(source, /let hitOcclusion = select\(1\.0, meshSurface\.occlusion/);
+  assert.match(source, /triangle\.baseColorAtlas/);
+  assert.match(source, /triangle\.textureSettings/);
+  assert.match(source, /mesh\.baseColorAtlas/);
+  assert.match(source, /hitTriangle\.materialSlot/);
+  assert.doesNotMatch(source, /getImageData\(.*render/);
+});
+
 test("wavefront compute defers visible colour until terminal path resolve", () => {
   const source = readRendererSource();
   const config = createWavefrontPathTracingComputeConfig({
@@ -713,14 +779,18 @@ test("wavefront compute defers visible colour until terminal path resolve", () =
   assert.match(source, /fn deferred_path_resolve_enabled\(\) -> bool/);
   assert.match(source, /fn clear_deferred_path\(rayId: u32\)/);
   assert.match(source, /record_deferred_terminal_source\(ray, sourceRadiance\);/);
-  assert.match(source, /record_deferred_terminal_source\(ray, hit\.color\.xyz\);/);
+  assert.match(source, /sourceRadiance = sourceRadiance \* misWeight;/);
   assert.match(source, /fn resolve_deferred_path_radiance\(rayId: u32\) -> vec3<f32>/);
   assert.match(source, /let terminal = pathVertices\[path_vertex_index\(rayId, config\.maxDepth\)\];/);
   assert.match(source, /depth = depth - 1u;/);
   assert.match(source, /radiance = radiance \* response\.xyz;/);
   assert.match(source, /let resolved = resolve_deferred_path_radiance\(index\) \* sample_weight\(\);/);
+  assert.match(
+    source,
+    /accumulation\[ray\.rayId\] =\s+accumulation\[ray\.rayId\] \+\s+vec4<f32>\(directEnvironment \* sample_weight\(\), 0\.0\);/
+  );
   assert.match(source, /if \(config\.deferredPathResolve\) \{/);
-  assert.match(source, /encodeTileOutput\(reserveEncoder\(\), tile, configOffset, parallelism\);/);
+  assert.match(source, /encodeTileOutput\(reserveEncoder\(1\), tile, configOffset, parallelism\);/);
 });
 
 test("analytic wavefront renderer rejects display-quality requests", () => {
@@ -877,7 +947,7 @@ test("wavefront mesh acceleration preserves triangle vertices and normals", () =
 });
 
 test("wavefront GPU mesh source packs raw mesh buffers without CPU BVH output", () => {
-  const source = createWavefrontGpuMeshSource([
+  const meshes = [
     {
       id: 31,
       positions: [0, 0, 0, 2, 0, 0, 0, 2, 0],
@@ -889,7 +959,9 @@ test("wavefront GPU mesh source packs raw mesh buffers without CPU BVH output", 
       mediumRefId: 3,
       color: [0.25, 0.5, 0.75, 0.9],
     },
-  ]);
+  ];
+  const materialSource = createWavefrontGpuMaterialSource(meshes);
+  const source = createWavefrontGpuMeshSource(meshes, materialSource);
   const vertexFloats = new Float32Array(source.vertices.buffer);
   const indexUints = new Uint32Array(source.indices.buffer);
   const meshUints = new Uint32Array(source.meshes.buffer);
@@ -907,6 +979,66 @@ test("wavefront GPU mesh source packs raw mesh buffers without CPU BVH output", 
     [31, wavefrontMaterialKinds.dielectric, 0, 22, 3, 0, 3, 0, 1, 0, 3]
   );
   assert.deepEqual(round(meshFloats.slice(12, 16)), [0.25, 0.5, 0.75, 0.9]);
+  assert.deepEqual(round(meshFloats.slice(36, 40)), round(materialSource.baseColorAtlas.defaultRect));
+  assert.deepEqual(round(meshFloats.slice(56, 60)), [1, 1, 1, 0]);
+});
+
+test("wavefront GPU material source packs per-mesh factors and atlases", () => {
+  const source = createWavefrontGpuMaterialSource([
+    {
+      positions: [0, 0, 0, 1, 0, 0, 0, 1, 0],
+      uvs: [0, 0, 1, 0, 0, 1],
+      color: [0.2, 0.4, 0.6, 0.8],
+      emission: [1.5, 1, 0.5, 1],
+      roughness: 0.35,
+      metallic: 0.9,
+      sheen: 0.2,
+      clearcoat: 0.6,
+      clearcoatRoughness: 0.15,
+      material: {
+        baseColorTexture: {
+          width: 2,
+          height: 2,
+          data: new Uint8Array([
+            255, 0, 0, 255,
+            0, 255, 0, 255,
+            0, 0, 255, 255,
+            255, 255, 255, 255,
+          ]),
+        },
+        metallicRoughnessTexture: {
+          width: 1,
+          height: 1,
+          data: new Uint8Array([255, 192, 128, 255]),
+        },
+        normalTexture: {
+          width: 1,
+          height: 1,
+          scale: 0.75,
+          data: new Uint8Array([128, 128, 255, 255]),
+        },
+        occlusionTexture: {
+          width: 1,
+          height: 1,
+          data: new Uint8Array([220, 220, 220, 255]),
+        },
+      },
+    },
+  ]);
+  const floats = new Float32Array(source.buffer);
+
+  assert.equal(source.buffer.byteLength, wavefrontPathTracingComputeLimits.materialRecordBytes);
+  assert.equal(source.count, 1);
+  assert.deepEqual(round(floats.slice(0, 4)), [0.2, 0.4, 0.6, 0.8]);
+  assert.deepEqual(round(floats.slice(4, 8)), [1.5, 1, 0.5, 1]);
+  assert.deepEqual(round(floats.slice(8, 12)), [0.35, 0.9, 0.8, 1.45]);
+  assert.deepEqual(round(floats.slice(12, 16)), [0.2, 0.2, 0.2, 0.6]);
+  assert.deepEqual(round(floats.slice(16, 20)), [0.15, 1, 0, 0]);
+  assert.deepEqual(round(floats.slice(20, 24)), [1, 1, 1, 1]);
+  assert.equal(Number(floats[44].toFixed(2)), 0.75);
+  assert.ok(source.baseColorAtlas.width >= 4);
+  assert.ok(source.baseColorAtlas.height >= 4);
+  assert.ok(source.baseColorAtlas.data.length >= source.baseColorAtlas.width * source.baseColorAtlas.height * 4);
 });
 
 test("wavefront emissive triangle index source tracks light mesh triangle order", () => {
@@ -963,6 +1095,7 @@ test("wavefront config stores emissive guidance metadata in the BVH buffer tail"
     config.memory.emissiveTriangleMetadataBytes,
     2 * wavefrontPathTracingComputeLimits.emissiveTriangleMetadataRecordBytes
   );
+  assert.equal(config.memory.materialTableBytes, wavefrontPathTracingComputeLimits.materialRecordBytes);
 });
 
 test("wavefront mesh acceleration derives flat normals when vertex normals are absent", () => {
@@ -1254,7 +1387,7 @@ test("wavefront compute helper reports unavailable WebGPU when navigator.gpu is 
   );
 });
 
-test("wavefront compute renderer rejects unavailable WebGPU setup paths", async () => {
+serialWebGpuTest("wavefront compute renderer rejects unavailable WebGPU setup paths", async () => {
   await withWebGpuConstants(async () => {
     await assert.rejects(
       createWavefrontPathTracingComputeRenderer({
@@ -1312,7 +1445,7 @@ test("wavefront compute renderer rejects unavailable WebGPU setup paths", async 
   });
 });
 
-test("wavefront compute renderer drives GPU-only mesh BVH passes", async () => {
+serialWebGpuTest("wavefront compute renderer drives GPU-only mesh BVH passes", async () => {
   await withWebGpuConstants(async () => {
     const device = new FakeWavefrontDevice();
     let requestedDeviceDescriptor = null;
@@ -1474,7 +1607,7 @@ test("wavefront compute renderer drives GPU-only mesh BVH passes", async () => {
     assert.ok(device.renderPasses >= 1);
     assert.equal(device.drawCalls.includes(3), true);
     assert.ok(device.queue.submissions.length >= 1);
-    assert.equal(device.queue.textureWrites.length, 1);
+    assert.equal(device.queue.textureWrites.length, 9);
     assert.equal(device.queue.textureWrites[0].size.width, 2);
     assert.equal(device.queue.textureWrites[0].size.height, 1);
     assert.equal(device.queue.textureWrites[0].layout.bytesPerRow, 256);
@@ -1496,7 +1629,7 @@ test("wavefront compute renderer drives GPU-only mesh BVH passes", async () => {
   });
 });
 
-test("wavefront compute renderer splits large frames into bounded command submissions", async () => {
+serialWebGpuTest("wavefront compute renderer splits large frames into bounded command submissions", async () => {
   await withWebGpuConstants(async () => {
     const device = new FakeWavefrontDevice();
     const renderer = await createWavefrontPathTracingComputeRenderer({
@@ -1518,7 +1651,7 @@ test("wavefront compute renderer splits large frames into bounded command submis
 
     assert.equal(frame.tiles, 16);
     assert.equal(frame.maxFramePassesPerSubmission, 5);
-    assert.equal(frame.commandSubmissions, 14);
+    assert.equal(frame.commandSubmissions, 22);
     assert.equal(frame.frameConfigSlots, 33);
     assert.equal(frame.gpuParallelism.physicalCoreCountAvailable, false);
     assert.equal(frame.gpuParallelism.exposesMultiWorkgroupParallelism, true);
@@ -1528,14 +1661,172 @@ test("wavefront compute renderer splits large frames into bounded command submis
     assert.ok(frame.gpuParallelism.multiWorkgroupDispatches > 0);
     assert.ok(frame.gpuParallelism.directWorkgroups > 1);
     assert.ok(frame.gpuParallelism.totalEstimatedShaderInvocationsUpperBound > frame.gpuParallelism.directShaderInvocations);
-    assert.equal(device.queue.submissions.length, 14);
+    assert.equal(device.queue.submissions.length, 22);
     assert.equal(submittedLabels.every((label) => label.includes(".batched.")), true);
 
     renderer.destroy();
   });
 });
 
-test("wavefront compute one-shot compatibility helper renders and always destroys", async () => {
+serialWebGpuTest("wavefront output-probe readback waits for submitted GPU work before mapAsync", async () => {
+  await withWebGpuConstants(async () => {
+    const device = new FakeWavefrontDevice();
+    device.requireSubmittedWorkDoneBeforeMapAsync = true;
+    const renderer = await createWavefrontPathTracingComputeRenderer({
+      canvas: createFakeWavefrontCanvas(),
+      navigator: createFakeWavefrontNavigator(device),
+      width: 8,
+      height: 8,
+      tileSize: 8,
+      maxDepth: 2,
+      samplesPerPixel: 4,
+      denoise: true,
+      deferredPathResolve: true,
+    });
+
+    const frame = await renderer.renderFrame({ readOutputProbe: true, probe: { x: 1, y: 1 } });
+
+    assert.equal(frame.outputProbe.x, 1);
+    assert.equal(frame.outputProbe.y, 1);
+    assert.deepEqual(frame.outputProbe.rgba, [32, 64, 128, 255]);
+    assert.equal(device.queue.submittedWorkDoneCalls, 3);
+    assert.equal(device.queue.submittedWorkDone, true);
+
+    renderer.destroy();
+  });
+});
+
+serialWebGpuTest("wavefront renderFrame waits for submitted GPU work before reporting completion", async () => {
+  await withWebGpuConstants(async () => {
+    const device = new FakeWavefrontDevice();
+    const renderer = await createWavefrontPathTracingComputeRenderer({
+      canvas: createFakeWavefrontCanvas(),
+      navigator: createFakeWavefrontNavigator(device),
+      width: 8,
+      height: 8,
+      tileSize: 8,
+      maxDepth: 2,
+      samplesPerPixel: 32,
+      denoise: false,
+      deferredPathResolve: true,
+    });
+
+    const frame = await renderer.renderFrame({ readOutputProbe: false });
+
+    assert.equal(frame.samplesPerPixel, 32);
+    assert.equal(frame.renderedSamplesPerPixel, 32);
+    assert.equal(device.queue.submittedWorkDone, true);
+    assert.equal(device.queue.submittedWorkDoneCalls, 1);
+    assert.equal(frame.gpuWorkerJobs.awaitedGpuCompletion, true);
+    assert.ok(frame.gpuWorkerJobs.completedPerFrame > 0);
+    assert.ok(frame.gpuWorkerJobs.completedPerSecond > 0);
+    assert.equal(
+      frame.gpuWorkerJobs.completedPerFrame,
+      frame.gpuWorkerJobs.directDispatchesCompleted + frame.gpuWorkerJobs.indirectDispatchesCompleted
+    );
+    assert.equal(
+      frame.gpuWorkerJobs.completedPerSubmission,
+      frame.gpuWorkerJobs.completedPerFrame / frame.commandSubmissions
+    );
+
+    renderer.destroy();
+  });
+});
+
+serialWebGpuTest("wavefront renderFrame rejects when awaited submitted GPU work times out", async () => {
+  await withWebGpuConstants(async () => {
+    const device = new FakeWavefrontDevice();
+    device.queue.onSubmittedWorkDone = async () => {
+      device.queue.submittedWorkDoneCalls += 1;
+      return new Promise((resolve) => {
+        setTimeout(resolve, 25);
+      });
+    };
+    const renderer = await createWavefrontPathTracingComputeRenderer({
+      canvas: createFakeWavefrontCanvas(),
+      navigator: createFakeWavefrontNavigator(device),
+      width: 8,
+      height: 8,
+      tileSize: 8,
+      maxDepth: 2,
+      samplesPerPixel: 32,
+      denoise: false,
+      deferredPathResolve: true,
+    });
+
+    await assert.rejects(
+      renderer.renderFrame({ readOutputProbe: false, submittedWorkTimeoutMs: 5 }),
+      /Timed out after 5 ms waiting for submitted GPU work\./
+    );
+    assert.equal(device.queue.submittedWorkDoneCalls, 1);
+    assert.equal(device.queue.submittedWorkDone, false);
+
+    renderer.destroy();
+  });
+});
+
+serialWebGpuTest("wavefront renderFrame throttles 8 spp through the awaited batch path", async () => {
+  await withWebGpuConstants(async () => {
+    const device = new FakeWavefrontDevice();
+    const renderer = await createWavefrontPathTracingComputeRenderer({
+      canvas: createFakeWavefrontCanvas(),
+      navigator: createFakeWavefrontNavigator(device),
+      width: 8,
+      height: 8,
+      tileSize: 8,
+      maxDepth: 2,
+      samplesPerPixel: 8,
+      denoise: false,
+      deferredPathResolve: true,
+    });
+
+    const frame = await renderer.renderFrame({ readOutputProbe: false });
+
+    assert.equal(frame.samplesPerPixel, 8);
+    assert.equal(frame.renderedSamplesPerPixel, 8);
+    assert.ok(frame.commandSubmissions > 1);
+    assert.equal(device.queue.submittedWorkDone, true);
+    assert.equal(device.queue.submittedWorkDoneCalls, 1);
+    assert.equal(frame.gpuWorkerJobs.awaitedGpuCompletion, true);
+    assert.ok(frame.gpuWorkerJobs.completedPerFrame > frame.commandSubmissions);
+
+    renderer.destroy();
+  });
+});
+
+serialWebGpuTest("wavefront renderFrame can adapt high spp down to a single in-budget sample", async () => {
+  await withWebGpuConstants(async () => {
+    const device = new FakeWavefrontDevice();
+    const renderer = await createWavefrontPathTracingComputeRenderer({
+      canvas: createFakeWavefrontCanvas(),
+      navigator: createFakeWavefrontNavigator(device),
+      width: 8,
+      height: 8,
+      tileSize: 8,
+      maxDepth: 2,
+      samplesPerPixel: 32,
+      denoise: false,
+      deferredPathResolve: true,
+    });
+
+    const frame = await renderer.renderFrame({
+      readOutputProbe: false,
+      frameTimeBudgetMs: 16,
+      minimumSamplesPerPixel: 1,
+    });
+
+    assert.equal(frame.samplesPerPixel, 32);
+    assert.equal(frame.renderedSamplesPerPixel, 1);
+    assert.equal(frame.frameTimeBudgetMs, 16);
+    assert.equal(frame.budgetConstrained, true);
+    assert.equal(frame.primaryRays, 64);
+    assert.equal(device.queue.submittedWorkDoneCalls, 1);
+
+    renderer.destroy();
+  });
+});
+
+serialWebGpuTest("wavefront compute one-shot compatibility helper renders and always destroys", async () => {
   await withWebGpuConstants(async () => {
     const device = new FakeWavefrontDevice();
     const frame = await renderWavefrontPathTracingComputeFrame({

--- a/tests/wavefront-compute.test.js
+++ b/tests/wavefront-compute.test.js
@@ -241,9 +241,13 @@ class FakeWavefrontDevice {
         this.queue.writes.push({ buffer, offset, byteLength: data.byteLength ?? data.length ?? 0 });
       },
       writeTexture: (destination, data, layout, size) => {
+        const byteLength = data.byteLength ?? data.length ?? 0;
+        const byteOffset = data.byteOffset ?? 0;
+        const sourceBuffer = data.buffer ?? data;
         this.queue.textureWrites.push({
           destination,
-          byteLength: data.byteLength ?? data.length ?? 0,
+          byteLength,
+          data: new Uint8Array(sourceBuffer.slice(byteOffset, byteOffset + byteLength)),
           layout,
           size,
         });
@@ -1344,9 +1348,9 @@ test("wavefront compute renderer drives GPU-only mesh BVH passes", async () => {
       environmentMap: {
         width: 2,
         height: 1,
-        data: new Float32Array([
-          1.2, 0.8, 0.4, 1,
-          0.2, 0.5, 1.6, 1,
+        data: new Uint8Array([
+          255, 128, 0, 255,
+          64, 32, 16, 255,
         ]),
         intensity: 1.7,
         rotationRadians: 0.25,
@@ -1474,6 +1478,12 @@ test("wavefront compute renderer drives GPU-only mesh BVH passes", async () => {
     assert.equal(device.queue.textureWrites[0].size.width, 2);
     assert.equal(device.queue.textureWrites[0].size.height, 1);
     assert.equal(device.queue.textureWrites[0].layout.bytesPerRow, 256);
+    const environmentMapUpload = new DataView(device.queue.textureWrites[0].data.buffer);
+    assert.equal(environmentMapUpload.getUint16(0, true), 0x3c00);
+    assert.equal(environmentMapUpload.getUint16(4, true), 0);
+    assert.equal(environmentMapUpload.getUint16(6, true), 0x3c00);
+    assert.ok(environmentMapUpload.getUint16(8, true) > 0);
+    assert.ok(environmentMapUpload.getUint16(8, true) < 0x3c00);
     const submittedLabels = device.queue.submissions.flat().map((submission) => submission.encoderLabel);
     assert.equal(submittedLabels.filter((label) => label.includes("buildAcceleration")).length, 1);
     assert.equal(submittedLabels.filter((label) => label.includes(".batched")).length, 3);

--- a/tests/wavefront-compute.test.js
+++ b/tests/wavefront-compute.test.js
@@ -41,8 +41,9 @@ const gpuConstants = Object.freeze({
   }),
   texture: Object.freeze({
     COPY_SRC: 1,
-    STORAGE_BINDING: 2,
-    TEXTURE_BINDING: 4,
+    COPY_DST: 2,
+    STORAGE_BINDING: 4,
+    TEXTURE_BINDING: 8,
   }),
   shader: Object.freeze({
     COMPUTE: 1,
@@ -232,11 +233,20 @@ class FakeWavefrontDevice {
     this.queue = {
       submissions: [],
       writes: [],
+      textureWrites: [],
       submit: (buffers) => {
         this.queue.submissions.push(buffers);
       },
       writeBuffer: (buffer, offset, data) => {
         this.queue.writes.push({ buffer, offset, byteLength: data.byteLength ?? data.length ?? 0 });
+      },
+      writeTexture: (destination, data, layout, size) => {
+        this.queue.textureWrites.push({
+          destination,
+          byteLength: data.byteLength ?? data.length ?? 0,
+          layout,
+          size,
+        });
       },
     };
   }
@@ -298,6 +308,7 @@ function createFakeWavefrontNavigator(device = new FakeWavefrontDevice(), adapte
       async requestAdapter() {
         return {
           limits: adapterOptions.limits,
+          info: adapterOptions.info,
           async requestDevice(descriptor) {
             adapterOptions.onRequestDevice?.(descriptor);
             return device;
@@ -357,7 +368,8 @@ test("wavefront compute config keeps 4K queues tile-bounded", () => {
   assert.equal(rendererWavefrontComputeStatsStride, 8);
   assert.equal(config.memory.queueBytes, 128 * 128 * wavefrontPathTracingComputeLimits.rayRecordBytes);
   assert.equal(config.memory.hitBytes, 128 * 128 * wavefrontPathTracingComputeLimits.hitRecordBytes);
-  assert.equal(config.memory.configBytes, 272);
+  assert.equal(config.memory.pathVertexBytes, 128 * 128 * 9 * wavefrontPathTracingComputeLimits.pathVertexRecordBytes);
+  assert.equal(config.memory.configBytes, 304);
   assert.equal(config.memory.counterBytes, wavefrontPathTracingComputeLimits.counterRecordBytes);
   assert.equal(
     config.memory.indirectDispatchBytes,
@@ -610,6 +622,11 @@ test("wavefront compute guides and gates environment lighting through portals", 
   assert.match(source, /ENVIRONMENT_PORTAL_RECORD_BYTES = 96/);
   assert.match(source, /environmentPortalRecordBytes/);
   assert.match(source, /@group\(0\) @binding\(19\) var<storage, read> environmentPortals/);
+  assert.match(source, /@group\(0\) @binding\(20\) var environmentMapTexture: texture_2d<f32>/);
+  assert.match(source, /@group\(0\) @binding\(21\) var environmentMapSampler: sampler/);
+  assert.match(source, /@group\(0\) @binding\(22\) var<storage, read_write> pathVertices/);
+  assert.match(source, /fn environment_map_radiance/);
+  assert.match(source, /textureSampleLevel\(environmentMapTexture, environmentMapSampler, uv, 0\.0\)/);
   assert.match(source, /fn environment_portal_radiance_scale/);
   assert.match(source, /fn gated_environment_radiance/);
   assert.match(source, /fn sample_environment_portal_direction/);
@@ -619,9 +636,19 @@ test("wavefront compute guides and gates environment lighting through portals", 
 test("wavefront compute applies environment ambient on terminal surface collisions", () => {
   const source = readRendererSource();
 
+  assert.match(source, /fn terminal_surface_environment_source/);
   assert.match(source, /fn terminal_surface_environment_contribution/);
+  assert.match(source, /fn surface_path_response/);
+  assert.match(source, /fn sunlit_baseline_radiance/);
+  assert.match(source, /let baseline = max\(config\.pathResolveSettings\.y, 0\.0\);/);
   assert.match(source, /let surfaceColor = max\(hit\.color\.xyz, config\.ambientColor\.xyz\);/);
-  assert.match(source, /let environmentFloor = max\(config\.ambientColor\.xyz, normalEnvironment \* 0\.12\);/);
+  assert.match(source, /let sunlitFloor = sunlit_baseline_radiance\(normal\);/);
+  assert.match(source, /max\(config\.ambientColor\.xyz, sunlitFloor \* 0\.82\)/);
+  assert.match(source, /max\(config\.ambientColor\.xyz \* 0\.35, sunlitFloor \* 0\.58\)/);
+  assert.match(source, /max\(0\.12, config\.pathResolveSettings\.y \* 0\.42\)/);
+  assert.match(source, /let environmentFloor = max\(ambientFloor, max\(sunlitFloor, normalEnvironment \* environmentInfluence\)\);/);
+  assert.match(source, /record_deferred_path_response\(ray, response\);/);
+  assert.match(source, /record_deferred_terminal_source\(ray, terminal_surface_environment_source\(hit\)\);/);
   assert.match(
     source,
     /let terminalEnvironment = terminal_surface_environment_contribution\(ray, hit\);/
@@ -642,12 +669,14 @@ test("wavefront compute estimates direct environment light before random continu
   assert.match(source, /fn surface_direct_environment_contribution/);
   assert.match(source, /fn direct_environment_portal_irradiance/);
   assert.match(source, /let surfaceColor = clamp\(max\(hit\.color\.xyz, config\.ambientColor\.xyz \* 0\.35\)/);
-  assert.match(source, /let skyIrradiance = max\(config\.ambientColor\.xyz \* 0\.72, normalEnvironment \* skyVisibility \* 0\.16\);/);
+  assert.match(source, /sunlitFloor \* select\(0\.72, 0\.45, environment_map_enabled\(\)\)/);
+  assert.match(source, /max\(0\.16, config\.pathResolveSettings\.y \* 0\.45\)/);
+  assert.match(source, /let skyIrradiance = max\(ambientIrradiance, normalEnvironment \* skyVisibility \* environmentIrradianceScale\);/);
   assert.match(source, /let sunIrradiance = sunRadiance \* sunFacing \* 0\.2;/);
   assert.match(source, /let portalIrradiance = direct_environment_portal_irradiance\(origin, normal\);/);
   assert.match(
     source,
-    /let shouldEstimateDirectEnvironment =\s+\(hit\.materialKind == 0u \|\| hit\.materialKind == 1u\) && hit\.material\.z >= 0\.95;/
+    /let shouldEstimateDirectEnvironment =\s+!deferred_path_resolve_enabled\(\) &&\s+\(hit\.materialKind == 0u \|\| hit\.materialKind == 1u\) &&\s+hit\.material\.z >= 0\.95;/
   );
   assert.match(
     source,
@@ -665,6 +694,29 @@ test("wavefront compute estimates direct environment light before random continu
     source.indexOf("let directEnvironment = surface_direct_environment_contribution(ray, hit);") <
       source.indexOf("if (ray.bounce + 1u >= config.maxDepth)")
   );
+});
+
+test("wavefront compute defers visible colour until terminal path resolve", () => {
+  const source = readRendererSource();
+  const config = createWavefrontPathTracingComputeConfig({
+    width: 64,
+    height: 64,
+    deferredPathResolve: false,
+  });
+
+  assert.equal(createWavefrontPathTracingComputeConfig({ width: 64, height: 64 }).deferredPathResolve, true);
+  assert.equal(config.deferredPathResolve, false);
+  assert.match(source, /fn deferred_path_resolve_enabled\(\) -> bool/);
+  assert.match(source, /fn clear_deferred_path\(rayId: u32\)/);
+  assert.match(source, /record_deferred_terminal_source\(ray, sourceRadiance\);/);
+  assert.match(source, /record_deferred_terminal_source\(ray, hit\.color\.xyz\);/);
+  assert.match(source, /fn resolve_deferred_path_radiance\(rayId: u32\) -> vec3<f32>/);
+  assert.match(source, /let terminal = pathVertices\[path_vertex_index\(rayId, config\.maxDepth\)\];/);
+  assert.match(source, /depth = depth - 1u;/);
+  assert.match(source, /radiance = radiance \* response\.xyz;/);
+  assert.match(source, /let resolved = resolve_deferred_path_radiance\(index\) \* sample_weight\(\);/);
+  assert.match(source, /if \(config\.deferredPathResolve\) \{/);
+  assert.match(source, /encodeTileOutput\(reserveEncoder\(\), tile, configOffset, parallelism\);/);
 });
 
 test("analytic wavefront renderer rejects display-quality requests", () => {
@@ -1023,6 +1075,7 @@ test("wavefront compute config accepts lighting-owned environment payloads", () 
       intensity: 1.25,
       mode: 2,
       exposure: 0.9,
+      sunlitBaseline: 0.37,
     },
   });
 
@@ -1033,6 +1086,7 @@ test("wavefront compute config accepts lighting-owned environment payloads", () 
   assert.equal(config.environmentLighting.intensity, 1.25);
   assert.equal(config.environmentLighting.mode, 2);
   assert.equal(config.environmentLighting.exposure, 0.9);
+  assert.equal(config.environmentLighting.sunlitBaseline, 0.37);
 });
 
 test("wavefront compute config normalizes environment portal apertures", () => {
@@ -1249,7 +1303,7 @@ test("wavefront compute renderer rejects unavailable WebGPU setup paths", async 
         width: 8,
         height: 8,
       }),
-      /requires maxStorageBuffersPerShaderStage>=9/
+      /requires maxStorageBuffersPerShaderStage>=10/
     );
   });
 });
@@ -1262,7 +1316,20 @@ test("wavefront compute renderer drives GPU-only mesh BVH passes", async () => {
     const renderer = await createWavefrontPathTracingComputeRenderer({
       canvas,
       navigator: createFakeWavefrontNavigator(device, {
-        limits: { maxStorageBuffersPerShaderStage: 10 },
+        limits: {
+          maxComputeInvocationsPerWorkgroup: 256,
+          maxComputeWorkgroupSizeX: 256,
+          maxComputeWorkgroupSizeY: 256,
+          maxComputeWorkgroupSizeZ: 64,
+          maxComputeWorkgroupsPerDimension: 65_535,
+          maxStorageBuffersPerShaderStage: 10,
+        },
+        info: {
+          vendor: "plasius-test-vendor",
+          architecture: "test-architecture",
+          device: "test-device",
+          description: "fake WebGPU adapter",
+        },
         onRequestDevice(descriptor) {
           requestedDeviceDescriptor = descriptor;
         },
@@ -1274,6 +1341,17 @@ test("wavefront compute renderer drives GPU-only mesh BVH passes", async () => {
       samplesPerPixel: 2,
       denoise: true,
       displayQuality: true,
+      environmentMap: {
+        width: 2,
+        height: 1,
+        data: new Float32Array([
+          1.2, 0.8, 0.4, 1,
+          0.2, 0.5, 1.6, 1,
+        ]),
+        intensity: 1.7,
+        rotationRadians: 0.25,
+        ambientStrength: 0.44,
+      },
       meshes: [
         {
           id: 77,
@@ -1307,7 +1385,7 @@ test("wavefront compute renderer drives GPU-only mesh BVH passes", async () => {
     assert.equal(canvas.context.configured.format, "bgra8unorm");
     assert.equal(
       requestedDeviceDescriptor.requiredLimits.maxStorageBuffersPerShaderStage,
-      9
+      10
     );
     assert.equal(frame.frame, 1);
     assert.equal(frame.displayQuality, true);
@@ -1315,7 +1393,28 @@ test("wavefront compute renderer drives GPU-only mesh BVH passes", async () => {
     assert.equal(frame.accelerationBuildSubmitted, true);
     assert.equal(frame.accelerationBuilt, true);
     assert.equal(frame.accelerationBuildCount, 1);
+    assert.equal(frame.environmentMap.enabled, true);
+    assert.equal(frame.environmentMap.width, 2);
+    assert.equal(frame.environmentMap.height, 1);
+    assert.equal(frame.environmentMap.projection, "equirectangular");
+    assert.equal(frame.environmentMap.intensity, 1.7);
+    assert.equal(frame.environmentMap.rotationRadians, 0.25);
+    assert.equal(frame.environmentMap.ambientStrength, 0.44);
     assert.equal(frame.commandSubmissions, 2);
+    assert.equal(frame.gpuParallelism.physicalCoreCount, null);
+    assert.equal(frame.gpuParallelism.physicalCoreCountAvailable, false);
+    assert.equal(frame.gpuParallelism.coreUtilizationStatus, "not-exposed-by-webgpu");
+    assert.equal(frame.gpuParallelism.adapterInfo.vendor, "plasius-test-vendor");
+    assert.equal(frame.gpuParallelism.adapterLimits.maxComputeInvocationsPerWorkgroup, 256);
+    assert.equal(frame.gpuParallelism.adapterLimits.maxComputeWorkgroupsPerDimension, 65_535);
+    assert.equal(frame.gpuParallelism.adapterLimits.maxStorageBuffersPerShaderStage, 10);
+    assert.equal(frame.gpuParallelism.configuredWorkgroupSize, 64);
+    assert.ok(frame.gpuParallelism.directDispatches > 0);
+    assert.ok(frame.gpuParallelism.directWorkgroups > 0);
+    assert.ok(frame.gpuParallelism.directShaderInvocations > 0);
+    assert.ok(frame.gpuParallelism.indirectDispatches > 0);
+    assert.ok(frame.gpuParallelism.totalEstimatedWorkgroupsUpperBound >= frame.gpuParallelism.directWorkgroups);
+    assert.equal(frame.gpuParallelism.exposesMultiWorkgroupParallelism, false);
     assert.equal(secondFrame.frame, 2);
     assert.equal(secondFrame.accelerationBuildSubmitted, false);
     assert.equal(secondFrame.accelerationBuilt, true);
@@ -1333,7 +1432,8 @@ test("wavefront compute renderer drives GPU-only mesh BVH passes", async () => {
     });
     assert.equal(frame.primaryRays, 128);
     assert.equal(frame.tiles, 1);
-    assert.equal(frame.frameConfigSlots, 4);
+    assert.equal(frame.deferredPathResolve, true);
+    assert.equal(frame.frameConfigSlots, 3);
     assert.equal(probe.x, 2);
     assert.equal(probe.y, 3);
     assert.deepEqual(probe.rgba, [32, 64, 128, 255]);
@@ -1343,9 +1443,14 @@ test("wavefront compute renderer drives GPU-only mesh BVH passes", async () => {
     assert.equal(nextConfig.displayQuality, true);
     assert.equal(snapshot.frame, 3);
     assert.equal(snapshot.triangleCount, 1);
+    assert.equal(snapshot.environmentMap.enabled, true);
+    assert.equal(snapshot.environmentMap.width, 2);
     assert.equal(snapshot.accelerationBuilt, true);
     assert.equal(snapshot.accelerationBuildCount, 1);
-    assert.equal(snapshot.frameConfigSlots, 4);
+    assert.equal(snapshot.deferredPathResolve, true);
+    assert.equal(snapshot.frameConfigSlots, 3);
+    assert.equal(snapshot.gpuParallelism.physicalCoreCountAvailable, false);
+    assert.equal(snapshot.gpuParallelism.indirectDispatches, compatibilityFrame.gpuParallelism.indirectDispatches);
     assert.ok(device.pipelineLabels.includes("plasius.wavefront.prepareMeshTrianglesAndLeaves"));
     assert.ok(device.pipelineLabels.includes("plasius.wavefront.generatePrimaryRays"));
     assert.ok(device.pipelineLabels.includes("plasius.wavefront.denoiseLinearRadiance"));
@@ -1365,6 +1470,10 @@ test("wavefront compute renderer drives GPU-only mesh BVH passes", async () => {
     assert.ok(device.renderPasses >= 1);
     assert.equal(device.drawCalls.includes(3), true);
     assert.ok(device.queue.submissions.length >= 1);
+    assert.equal(device.queue.textureWrites.length, 1);
+    assert.equal(device.queue.textureWrites[0].size.width, 2);
+    assert.equal(device.queue.textureWrites[0].size.height, 1);
+    assert.equal(device.queue.textureWrites[0].layout.bytesPerRow, 256);
     const submittedLabels = device.queue.submissions.flat().map((submission) => submission.encoderLabel);
     assert.equal(submittedLabels.filter((label) => label.includes("buildAcceleration")).length, 1);
     assert.equal(submittedLabels.filter((label) => label.includes(".batched")).length, 3);
@@ -1399,9 +1508,17 @@ test("wavefront compute renderer splits large frames into bounded command submis
 
     assert.equal(frame.tiles, 16);
     assert.equal(frame.maxFramePassesPerSubmission, 5);
-    assert.equal(frame.commandSubmissions, 10);
-    assert.equal(frame.frameConfigSlots, 49);
-    assert.equal(device.queue.submissions.length, 10);
+    assert.equal(frame.commandSubmissions, 14);
+    assert.equal(frame.frameConfigSlots, 33);
+    assert.equal(frame.gpuParallelism.physicalCoreCountAvailable, false);
+    assert.equal(frame.gpuParallelism.exposesMultiWorkgroupParallelism, true);
+    assert.equal(frame.gpuParallelism.largestDirectWorkgroupsPerDispatch, 4096);
+    assert.equal(frame.gpuParallelism.largestEstimatedIndirectWorkgroupsPerDispatch, 256);
+    assert.equal(frame.gpuParallelism.indirectDispatchesWithMultiWorkgroupCapacity, frame.gpuParallelism.indirectDispatches);
+    assert.ok(frame.gpuParallelism.multiWorkgroupDispatches > 0);
+    assert.ok(frame.gpuParallelism.directWorkgroups > 1);
+    assert.ok(frame.gpuParallelism.totalEstimatedShaderInvocationsUpperBound > frame.gpuParallelism.directShaderInvocations);
+    assert.equal(device.queue.submissions.length, 14);
     assert.equal(submittedLabels.every((label) => label.includes(".batched.")), true);
 
     renderer.destroy();
@@ -1441,5 +1558,5 @@ test("default wavefront scene includes emissive termination geometry", () => {
     sceneObjectCapacity: 128,
   });
   assert.ok(estimate.queueBytes < 134_217_728);
-  assert.ok(estimate.totalHotBufferBytes < 32_000_000);
+  assert.ok(estimate.totalHotBufferBytes < 40_000_000);
 });

--- a/tests/wavefront-compute.test.js
+++ b/tests/wavefront-compute.test.js
@@ -63,6 +63,10 @@ function readRendererSource() {
   return readFileSync(new URL("../src/wavefront-compute.js", import.meta.url), "utf8");
 }
 
+function readRendererTypes() {
+  return readFileSync(new URL("../src/index.d.ts", import.meta.url), "utf8");
+}
+
 async function withWebGpuConstants(callback) {
   const previous = {
     GPUBufferUsage: globalThis.GPUBufferUsage,
@@ -408,12 +412,18 @@ test("wavefront compute config keeps 4K queues tile-bounded", () => {
 
 test("wavefront compute compatibility exports expose the canonical mesh shader", () => {
   const shaderSource = createWavefrontPathTracingComputeShaderSource();
+  const types = readRendererTypes();
 
   assert.match(shaderSource, /fn prepareMeshTrianglesAndLeaves/);
   assert.match(shaderSource, /fn intersect_bvh/);
   assert.match(shaderSource, /fn intersect_triangle/);
   assert.match(shaderSource, /fn write_active_dispatch_args/);
   assert.doesNotMatch(shaderSource, /intersectSphere/);
+  assert.match(types, /hitRecordBytes: 256;/);
+  assert.match(types, /sceneObjectRecordBytes: 144;/);
+  assert.match(types, /meshRangeRecordBytes: 240;/);
+  assert.match(types, /triangleRecordBytes: 352;/);
+  assert.match(types, /materialRecordBytes: 192;/);
   assert.throws(
     () => createWavefrontPathTracingComputeShaderSource({ workgroupSize: 32 }),
     /requires workgroupSize=64/
@@ -520,6 +530,7 @@ test("wavefront reference triangle intersection resolves a one-triangle hit", ()
   assert.deepEqual(round(hit.barycentrics), [0.25, 0.25, 0.5]);
   assert.deepEqual(round(hit.uv), [0.5, 0.5]);
   assert.deepEqual(round(hit.geometricNormal), [0, 0, 1]);
+  assert.deepEqual(round(hit.materialResponse), [0, 0, 0, 0]);
 });
 
 test("wavefront reference tracing returns an environment hit on miss", () => {
@@ -547,6 +558,24 @@ test("wavefront reference tracing returns an environment hit on miss", () => {
   assert.equal(hit.distance, -1);
   assert.equal(hit.triangleIndex, -1);
   assert.deepEqual(round(hit.geometricNormal), [0, 0, 1]);
+  assert.deepEqual(round(hit.materialResponse), [0, 0, 0, 0]);
+});
+
+test("wavefront reference mesh sampling preserves normalized numeric texture channels", () => {
+  const acceleration = createWavefrontMeshAcceleration([
+    {
+      positions: [-1, -1, 0, 1, -1, 0, 0, 1, 0],
+      indices: [0, 1, 2],
+      uvs: [0, 0, 1, 0, 0.5, 1],
+      baseColorTexture: {
+        width: 1,
+        height: 1,
+        data: [1, 0, 0, 1],
+      },
+    },
+  ]);
+
+  assert.deepEqual(round(acceleration.triangles[0].color), [0.72, 0, 0, 1]);
 });
 
 test("wavefront reference tracing selects the nearest triangle hit", () => {
@@ -628,7 +657,7 @@ test("wavefront compute denoise adapts filter cost and strength to spp", () => {
   assert.match(source, /const useTwoPassDenoise = renderedSamplesPerPixel < 4;/);
   assert.match(source, /const denoisePassCount = renderedSamplesPerPixel < 4 \? 2 : 1;/);
   assert.match(source, /tone_map_radiance/);
-  assert.doesNotMatch(source, /getImageData|putImageData|Uint8ClampedArray/);
+  assert.doesNotMatch(source, /getImageData|putImageData/);
 });
 
 test("wavefront compute guides active continuation rays toward emissive triangles", () => {
@@ -639,6 +668,9 @@ test("wavefront compute guides active continuation rays toward emissive triangle
   assert.match(source, /config\.emissiveTriangleCount/);
   assert.match(source, /RAY_FLAG_GUIDED_EMISSIVE/);
   assert.match(source, /guidedLightWeight/);
+  assert.match(source, /guidedEmissiveAvailable/);
+  assert.match(source, /sample_emissive_triangle_direction\(hit, seed \+ 101u, normal\)/);
+  assert.match(source, /RAY_FLAG_GUIDED_EMISSIVE/);
   assert.match(source, /\(pixelId \* 747796405u\) \^/);
   assert.match(source, /mix_seed\(sourcePixelId, sampleId, 0u, config\.frameIndex, 1u\)/);
   assert.match(source, /mix_seed\(ray\.sourcePixelId, ray\.sampleId, ray\.bounce, config\.frameIndex, 11u\)/);
@@ -661,6 +693,8 @@ test("wavefront compute guides and gates environment lighting through portals", 
   assert.match(source, /fn environment_portal_radiance_scale/);
   assert.match(source, /fn gated_environment_radiance/);
   assert.match(source, /fn sample_environment_portal_direction/);
+  assert.match(source, /guidedPortalAvailable/);
+  assert.match(source, /sample_environment_portal_direction\(hit, seed \+ 131u, normal\)/);
   assert.match(source, /gated_environment_radiance\(ray\.origin\.xyz, ray\.direction\.xyz\)/);
 });
 
@@ -759,6 +793,9 @@ test("wavefront compute samples material textures on the GPU at the resolved hit
   assert.match(source, /fn sample_surface_material\(/);
   assert.match(source, /let meshSurface = sample_surface_material\(/);
   assert.match(source, /let hitOcclusion = select\(1\.0, meshSurface\.occlusion/);
+  assert.match(source, /mix\(1\.0, occlusionTexel\.x, clamp\(triangle\.textureSettings\.y, 0\.0, 1\.0\)\)/);
+  assert.match(source, /\(normalTexel\.x \* 2\.0 - 1\.0\) \* normalScale/);
+  assert.match(source, /\(normalTexel\.y \* 2\.0 - 1\.0\) \* normalScale/);
   assert.match(source, /triangle\.baseColorAtlas/);
   assert.match(source, /triangle\.textureSettings/);
   assert.match(source, /mesh\.baseColorAtlas/);
@@ -792,6 +829,24 @@ test("wavefront compute defers visible colour until terminal path resolve", () =
   assert.match(source, /if \(config\.deferredPathResolve\) \{/);
   assert.match(source, /createGpuSubmissionBatcher\(\{/);
   assert.match(source, /encodeTileOutput\(batch\.reserve\(1\), tile, configOffset, parallelism\);/);
+});
+
+test("wavefront compute caches the generated BRDF LUT upload", () => {
+  const source = readRendererSource();
+
+  assert.match(source, /const cached = BRDF_LUT_UPLOAD_CACHE\.get\(cacheKey\);/);
+  assert.match(source, /BRDF_LUT_UPLOAD_CACHE\.set\(cacheKey, upload\);/);
+});
+
+test("wavefront compute falls back to uniform environment sampling when only external HDRI textures are bound", () => {
+  const source = readRendererSource();
+
+  assert.match(source, /function environmentMapHasSamplingData\(environmentMap\)/);
+  assert.match(source, /hasImportanceData: false/);
+  assert.match(source, /config\.environmentMapMeta\.w > 0\.5/);
+  assert.match(source, /fn uniform_sphere_pdf\(\) -> f32/);
+  assert.match(source, /fn sample_uniform_sphere_direction\(sample: vec2<f32>\) -> vec3<f32>/);
+  assert.match(source, /if \(!environment_importance_sampling_enabled\(\)\) \{\s+return uniform_sphere_pdf\(\);/);
 });
 
 test("analytic wavefront renderer rejects display-quality requests", () => {
@@ -1534,10 +1589,12 @@ serialWebGpuTest("wavefront compute renderer drives GPU-only mesh BVH passes", a
     assert.equal(frame.environmentMap.enabled, true);
     assert.equal(frame.environmentMap.width, 2);
     assert.equal(frame.environmentMap.height, 1);
+    assert.equal(frame.environmentMap.mipLevelCount, 2);
     assert.equal(frame.environmentMap.projection, "equirectangular");
     assert.equal(frame.environmentMap.intensity, 1.7);
     assert.equal(frame.environmentMap.rotationRadians, 0.25);
     assert.equal(frame.environmentMap.ambientStrength, 0.44);
+    assert.equal(frame.environmentMap.hasImportanceData, true);
     assert.equal(frame.commandSubmissions, 2);
     assert.equal(frame.gpuParallelism.physicalCoreCount, null);
     assert.equal(frame.gpuParallelism.physicalCoreCountAvailable, false);
@@ -1579,10 +1636,15 @@ serialWebGpuTest("wavefront compute renderer drives GPU-only mesh BVH passes", a
     assert.deepEqual(round(nextConfig.camera.position), [0.8, 1.3, 5.2]);
     assert.equal(nextConfig.camera.fovYDegrees, 42);
     assert.equal(nextConfig.displayQuality, true);
+    assert.equal(movedConfig.environmentMap.mipLevelCount, 2);
+    assert.equal(nextConfig.environmentMap.mipLevelCount, 2);
+    assert.equal(nextConfig.environmentMap.hasImportanceData, true);
     assert.equal(snapshot.frame, 3);
     assert.equal(snapshot.triangleCount, 1);
     assert.equal(snapshot.environmentMap.enabled, true);
     assert.equal(snapshot.environmentMap.width, 2);
+    assert.equal(snapshot.environmentMap.mipLevelCount, 2);
+    assert.equal(snapshot.environmentMap.hasImportanceData, true);
     assert.equal(snapshot.accelerationBuilt, true);
     assert.equal(snapshot.accelerationBuildCount, 1);
     assert.equal(snapshot.deferredPathResolve, true);


### PR DESCRIPTION
## Summary

- move wavefront adaptive sampling ownership into `@plasius/gpu-renderer` and preserve the resolved sampling plan through fallback render paths
- harden `waitForSubmittedGpuWork` and serialise the WebGPU-mutating tests so local renderer validation is deterministic
- add and update ADR/design docs for deferred path resolve, texture sampling, environment response, and HDRI/BRDF/MIS direction

## Validation

- `npm run typecheck`
- `npm run build`
- `npm run test:coverage`

## Issues

- Refs Plasius-LTD/plasius-ltd-site#845
- Refs Plasius-LTD/plasius-ltd-site#1027
- Refs #20
