### PR TITLE
feat: add wavefront volume medium transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ All notable changes to this project will be documented in this file.
     highlight proxy.
   - Added ADR and design coverage for prefiltered HDRI, BRDF LUT, and MIS-based
     environment lighting in the wavefront display-quality path.
+  - Added ADR/design coverage and public contract support for authored volume
+    transport so mesh materials can derive Beer-Lambert media from glTF-style
+    attenuation inputs while preserving shell thickness in GPU material
+    packing.
   - Added adaptive `renderFrame(...)` sampling controls so callers can cap a
     frame with `frameTimeBudgetMs`, guarantee a `minimumSamplesPerPixel`, and
     inspect actual `renderedSamplesPerPixel` separately from the configured SPP

--- a/README.md
+++ b/README.md
@@ -201,6 +201,15 @@ response now also samples reflection-aligned environment radiance so leather,
 chrome, and other polished authored materials can read from the active
 environment map or procedural sky instead of relying mostly on a sun-direction
 proxy.
+Authored participating-media inputs can also enter through the same mesh path.
+A mesh may provide an explicit `medium` block or a glTF-style `material.volume`
+block with `thickness`, `attenuationColor`, and `attenuationDistance`; the
+renderer derives the medium-table entry, carries the active medium id on the
+GPU ray, and applies Beer-Lambert transmittance to travelled segments on the
+GPU. Thickness is now preserved in material packing for later shell-volume
+work, but the current renderer still tracks only one active medium id per ray
+and does not yet implement nested media, spectral dispersion, or a branching
+reflection/refraction tree.
 
 `samplesPerPixel` controls how many GPU primary-ray samples are accumulated per
 screen pixel within a single render. This multiplies dispatch work but does not

--- a/docs/adrs/adr-0014-wavefront-volume-medium-transport.md
+++ b/docs/adrs/adr-0014-wavefront-volume-medium-transport.md
@@ -1,0 +1,50 @@
+# ADR 0014: Wavefront Volume And Medium Transport For Authored Materials
+
+## Status
+
+Accepted
+
+## Context
+
+The wavefront renderer now carries generic glTF-style surface parameters,
+samples texture hits on the GPU, and can attenuate travelled ray segments with a
+Beer-Lambert medium table. That still left an integration gap: authored volume
+inputs such as `KHR_materials_volume` attenuation colour, attenuation distance,
+and shell thickness were not part of the normal mesh material contract, so
+callers had to inject ad hoc `medium` objects instead of forwarding authored
+material data directly.
+
+The public scene-object API also already exposed `mediumRefId` and `medium`
+fields, but the GPU scene-object record still discarded that information.
+
+## Decision
+
+`@plasius/gpu-renderer` will treat authored volume inputs as first-class
+wavefront material transport data.
+
+The renderer now:
+
+- accepts a `volume` input block alongside explicit `medium` input for meshes
+  and scene objects;
+- derives a medium-table entry automatically for meshes when authored volume
+  attenuation data is present;
+- carries authored shell thickness through material packing in the fourth
+  `materialExtension` channel;
+- preserves scene-object `mediumRefId` values in the GPU record so analytic
+  fixtures can participate in medium lookup as well;
+- keeps Beer-Lambert segment attenuation fully on the GPU once a medium is
+  active on a ray.
+
+## Consequences
+
+- Authored mesh materials can now express transmissive attenuation without
+  requiring renderer-specific medium wiring at every call site.
+- The renderer boundary is closer to glTF PBR plus `KHR_materials_volume`, even
+  though texture-driven volume thickness and other advanced extension inputs are
+  still follow-on work.
+- Thickness is transported now for correctness of the public contract and later
+  shading work, but this change does not yet add a full shell-thickness volume
+  solve.
+- The transport model is still not physically complete: there is still no
+  nested medium stack, spectral dispersion, or reflected/transmitted branching
+  tree in deferred path resolution.

--- a/docs/adrs/index.md
+++ b/docs/adrs/index.md
@@ -13,3 +13,4 @@
 - [ADR 0011: Generic glTF Material Transport For Wavefront Shading](./adr-0011-generic-gltf-material-transport.md)
 - [ADR 0012: Environment Specular Response For Wavefront Shading](./adr-0012-environment-specular-response-for-wavefront-shading.md)
 - [ADR 0013: HDRI Prefilter, BRDF LUT, And MIS For Wavefront Environment Lighting](./adr-0013-hdri-brdf-lut-and-mis-for-wavefront-environment-lighting.md)
+- [ADR 0014: Wavefront Volume And Medium Transport For Authored Materials](./adr-0014-wavefront-volume-medium-transport.md)

--- a/docs/design/wavefront-volume-medium-transport.md
+++ b/docs/design/wavefront-volume-medium-transport.md
@@ -1,0 +1,45 @@
+# Wavefront Volume And Medium Transport
+
+## Goal
+
+Let authored transmissive materials carry volume attenuation data into the
+shared wavefront renderer without demo-local medium construction.
+
+## Scope
+
+- accept authored `volume` inputs plus explicit `medium` inputs on mesh and
+  scene-object contracts;
+- derive mesh medium-table entries from volume attenuation data when no explicit
+  medium is supplied;
+- preserve authored shell thickness through GPU material packing;
+- wire scene-object medium references through the GPU scene-object record;
+- keep Beer-Lambert segment attenuation on the GPU once a ray is inside a
+  medium.
+
+## Data Flow
+
+1. Caller supplies either:
+   - explicit `medium`, or
+   - a glTF-style `volume` block with thickness and attenuation data.
+2. Mesh normalization derives:
+   - `mediumRefId`
+   - normalized medium coefficients
+   - `thickness`
+3. Config assembly collects all referenced media into the compact medium-table
+   texture.
+4. The trace pass carries the active `mediumRefId` on the ray.
+5. Surface resolution multiplies travelled throughput by Beer-Lambert
+   transmittance for the distance traversed in the current medium.
+
+## Explicit Non-Goals
+
+- nested medium stacks;
+- reflected/transmitted branching trees;
+- spectral or wavelength-sampled dispersion;
+- full texture-driven support for every `KHR_materials_*` extension.
+
+## Validation
+
+- unit coverage for implicit medium derivation from volume inputs;
+- stable packing tests for scene-object and material records;
+- renderer typecheck, build, lint, tests, and coverage.

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -42,6 +42,27 @@ export interface WavefrontTextureSampleInput {
   readonly data: Uint8ClampedArray | Uint8Array | readonly number[];
 }
 
+export interface WavefrontMediumInput {
+  readonly id?: number;
+  readonly mediumId?: number;
+  readonly phaseModel?: number | "isotropic";
+  readonly density?: number;
+  readonly attenuationColor?: RendererColor | readonly number[];
+  readonly attenuationDistance?: number;
+  readonly absorption?: readonly [number, number, number] | readonly number[];
+  readonly scattering?: readonly [number, number, number] | readonly number[];
+}
+
+export interface WavefrontVolumeInput {
+  readonly thickness?: number;
+  readonly phaseModel?: number | "isotropic";
+  readonly density?: number;
+  readonly attenuationColor?: RendererColor | readonly number[];
+  readonly attenuationDistance?: number;
+  readonly absorption?: readonly [number, number, number] | readonly number[];
+  readonly scattering?: readonly [number, number, number] | readonly number[];
+}
+
 export interface WavefrontCameraOptions {
   readonly position?: readonly [number, number, number] | readonly number[];
   readonly target?: readonly [number, number, number] | readonly number[];
@@ -62,6 +83,9 @@ export interface WavefrontSceneObjectInput {
   readonly type?: WavefrontSceneObjectKind;
   readonly materialKind?: WavefrontMaterialKind;
   readonly flags?: number;
+  readonly mediumRefId?: number;
+  readonly mediumId?: number;
+  readonly medium?: WavefrontMediumInput | null;
   readonly center?: readonly [number, number, number] | readonly number[];
   readonly position?: readonly [number, number, number] | readonly number[];
   readonly radius?: number;
@@ -90,7 +114,9 @@ export interface WavefrontSceneObjectInput {
   readonly clearcoatRoughness?: number;
   readonly specular?: number;
   readonly specularColor?: RendererColor | readonly number[];
+  readonly thickness?: number;
   readonly transmission?: number;
+  readonly volume?: WavefrontVolumeInput | null;
   readonly material?: {
     readonly kind?: WavefrontMaterialKind;
     readonly color?: RendererColor | readonly number[];
@@ -108,7 +134,11 @@ export interface WavefrontSceneObjectInput {
     readonly clearcoatRoughness?: number;
     readonly specular?: number;
     readonly specularColor?: RendererColor | readonly number[];
+    readonly thickness?: number;
     readonly transmission?: number;
+    readonly medium?: WavefrontMediumInput | null;
+    readonly mediumId?: number;
+    readonly volume?: WavefrontVolumeInput | null;
   };
 }
 
@@ -117,6 +147,8 @@ export interface WavefrontSceneObject {
   readonly kind: number;
   readonly materialKind: number;
   readonly flags: number;
+  readonly mediumRefId: number;
+  readonly medium: WavefrontMediumInput | null;
   readonly center: readonly [number, number, number] | readonly number[];
   readonly halfExtent: readonly [number, number, number] | readonly number[];
   readonly color: readonly [number, number, number, number] | readonly number[];
@@ -132,6 +164,7 @@ export interface WavefrontSceneObject {
   readonly clearcoatRoughness: number;
   readonly specular: number;
   readonly specularColor: readonly [number, number, number, number] | readonly number[];
+  readonly thickness: number;
   readonly transmission: number;
 }
 
@@ -165,7 +198,9 @@ export interface WavefrontMeshInput {
   readonly clearcoatRoughness?: number;
   readonly specular?: number;
   readonly specularColor?: RendererColor | readonly number[];
+  readonly thickness?: number;
   readonly transmission?: number;
+  readonly volume?: WavefrontVolumeInput | null;
   readonly material?: {
     readonly kind?: WavefrontMaterialKind;
     readonly color?: RendererColor | readonly number[];
@@ -183,8 +218,12 @@ export interface WavefrontMeshInput {
     readonly clearcoatRoughness?: number;
     readonly specular?: number;
     readonly specularColor?: RendererColor | readonly number[];
+    readonly thickness?: number;
     readonly transmission?: number;
     readonly id?: number;
+    readonly medium?: WavefrontMediumInput | null;
+    readonly mediumId?: number;
+    readonly volume?: WavefrontVolumeInput | null;
     readonly baseColorTexture?: WavefrontTextureSampleInput | null;
     readonly metallicRoughnessTexture?: WavefrontTextureSampleInput | null;
     readonly normalTexture?: WavefrontTextureSampleInput | null;
@@ -196,9 +235,7 @@ export interface WavefrontMeshInput {
   readonly normalTexture?: WavefrontTextureSampleInput | null;
   readonly occlusionTexture?: WavefrontTextureSampleInput | null;
   readonly emissiveTexture?: WavefrontTextureSampleInput | null;
-  readonly medium?: {
-    readonly id?: number;
-  };
+  readonly medium?: WavefrontMediumInput | null;
 }
 
 export interface WavefrontTriangleRecord {
@@ -346,6 +383,7 @@ export interface WavefrontGpuMeshSource {
       readonly flags: number;
       readonly materialRefId: number;
       readonly mediumRefId: number;
+      readonly medium: WavefrontMediumInput | null;
       readonly color: readonly number[];
       readonly emission: readonly number[];
       readonly roughness: number;
@@ -359,6 +397,7 @@ export interface WavefrontGpuMeshSource {
       readonly clearcoatRoughness: number;
       readonly specular: number;
       readonly specularColor: readonly [number, number, number, number] | readonly number[];
+      readonly thickness: number;
       readonly transmission: number;
       readonly baseColorTexture: WavefrontTextureSampleInput | null;
       readonly metallicRoughnessTexture: WavefrontTextureSampleInput | null;
@@ -478,6 +517,16 @@ export interface WavefrontPathTracingComputeConfig {
   readonly sceneObjects: readonly WavefrontSceneObject[];
   readonly sceneObjectCount: number;
   readonly sceneObjectCapacity: number;
+  readonly mediums: readonly Readonly<{
+    readonly id: number;
+    readonly phaseModel: number;
+    readonly density: number;
+    readonly attenuationColor: readonly [number, number, number, number] | readonly number[];
+    readonly attenuationDistance: number;
+    readonly absorption: readonly [number, number, number] | readonly number[];
+    readonly scattering: readonly [number, number, number] | readonly number[];
+  }>[];
+  readonly mediumCount: number;
   readonly accelerationBuildMode: WavefrontAccelerationBuildMode;
   readonly gpuAccelerationBuildRequired: boolean;
   readonly gpuMeshSource: WavefrontGpuMeshSource;
@@ -622,6 +671,7 @@ export interface CreateWavefrontPathTracingComputeRendererOptions {
   readonly tilePixelCapacity?: number;
   readonly sceneObjectCapacity?: number;
   readonly sceneObjects?: readonly WavefrontSceneObjectInput[];
+  readonly mediums?: readonly WavefrontMediumInput[];
   readonly mesh?: WavefrontMeshInput;
   readonly meshes?: readonly WavefrontMeshInput[];
   readonly triangleCapacity?: number;
@@ -689,6 +739,7 @@ export interface WavefrontPathTracingComputeRenderer {
     emissiveTriangleCount: number;
     environmentPortalCount: number;
     environmentPortalMode: 0 | 1 | 2;
+    mediumCount: number;
     environmentMap: WavefrontEnvironmentMapSnapshot;
     deferredPathResolve: boolean;
     bvhNodeCount: number;
@@ -723,6 +774,7 @@ export interface WavefrontPathTracingComputeFrameStats {
   readonly emissiveTriangleCount: number;
   readonly environmentPortalCount: number;
   readonly environmentPortalMode: 0 | 1 | 2;
+  readonly mediumCount: number;
   readonly environmentMap: WavefrontEnvironmentMapSnapshot;
   readonly deferredPathResolve: boolean;
   readonly bvhNodeCount: number;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -952,7 +952,7 @@ export const wavefrontPathTracingComputeLimits: Readonly<{
   traceStorageBufferBindings: number;
   rayRecordBytes: 80;
   hitRecordBytes: 256;
-  sceneObjectRecordBytes: 144;
+  sceneObjectRecordBytes: 160;
   meshVertexRecordBytes: 48;
   meshRangeRecordBytes: 240;
   triangleRecordBytes: 352;

--- a/src/wavefront-compute.js
+++ b/src/wavefront-compute.js
@@ -17,13 +17,14 @@ const DEFAULT_BRDF_LUT_SIZE = 256;
 const DEFAULT_MAX_FRAME_PASSES_PER_SUBMISSION = 256;
 const DEFAULT_SCENE_OBJECT_CAPACITY = 128;
 const DEFAULT_ENVIRONMENT_PORTAL_CAPACITY = 32;
+const DEFAULT_MEDIUM_PHASE_MODEL = 0;
 const WORKGROUP_SIZE = 64;
 export const rendererWavefrontComputeMode = "webgpu-compute";
 export const rendererWavefrontComputeWorkgroupSize = WORKGROUP_SIZE;
 export const rendererWavefrontComputeStatsStride = 8;
 const RAY_RECORD_BYTES = 80;
 const HIT_RECORD_BYTES = 256;
-const SCENE_OBJECT_RECORD_BYTES = 144;
+const SCENE_OBJECT_RECORD_BYTES = 160;
 const MESH_VERTEX_RECORD_BYTES = 48;
 const MESH_RANGE_RECORD_BYTES = 240;
 const TRIANGLE_RECORD_BYTES = 352;
@@ -32,6 +33,7 @@ const BVH_NODE_RECORD_BYTES = 48;
 const BVH_LEAF_REF_RECORD_BYTES = 16;
 const EMISSIVE_TRIANGLE_INDEX_BYTES = 4;
 const ENVIRONMENT_PORTAL_RECORD_BYTES = 96;
+const MEDIUM_TABLE_ROWS = 2;
 const ACCUMULATION_RECORD_BYTES = 16;
 const PATH_VERTEX_RECORD_BYTES = 16;
 const GPU_SUBMITTED_WORK_TIMEOUT_MS = 5_000;
@@ -437,6 +439,170 @@ function deriveBounds(input) {
   return null;
 }
 
+function deriveBeerLambertAbsorptionFromAttenuationColor(
+  attenuationColor,
+  attenuationDistance,
+  density = 1
+) {
+  const distance = Number(attenuationDistance);
+  const densityScale = Math.max(0, Number(density) || 0);
+  if (!Number.isFinite(distance) || distance <= 0 || densityScale <= 0) {
+    return [0, 0, 0];
+  }
+  return attenuationColor.slice(0, 3).map((channel) => {
+    const clamped = clamp(Number(channel) || 0, 0.0001, 1);
+    return Math.max(0, (-Math.log(clamped) / distance) * densityScale);
+  });
+}
+
+function readMediumPhaseModel(value) {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return Math.max(0, Math.trunc(value));
+  }
+  switch (String(value ?? "").trim().toLowerCase()) {
+    case "isotropic":
+    default:
+      return DEFAULT_MEDIUM_PHASE_MODEL;
+  }
+}
+
+function resolveWavefrontVolumeInput(input) {
+  return input?.volume ?? input?.material?.volume ?? null;
+}
+
+function normalizeWavefrontThickness(input, label) {
+  const volume = resolveWavefrontVolumeInput(input);
+  return Math.max(
+    0,
+    readFiniteNumber(
+      label,
+      input?.thickness ?? volume?.thickness ?? input?.material?.thickness,
+      0
+    )
+  );
+}
+
+function deriveWavefrontMeshMedium(input, fallbackId = 1) {
+  if (input?.medium) {
+    return normalizeWavefrontMedium(input.medium, fallbackId);
+  }
+  const volume = resolveWavefrontVolumeInput(input);
+  if (!volume) {
+    return null;
+  }
+  return normalizeWavefrontMedium(
+    {
+      id:
+        input.mediumRefId ??
+        input.mediumId ??
+        input.material?.mediumId ??
+        input.materialRefId ??
+        input.materialId ??
+        input.id ??
+        fallbackId,
+      phaseModel: volume.phaseModel,
+      density: volume.density,
+      attenuationColor: volume.attenuationColor,
+      attenuationDistance: volume.attenuationDistance,
+      absorption: volume.absorption,
+      scattering: volume.scattering,
+    },
+    fallbackId
+  );
+}
+
+function normalizeWavefrontMedium(input = {}, index = 0) {
+  const id = readNonNegativeInteger("medium id", input.id ?? input.mediumId, index);
+  const density = Math.max(0, readFiniteNumber("medium density", input.density, 1));
+  const attenuationColor = asColor(
+    input.attenuationColor ?? input.color ?? input.medium?.attenuationColor,
+    [1, 1, 1, 1]
+  );
+  const attenuationDistance = readFiniteNumber(
+    "medium attenuationDistance",
+    input.attenuationDistance ?? input.distance ?? input.medium?.attenuationDistance,
+    0
+  );
+  const absorption =
+    Array.isArray(input.absorption) || Array.isArray(input.medium?.absorption)
+      ? asVec3(input.absorption ?? input.medium?.absorption, [0, 0, 0]).map((value) =>
+          Math.max(0, Number(value) || 0)
+        )
+      : deriveBeerLambertAbsorptionFromAttenuationColor(
+          attenuationColor,
+          attenuationDistance,
+          density
+        );
+  const scattering = asVec3(
+    input.scattering ?? input.medium?.scattering,
+    [0, 0, 0]
+  ).map((value) => Math.max(0, Number(value) || 0));
+  return Object.freeze({
+    id,
+    phaseModel: readMediumPhaseModel(input.phaseModel ?? input.medium?.phaseModel),
+    density,
+    attenuationColor: Object.freeze(attenuationColor),
+    attenuationDistance,
+    absorption: Object.freeze(absorption),
+    scattering: Object.freeze(scattering),
+  });
+}
+
+function collectWavefrontMediums(options, meshes, sceneObjects = []) {
+  const mediumsById = new Map();
+  mediumsById.set(
+    0,
+    Object.freeze({
+      id: 0,
+      phaseModel: DEFAULT_MEDIUM_PHASE_MODEL,
+      density: 0,
+      attenuationColor: Object.freeze([1, 1, 1, 1]),
+      attenuationDistance: 0,
+      absorption: Object.freeze([0, 0, 0]),
+      scattering: Object.freeze([0, 0, 0]),
+    })
+  );
+
+  const register = (input, fallbackId = mediumsById.size) => {
+    if (!input) {
+      return;
+    }
+    const normalized = normalizeWavefrontMedium(
+      typeof input === "object" ? { id: fallbackId, ...input } : { id: fallbackId },
+      fallbackId
+    );
+    const existing = mediumsById.get(normalized.id);
+    if (existing && JSON.stringify(existing) !== JSON.stringify(normalized)) {
+      throw new Error(`Medium id ${normalized.id} is defined more than once with different values.`);
+    }
+    mediumsById.set(normalized.id, normalized);
+  };
+
+  for (const medium of options.mediums ?? []) {
+    register(medium);
+  }
+  for (const mesh of meshes) {
+    register(mesh.medium, mesh.mediumRefId ?? mesh.medium?.id ?? 0);
+  }
+  for (const mesh of meshes) {
+    if ((mesh.mediumRefId ?? 0) > 0 && !mediumsById.has(mesh.mediumRefId)) {
+      register({ id: mesh.mediumRefId });
+    }
+  }
+  for (const object of sceneObjects) {
+    register(object.medium, object.mediumRefId ?? object.medium?.id ?? 0);
+  }
+  for (const object of sceneObjects) {
+    if ((object.mediumRefId ?? 0) > 0 && !mediumsById.has(object.mediumRefId)) {
+      register({ id: object.mediumRefId });
+    }
+  }
+
+  return Object.freeze(
+    Array.from(mediumsById.values()).sort((left, right) => left.id - right.id)
+  );
+}
+
 export function normalizeWavefrontSceneObject(input = {}, index = 0) {
   const bounds = deriveBounds(input);
   const kind = readObjectKind(input.kind ?? input.type ?? (bounds ? "box" : "sphere"));
@@ -474,6 +640,8 @@ export function normalizeWavefrontSceneObject(input = {}, index = 0) {
     input.specularColor ?? input.material?.specularColor,
     [1, 1, 1, 1]
   ).map((value, componentIndex) => (componentIndex < 3 ? clamp(value, 0, 1) : 1));
+  const medium =
+    input.medium ? normalizeWavefrontMedium(input.medium, index + 1) : null;
   const resolvedMaterialKind =
     emission[0] > 0 || emission[1] > 0 || emission[2] > 0
       ? MATERIAL_EMISSIVE
@@ -488,6 +656,12 @@ export function normalizeWavefrontSceneObject(input = {}, index = 0) {
     kind,
     materialKind: resolvedMaterialKind,
     flags: readNonNegativeInteger("flags", input.flags, 0),
+    mediumRefId: readNonNegativeInteger(
+      "mediumRefId",
+      input.mediumRefId ?? input.medium?.id ?? input.mediumId,
+      0
+    ),
+    medium,
     center: Object.freeze(center),
     halfExtent: Object.freeze(halfExtent),
     color: Object.freeze(color),
@@ -511,6 +685,7 @@ export function normalizeWavefrontSceneObject(input = {}, index = 0) {
     ),
     specular: clamp(readFiniteNumber("specular", input.specular ?? input.material?.specular, 1), 0, 1),
     specularColor: Object.freeze(specularColor),
+    thickness: normalizeWavefrontThickness(input, "thickness"),
     transmission,
   });
 }
@@ -620,6 +795,7 @@ export function normalizeWavefrontMesh(input = {}, meshIndex = 0) {
     input.specularColor ?? input.material?.specularColor,
     [1, 1, 1, 1]
   ).map((value, componentIndex) => (componentIndex < 3 ? clamp(value, 0, 1) : 1));
+  const medium = deriveWavefrontMeshMedium(input, meshIndex + 1);
   const resolvedMaterialKind =
     emission[0] > 0 || emission[1] > 0 || emission[2] > 0
       ? MATERIAL_EMISSIVE
@@ -644,9 +820,14 @@ export function normalizeWavefrontMesh(input = {}, meshIndex = 0) {
     ),
     mediumRefId: readNonNegativeInteger(
       "mesh mediumRefId",
-      input.mediumRefId ?? input.medium?.id ?? input.mediumId,
+      input.mediumRefId ??
+        medium?.id ??
+        input.medium?.id ??
+        input.mediumId ??
+        input.material?.mediumId,
       0
     ),
+    medium,
     color: Object.freeze(color),
     emission: Object.freeze(emission),
     roughness: clamp(readFiniteNumber("roughness", input.roughness ?? input.material?.roughness, 0.72), 0, 1),
@@ -668,6 +849,7 @@ export function normalizeWavefrontMesh(input = {}, meshIndex = 0) {
     ),
     specular: clamp(readFiniteNumber("specular", input.specular ?? input.material?.specular, 1), 0, 1),
     specularColor: Object.freeze(specularColor),
+    thickness: normalizeWavefrontThickness(input, "mesh thickness"),
     transmission,
     baseColorTexture: input.baseColorTexture ?? input.material?.baseColorTexture ?? null,
     metallicRoughnessTexture:
@@ -902,7 +1084,7 @@ function createMeshTriangleRecords(meshes) {
             mesh.clearcoatRoughness,
             mesh.specular,
             mesh.transmission,
-            0,
+            mesh.thickness,
           ]),
           specularColor: Object.freeze([
             mesh.specularColor[0] ?? 1,
@@ -1231,7 +1413,7 @@ export function createWavefrontGpuMaterialSource(meshes = []) {
       mesh.clearcoatRoughness,
       mesh.specular,
       mesh.transmission,
-      0,
+      mesh.thickness,
     ]);
     writeVec4(floatView, byteOffset + 80, [
       mesh.specularColor[0] ?? 1,
@@ -1419,7 +1601,7 @@ export function createWavefrontGpuMeshSource(meshes = [], gpuMaterialSourceInput
       mesh.clearcoatRoughness,
       mesh.specular,
       mesh.transmission,
-      0,
+      mesh.thickness,
     ]);
     writeVec4(meshFloats, floatOffset * 4 + 128, [
       mesh.specularColor[0] ?? 1,
@@ -1534,12 +1716,17 @@ function normalizeSceneObjects(sceneObjects, useDefaultScene = true) {
   return source.map((object, index) => normalizeWavefrontSceneObject(object, index));
 }
 
+function normalizeWavefrontMeshes(meshes) {
+  const source = Array.isArray(meshes) ? meshes : [];
+  return source.map((mesh, index) => normalizeWavefrontMesh(mesh, index));
+}
+
 function normalizeMeshes(options = {}) {
   if (Array.isArray(options.meshes)) {
-    return options.meshes;
+    return normalizeWavefrontMeshes(options.meshes);
   }
   if (options.mesh) {
-    return [options.mesh];
+    return normalizeWavefrontMeshes([options.mesh]);
   }
   return [];
 }
@@ -1899,6 +2086,7 @@ export function createWavefrontPathTracingComputeConfig(options = {}) {
   const sceneObjects = Object.freeze(
     normalizeSceneObjects(options.sceneObjects, meshes.length === 0)
   );
+  const mediums = collectWavefrontMediums(options, meshes, sceneObjects);
   const sceneObjectCapacity = Math.max(
     sceneObjects.length,
     readPositiveInteger("sceneObjectCapacity", options.sceneObjectCapacity, DEFAULT_SCENE_OBJECT_CAPACITY)
@@ -1971,6 +2159,8 @@ export function createWavefrontPathTracingComputeConfig(options = {}) {
     sceneObjects,
     sceneObjectCount: sceneObjects.length,
     sceneObjectCapacity,
+    mediums,
+    mediumCount: mediums.length,
     accelerationBuildMode,
     gpuAccelerationBuildRequired: accelerationBuildMode === "gpu" && triangleCount > 0,
     gpuMeshSource,
@@ -2089,29 +2279,30 @@ export function packWavefrontSceneObjects(sceneObjects, capacity = sceneObjects.
     uintView[u32 + 1] = object.id;
     uintView[u32 + 2] = object.materialKind;
     uintView[u32 + 3] = object.flags;
-    writeVec4(floatView, byteOffset + 16, [...object.center, 0]);
-    writeVec4(floatView, byteOffset + 32, [...object.halfExtent, 0]);
-    writeVec4(floatView, byteOffset + 48, object.color);
-    writeVec4(floatView, byteOffset + 64, object.emission);
-    writeVec4(floatView, byteOffset + 80, [
+    uintView[u32 + 4] = object.mediumRefId;
+    writeVec4(floatView, byteOffset + 32, [...object.center, 0]);
+    writeVec4(floatView, byteOffset + 48, [...object.halfExtent, 0]);
+    writeVec4(floatView, byteOffset + 64, object.color);
+    writeVec4(floatView, byteOffset + 80, object.emission);
+    writeVec4(floatView, byteOffset + 96, [
       object.roughness,
       object.metallic,
       object.opacity,
       object.ior,
     ]);
-    writeVec4(floatView, byteOffset + 96, [
+    writeVec4(floatView, byteOffset + 112, [
       object.sheenColor[0] ?? 0,
       object.sheenColor[1] ?? 0,
       object.sheenColor[2] ?? 0,
       object.clearcoat,
     ]);
-    writeVec4(floatView, byteOffset + 112, [
+    writeVec4(floatView, byteOffset + 128, [
       object.clearcoatRoughness,
       object.specular,
       object.transmission,
-      0,
+      object.thickness,
     ]);
-    writeVec4(floatView, byteOffset + 128, [
+    writeVec4(floatView, byteOffset + 144, [
       object.specularColor[0] ?? 1,
       object.specularColor[1] ?? 1,
       object.specularColor[2] ?? 1,
@@ -3137,6 +3328,55 @@ function createBrdfLutResource(device, constants, size = DEFAULT_BRDF_LUT_SIZE) 
   });
 }
 
+function createMediumTextureResource(device, constants, mediums) {
+  const normalized = Array.isArray(mediums) && mediums.length > 0 ? mediums : [{ id: 0 }];
+  const width = Math.max(
+    1,
+    normalized.reduce((maximum, medium) => Math.max(maximum, medium.id ?? 0), 0) + 1
+  );
+  const level = {
+    width,
+    height: MEDIUM_TABLE_ROWS,
+    data: new Float32Array(width * MEDIUM_TABLE_ROWS * 4),
+  };
+
+  for (const medium of normalized) {
+    const mediumId = Math.max(0, Math.trunc(Number(medium.id) || 0));
+    const absorptionOffset = mediumId * 4;
+    level.data[absorptionOffset] = Math.max(0, medium.absorption?.[0] ?? 0);
+    level.data[absorptionOffset + 1] = Math.max(0, medium.absorption?.[1] ?? 0);
+    level.data[absorptionOffset + 2] = Math.max(0, medium.absorption?.[2] ?? 0);
+    level.data[absorptionOffset + 3] = Math.max(0, medium.phaseModel ?? 0);
+
+    const scatteringOffset = (width + mediumId) * 4;
+    level.data[scatteringOffset] = Math.max(0, medium.scattering?.[0] ?? 0);
+    level.data[scatteringOffset + 1] = Math.max(0, medium.scattering?.[1] ?? 0);
+    level.data[scatteringOffset + 2] = Math.max(0, medium.scattering?.[2] ?? 0);
+    level.data[scatteringOffset + 3] = Math.max(0, medium.density ?? 0);
+  }
+
+  const upload = createFloat16RgbaUploadFromLevels([level])[0];
+  const texture = device.createTexture({
+    label: "plasius.wavefront.mediumTable",
+    size: { width, height: MEDIUM_TABLE_ROWS },
+    format: "rgba16float",
+    usage: constants.texture.TEXTURE_BINDING | constants.texture.COPY_DST,
+  });
+  device.queue.writeTexture(
+    { texture },
+    upload.bytes,
+    { bytesPerRow: upload.bytesPerRow, rowsPerImage: upload.height },
+    { width, height: MEDIUM_TABLE_ROWS, depthOrArrayLayers: 1 }
+  );
+  return Object.freeze({
+    texture,
+    view: texture.createView(),
+    ownsTexture: true,
+    count: normalized.length,
+    width,
+  });
+}
+
 function createAtlasTextureResource(device, constants, atlas, label) {
   const upload = createRgba8TextureUpload(atlas);
   const texture = device.createTexture({
@@ -3283,6 +3523,10 @@ struct SceneObject {
   objectId: u32,
   materialKind: u32,
   flags: u32,
+  mediumRefId: u32,
+  pad0: u32,
+  pad1: u32,
+  pad2: u32,
   center: vec4<f32>,
   halfExtent: vec4<f32>,
   color: vec4<f32>,
@@ -3343,9 +3587,9 @@ struct BvhLeafRef {
 struct ScatterResult {
   direction: vec4<f32>,
   pdf: f32,
+  mediumRefId: u32,
   flags: u32,
   pad0: u32,
-  pad1: u32,
 };
 
 struct MeshVertex {
@@ -3491,6 +3735,7 @@ struct EnvironmentPortal {
 @group(0) @binding(29) var brdfLutTexture: texture_2d<f32>;
 @group(0) @binding(30) var brdfLutSampler: sampler;
 @group(0) @binding(31) var environmentSamplingTexture: texture_2d<f32>;
+@group(0) @binding(32) var mediumTableTexture: texture_2d<f32>;
 
 fn hash_u32(value: u32) -> u32 {
   var x = value;
@@ -4156,6 +4401,60 @@ fn gated_environment_radiance(origin: vec3<f32>, direction: vec3<f32>) -> vec3<f
   return environment_radiance(origin, direction);
 }
 
+fn medium_dimensions() -> vec2<u32> {
+  return textureDimensions(mediumTableTexture);
+}
+
+fn medium_valid(mediumRefId: u32) -> bool {
+  let dimensions = medium_dimensions();
+  return mediumRefId > 0u && mediumRefId < dimensions.x;
+}
+
+fn medium_absorption(mediumRefId: u32) -> vec3<f32> {
+  if (!medium_valid(mediumRefId)) {
+    return vec3<f32>(0.0);
+  }
+  return max(
+    textureLoad(mediumTableTexture, vec2<i32>(i32(mediumRefId), 0), 0).xyz,
+    vec3<f32>(0.0)
+  );
+}
+
+fn medium_scattering(mediumRefId: u32) -> vec3<f32> {
+  if (!medium_valid(mediumRefId)) {
+    return vec3<f32>(0.0);
+  }
+  return max(
+    textureLoad(mediumTableTexture, vec2<i32>(i32(mediumRefId), 1), 0).xyz,
+    vec3<f32>(0.0)
+  );
+}
+
+fn medium_transmittance(mediumRefId: u32, distance: f32) -> vec3<f32> {
+  if (!medium_valid(mediumRefId) || distance <= 0.000001) {
+    return vec3<f32>(1.0);
+  }
+  let extinction = medium_absorption(mediumRefId) + medium_scattering(mediumRefId);
+  return vec3<f32>(
+    exp(-extinction.x * distance),
+    exp(-extinction.y * distance),
+    exp(-extinction.z * distance)
+  );
+}
+
+fn transmitted_medium_ref_id(ray: RayRecord, hit: HitRecord) -> u32 {
+  if (hit.mediumRefId == 0u) {
+    return ray.mediumRefId;
+  }
+  if (hit.frontFace == 1u) {
+    return hit.mediumRefId;
+  }
+  if (ray.mediumRefId == hit.mediumRefId) {
+    return 0u;
+  }
+  return ray.mediumRefId;
+}
+
 fn surface_path_response(hit: HitRecord) -> vec3<f32> {
   let color = clamp(hit.color.xyz, vec3<f32>(0.0), vec3<f32>(1.0));
   let opacity = clamp(hit.material.z, 0.0, 1.0);
@@ -4254,11 +4553,15 @@ fn terminal_surface_environment_source(ray: RayRecord, hit: HitRecord) -> vec3<f
   return clamp_sample_radiance(environmentFloor * materialFloor);
 }
 
-fn terminal_surface_environment_contribution(ray: RayRecord, hit: HitRecord) -> vec3<f32> {
+fn terminal_surface_environment_contribution(
+  ray: RayRecord,
+  throughput: vec3<f32>,
+  hit: HitRecord
+) -> vec3<f32> {
   let surfaceColor = max(hit.color.xyz, config.ambientColor.xyz);
   let occlusion = mix(0.75, 1.0, clamp(hit.occlusion, 0.0, 1.0));
   return clamp_sample_radiance(
-    ray.throughput.xyz *
+    throughput *
     surfaceColor *
     terminal_surface_environment_source(ray, hit) *
     occlusion
@@ -4732,7 +5035,7 @@ fn intersect_sphere(ray: RayRecord, object: SceneObject) -> Candidate {
     0xffffffffu,
     object.objectId,
     object.objectId,
-    0u
+    object.mediumRefId
   );
 }
 
@@ -4784,7 +5087,7 @@ fn intersect_box(ray: RayRecord, object: SceneObject) -> Candidate {
     0xffffffffu,
     object.objectId,
     object.objectId,
-    0u
+    object.mediumRefId
   );
 }
 
@@ -5039,6 +5342,10 @@ fn intersectActiveQueue(@builtin(global_invocation_id) globalId: vec3<u32>) {
     0u,
     0u,
     0u,
+    0u,
+    0u,
+    0u,
+    0u,
     vec4<f32>(0.0),
     vec4<f32>(0.0),
     vec4<f32>(0.0),
@@ -5238,9 +5545,9 @@ fn scatter_direction(ray: RayRecord, hit: HitRecord, seed: u32) -> ScatterResult
     return ScatterResult(
       vec4<f32>(reflect(ray.direction.xyz, normal), 0.0),
       1.0,
+      ray.mediumRefId,
       RAY_FLAG_DELTA_SAMPLE,
       0u,
-      0u
     );
   }
 
@@ -5260,17 +5567,17 @@ fn scatter_direction(ray: RayRecord, hit: HitRecord, seed: u32) -> ScatterResult
       return ScatterResult(
         vec4<f32>(reflect(ray.direction.xyz, normal), 0.0),
         1.0,
+        ray.mediumRefId,
         RAY_FLAG_DELTA_SAMPLE,
         0u,
-        0u
       );
     }
     return ScatterResult(
       vec4<f32>(refract_direction(ray.direction.xyz, normal, etaRatio), 0.0),
       1.0,
+      transmitted_medium_ref_id(ray, hit),
       RAY_FLAG_DELTA_SAMPLE,
       0u,
-      0u
     );
   }
 
@@ -5285,9 +5592,9 @@ fn scatter_direction(ray: RayRecord, hit: HitRecord, seed: u32) -> ScatterResult
       return ScatterResult(
         vec4<f32>(guidedDirection, 0.0),
         guidedPdf,
+        ray.mediumRefId,
         RAY_FLAG_GUIDED_EMISSIVE,
         0u,
-        0u
       );
     }
   }
@@ -5295,7 +5602,7 @@ fn scatter_direction(ray: RayRecord, hit: HitRecord, seed: u32) -> ScatterResult
     let guidedDirection = sample_environment_portal_direction(hit, seed + 131u, normal);
     if (dot(normal, guidedDirection) > 0.000001) {
       let guidedPdf = max(evaluate_surface_bsdf_pdf(hit, viewDirection, guidedDirection), 0.000001);
-      return ScatterResult(vec4<f32>(guidedDirection, 0.0), guidedPdf, 0u, 0u, 0u);
+      return ScatterResult(vec4<f32>(guidedDirection, 0.0), guidedPdf, ray.mediumRefId, 0u, 0u);
     }
   }
 
@@ -5329,7 +5636,7 @@ fn scatter_direction(ray: RayRecord, hit: HitRecord, seed: u32) -> ScatterResult
     );
   }
   let pdf = max(evaluate_surface_bsdf_pdf(hit, viewDirection, lightDirection), 0.000001);
-  return ScatterResult(vec4<f32>(lightDirection, 0.0), pdf, 0u, 0u, 0u);
+  return ScatterResult(vec4<f32>(lightDirection, 0.0), pdf, ray.mediumRefId, 0u, 0u);
 }
 
 @compute @workgroup_size(64)
@@ -5342,15 +5649,17 @@ fn resolveSurfaceRecords(@builtin(global_invocation_id) globalId: vec3<u32>) {
 
   let ray = activeQueue[index];
   let hit = hits[index];
+  let segmentTransmittance = medium_transmittance(ray.mediumRefId, hit.distance);
+  let arrivingThroughput = ray.throughput.xyz * segmentTransmittance;
   var contribution = vec3<f32>(0.0);
 
   if (hit.hitType == 1u) {
     let guidedLightWeight = select(1.0, 0.24, (ray.flags & RAY_FLAG_GUIDED_EMISSIVE) != 0u);
     let sourceRadiance = max(hit.emission.xyz, hit.color.xyz) * guidedLightWeight;
     if (deferred_path_resolve_enabled()) {
-      record_deferred_terminal_source(ray, sourceRadiance);
+      record_deferred_terminal_source(ray, sourceRadiance * segmentTransmittance);
     } else {
-      contribution = clamp_sample_radiance(ray.throughput.xyz * sourceRadiance);
+      contribution = clamp_sample_radiance(arrivingThroughput * sourceRadiance);
       accumulation[ray.rayId] =
         accumulation[ray.rayId] + vec4<f32>(contribution * sample_weight(), 1.0);
     }
@@ -5367,9 +5676,9 @@ fn resolveSurfaceRecords(@builtin(global_invocation_id) globalId: vec3<u32>) {
       sourceRadiance = sourceRadiance * misWeight;
     }
     if (deferred_path_resolve_enabled()) {
-      record_deferred_terminal_source(ray, sourceRadiance);
+      record_deferred_terminal_source(ray, sourceRadiance * segmentTransmittance);
     } else {
-      contribution = clamp_sample_radiance(ray.throughput.xyz * sourceRadiance);
+      contribution = clamp_sample_radiance(arrivingThroughput * sourceRadiance);
       accumulation[ray.rayId] =
         accumulation[ray.rayId] + vec4<f32>(contribution * sample_weight(), 1.0);
     }
@@ -5377,7 +5686,11 @@ fn resolveSurfaceRecords(@builtin(global_invocation_id) globalId: vec3<u32>) {
     return;
   }
 
-  let response = stabilize_surface_path_response(ray, hit, surface_path_response(hit));
+  let response = stabilize_surface_path_response(
+    ray,
+    hit,
+    surface_path_response(hit) * segmentTransmittance
+  );
   record_deferred_path_response(ray, response);
 
   let shouldEstimateDirectEnvironment =
@@ -5385,7 +5698,22 @@ fn resolveSurfaceRecords(@builtin(global_invocation_id) globalId: vec3<u32>) {
     hit.material.z >= 0.95 &&
     ray.bounce < 2u;
   if (shouldEstimateDirectEnvironment) {
-    let directEnvironment = surface_direct_environment_contribution(ray, hit);
+    let directEnvironment = surface_direct_environment_contribution(
+      RayRecord(
+        ray.rayId,
+        ray.parentRayId,
+        ray.sourcePixelId,
+        ray.sampleId,
+        ray.bounce,
+        ray.mediumRefId,
+        ray.flags,
+        0u,
+        ray.origin,
+        ray.direction,
+        vec4<f32>(arrivingThroughput, ray.throughput.w)
+      ),
+      hit
+    );
     accumulation[ray.rayId] =
       accumulation[ray.rayId] + vec4<f32>(directEnvironment * sample_weight(), 0.0);
   }
@@ -5394,7 +5722,11 @@ fn resolveSurfaceRecords(@builtin(global_invocation_id) globalId: vec3<u32>) {
     if (deferred_path_resolve_enabled()) {
       record_deferred_terminal_source(ray, terminal_surface_environment_source(ray, hit));
     } else {
-      let terminalEnvironment = terminal_surface_environment_contribution(ray, hit);
+      let terminalEnvironment = terminal_surface_environment_contribution(
+        ray,
+        arrivingThroughput,
+        hit
+      );
       accumulation[ray.rayId] =
         accumulation[ray.rayId] + vec4<f32>(terminalEnvironment * sample_weight(), 1.0);
     }
@@ -5409,7 +5741,11 @@ fn resolveSurfaceRecords(@builtin(global_invocation_id) globalId: vec3<u32>) {
     if (deferred_path_resolve_enabled()) {
       record_deferred_terminal_source(ray, terminal_surface_environment_source(ray, hit));
     } else {
-      let overflowEnvironment = terminal_surface_environment_contribution(ray, hit);
+      let overflowEnvironment = terminal_surface_environment_contribution(
+        ray,
+        arrivingThroughput,
+        hit
+      );
       accumulation[ray.rayId] =
         accumulation[ray.rayId] + vec4<f32>(overflowEnvironment * sample_weight(), 1.0);
     }
@@ -5423,7 +5759,7 @@ fn resolveSurfaceRecords(@builtin(global_invocation_id) globalId: vec3<u32>) {
     ray.sourcePixelId,
     ray.sampleId,
     ray.bounce + 1u,
-    ray.mediumRefId,
+    scatter.mediumRefId,
     scatter.flags,
     0u,
     vec4<f32>(offset_origin(hit.position.xyz, hit.shadingNormal.xyz), 1.0),
@@ -5945,6 +6281,11 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
     config.environmentMap,
     config.environmentColor
   );
+  const mediumTextureResource = createMediumTextureResource(
+    device,
+    constants,
+    config.mediums
+  );
   config = Object.freeze({
     ...config,
     environmentMap: Object.freeze({
@@ -6033,6 +6374,7 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
       { binding: 29, visibility: constants.shader.COMPUTE, texture: { sampleType: "float" } },
       { binding: 30, visibility: constants.shader.COMPUTE, sampler: { type: "filtering" } },
       { binding: 31, visibility: constants.shader.COMPUTE, texture: { sampleType: "float" } },
+      { binding: 32, visibility: constants.shader.COMPUTE, texture: { sampleType: "float" } },
     ],
   });
   const accelerationBindGroupLayout = device.createBindGroupLayout({
@@ -6222,6 +6564,7 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
         { binding: 29, resource: brdfLutResource.view },
         { binding: 30, resource: brdfLutResource.sampler },
         { binding: 31, resource: environmentSamplingResource.view },
+        { binding: 32, resource: mediumTextureResource.view },
       ],
     });
   }
@@ -6418,6 +6761,7 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
       emissiveTriangleCount: config.emissiveTriangleCount,
       environmentPortalCount: config.environmentPortalCount,
       environmentPortalMode: config.environmentPortalMode,
+      mediumCount: config.mediumCount,
       environmentMap: createEnvironmentMapSnapshot(config.environmentMap),
       deferredPathResolve: config.deferredPathResolve,
       bvhNodeCount: config.bvhNodeCount,
@@ -7036,6 +7380,7 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
       emissiveTriangleCount: config.emissiveTriangleCount,
       environmentPortalCount: config.environmentPortalCount,
       environmentPortalMode: config.environmentPortalMode,
+      mediumCount: config.mediumCount,
       environmentMap: createEnvironmentMapSnapshot(config.environmentMap),
       deferredPathResolve: config.deferredPathResolve,
       bvhNodeCount: config.bvhNodeCount,
@@ -7070,17 +7415,20 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
     activeDispatchBuffer.destroy?.();
     radianceTexture.destroy?.();
     denoiseScratchTexture.destroy?.();
-        outputTexture.destroy?.();
-        if (environmentMapResource.ownsTexture) {
-          environmentMapResource.texture?.destroy?.();
-        }
-        if (environmentSamplingResource.ownsTexture) {
-          environmentSamplingResource.texture?.destroy?.();
-        }
-        brdfLutResource.texture?.destroy?.();
-        if (baseColorAtlasResource.ownsTexture) {
-          baseColorAtlasResource.texture?.destroy?.();
-        }
+    outputTexture.destroy?.();
+    if (environmentMapResource.ownsTexture) {
+      environmentMapResource.texture?.destroy?.();
+    }
+    if (environmentSamplingResource.ownsTexture) {
+      environmentSamplingResource.texture?.destroy?.();
+    }
+    if (mediumTextureResource.ownsTexture) {
+      mediumTextureResource.texture?.destroy?.();
+    }
+    brdfLutResource.texture?.destroy?.();
+    if (baseColorAtlasResource.ownsTexture) {
+      baseColorAtlasResource.texture?.destroy?.();
+    }
     if (metallicRoughnessAtlasResource.ownsTexture) {
       metallicRoughnessAtlasResource.texture?.destroy?.();
     }

--- a/src/wavefront-compute.js
+++ b/src/wavefront-compute.js
@@ -13,7 +13,8 @@ const DEFAULT_MAX_DEPTH = 6;
 const DEFAULT_TILE_SIZE = 128;
 const DEFAULT_SAMPLES_PER_PIXEL = 1;
 const MAX_SAMPLES_PER_PIXEL = 256;
-const DEFAULT_BRDF_LUT_SIZE = 256;
+const DEFAULT_BRDF_LUT_SIZE = 128;
+const DEFAULT_BRDF_LUT_SAMPLE_COUNT = 256;
 const DEFAULT_MAX_FRAME_PASSES_PER_SUBMISSION = 256;
 const DEFAULT_SCENE_OBJECT_CAPACITY = 128;
 const DEFAULT_ENVIRONMENT_PORTAL_CAPACITY = 32;
@@ -482,9 +483,29 @@ function normalizeWavefrontThickness(input, label) {
   );
 }
 
-function deriveWavefrontMeshMedium(input, fallbackId = 1) {
+function resolveWavefrontMediumId(input, fallbackId = 1) {
+  return (
+    input?.mediumRefId ??
+    input?.mediumId ??
+    input?.material?.mediumId ??
+    input?.materialRefId ??
+    input?.material?.id ??
+    input?.materialId ??
+    input?.id ??
+    fallbackId
+  );
+}
+
+function deriveWavefrontTransportMedium(input, fallbackId = 1) {
+  const resolvedId = resolveWavefrontMediumId(input, fallbackId);
   if (input?.medium) {
-    return normalizeWavefrontMedium(input.medium, fallbackId);
+    return normalizeWavefrontMedium(
+      {
+        ...input.medium,
+        id: input.medium.id ?? input.medium.mediumId ?? resolvedId,
+      },
+      fallbackId
+    );
   }
   const volume = resolveWavefrontVolumeInput(input);
   if (!volume) {
@@ -492,14 +513,7 @@ function deriveWavefrontMeshMedium(input, fallbackId = 1) {
   }
   return normalizeWavefrontMedium(
     {
-      id:
-        input.mediumRefId ??
-        input.mediumId ??
-        input.material?.mediumId ??
-        input.materialRefId ??
-        input.materialId ??
-        input.id ??
-        fallbackId,
+      id: resolvedId,
       phaseModel: volume.phaseModel,
       density: volume.density,
       attenuationColor: volume.attenuationColor,
@@ -640,8 +654,7 @@ export function normalizeWavefrontSceneObject(input = {}, index = 0) {
     input.specularColor ?? input.material?.specularColor,
     [1, 1, 1, 1]
   ).map((value, componentIndex) => (componentIndex < 3 ? clamp(value, 0, 1) : 1));
-  const medium =
-    input.medium ? normalizeWavefrontMedium(input.medium, index + 1) : null;
+  const medium = deriveWavefrontTransportMedium(input, index + 1);
   const resolvedMaterialKind =
     emission[0] > 0 || emission[1] > 0 || emission[2] > 0
       ? MATERIAL_EMISSIVE
@@ -658,7 +671,7 @@ export function normalizeWavefrontSceneObject(input = {}, index = 0) {
     flags: readNonNegativeInteger("flags", input.flags, 0),
     mediumRefId: readNonNegativeInteger(
       "mediumRefId",
-      input.mediumRefId ?? input.medium?.id ?? input.mediumId,
+      input.mediumRefId ?? medium?.id ?? input.medium?.id ?? input.mediumId,
       0
     ),
     medium,
@@ -795,7 +808,7 @@ export function normalizeWavefrontMesh(input = {}, meshIndex = 0) {
     input.specularColor ?? input.material?.specularColor,
     [1, 1, 1, 1]
   ).map((value, componentIndex) => (componentIndex < 3 ? clamp(value, 0, 1) : 1));
-  const medium = deriveWavefrontMeshMedium(input, meshIndex + 1);
+  const medium = deriveWavefrontTransportMedium(input, meshIndex + 1);
   const resolvedMaterialKind =
     emission[0] > 0 || emission[1] > 0 || emission[2] > 0
       ? MATERIAL_EMISSIVE
@@ -2901,7 +2914,10 @@ function integrateBrdfSample(nDotV, roughness, sampleCount) {
   return [scaleTerm / sampleCount, biasTerm / sampleCount];
 }
 
-function createBrdfLutUploadBytes(size = DEFAULT_BRDF_LUT_SIZE, sampleCount = 1024) {
+function createBrdfLutUploadBytes(
+  size = DEFAULT_BRDF_LUT_SIZE,
+  sampleCount = DEFAULT_BRDF_LUT_SAMPLE_COUNT
+) {
   const cacheKey = `${Math.max(1, Math.trunc(size))}:${Math.max(1, Math.trunc(sampleCount))}`;
   const cached = BRDF_LUT_UPLOAD_CACHE.get(cacheKey);
   if (cached) {
@@ -3375,6 +3391,36 @@ function createMediumTextureResource(device, constants, mediums) {
     count: normalized.length,
     width,
   });
+}
+
+function mediumTablesEqual(left, right) {
+  const leftMediums = Array.isArray(left) ? left : [];
+  const rightMediums = Array.isArray(right) ? right : [];
+  if (leftMediums.length !== rightMediums.length) {
+    return false;
+  }
+  for (let index = 0; index < leftMediums.length; index += 1) {
+    const leftMedium = leftMediums[index];
+    const rightMedium = rightMediums[index];
+    if ((leftMedium?.id ?? 0) !== (rightMedium?.id ?? 0)) {
+      return false;
+    }
+    if ((leftMedium?.phaseModel ?? 0) !== (rightMedium?.phaseModel ?? 0)) {
+      return false;
+    }
+    if ((leftMedium?.density ?? 0) !== (rightMedium?.density ?? 0)) {
+      return false;
+    }
+    for (let component = 0; component < 3; component += 1) {
+      if ((leftMedium?.absorption?.[component] ?? 0) !== (rightMedium?.absorption?.[component] ?? 0)) {
+        return false;
+      }
+      if ((leftMedium?.scattering?.[component] ?? 0) !== (rightMedium?.scattering?.[component] ?? 0)) {
+        return false;
+      }
+    }
+  }
+  return true;
 }
 
 function createAtlasTextureResource(device, constants, atlas, label) {
@@ -6281,7 +6327,7 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
     config.environmentMap,
     config.environmentColor
   );
-  const mediumTextureResource = createMediumTextureResource(
+  let mediumTextureResource = createMediumTextureResource(
     device,
     constants,
     config.mediums
@@ -6569,10 +6615,14 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
     });
   }
 
-  const bindGroups = [
-    createTraceBindGroup(activeQueue, nextQueue, "plasius.wavefront.bind.activeNext"),
-    createTraceBindGroup(nextQueue, activeQueue, "plasius.wavefront.bind.nextActive"),
-  ];
+  function createTraceBindGroups() {
+    return [
+      createTraceBindGroup(activeQueue, nextQueue, "plasius.wavefront.bind.activeNext"),
+      createTraceBindGroup(nextQueue, activeQueue, "plasius.wavefront.bind.nextActive"),
+    ];
+  }
+
+  let bindGroups = createTraceBindGroups();
   const bvhBuildBindGroup = device.createBindGroup({
     label: "plasius.wavefront.bind.bvhBuild",
     layout: accelerationBindGroupLayout,
@@ -7351,10 +7401,23 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
     });
   }
 
+  function rebuildMediumResources(nextConfig) {
+    const previousMediumTextureResource = mediumTextureResource;
+    mediumTextureResource = createMediumTextureResource(device, constants, nextConfig.mediums);
+    bindGroups = createTraceBindGroups();
+    if (previousMediumTextureResource?.ownsTexture) {
+      previousMediumTextureResource.texture?.destroy?.();
+    }
+  }
+
   function updateSceneObjects(sceneObjects) {
     const nextPackedScene = packWavefrontSceneObjects(sceneObjects, config.sceneObjectCapacity);
     packedScene = nextPackedScene;
-    config = rebuildLiveConfig();
+    const nextConfig = rebuildLiveConfig();
+    if (!mediumTablesEqual(config.mediums, nextConfig.mediums)) {
+      rebuildMediumResources(nextConfig);
+    }
+    config = nextConfig;
     device.queue.writeBuffer(sceneObjectBuffer, 0, packedScene.buffer);
     return config;
   }

--- a/tests/wavefront-compute.test.js
+++ b/tests/wavefront-compute.test.js
@@ -710,7 +710,10 @@ test("wavefront compute applies environment ambient on terminal surface collisio
   assert.match(source, /let baseline = max\(config\.pathResolveSettings\.y, 0\.0\);/);
   assert.match(source, /let daylightFloor = max\(config\.pathResolveSettings\.y, 0\.0\) \* 0\.08;/);
   assert.match(source, /let hdriFloor = max\(config\.environmentMapSettings\.w, 0\.0\) \* 0\.02;/);
-  assert.match(source, /let response = stabilize_surface_path_response\(ray, hit, surface_path_response\(hit\)\);/);
+  assert.match(
+    source,
+    /let response = stabilize_surface_path_response\(\s+ray,\s+hit,\s+surface_path_response\(hit\) \* segmentTransmittance\s+\);/
+  );
   assert.match(source, /let surfaceColor = max\(hit\.color\.xyz, config\.ambientColor\.xyz\);/);
   assert.match(source, /let sunlitFloor = sunlit_baseline_radiance\(normal\);/);
   assert.match(source, /let glossiness = surface_glossiness\(hit\);/);
@@ -726,7 +729,7 @@ test("wavefront compute applies environment ambient on terminal surface collisio
   assert.match(source, /record_deferred_terminal_source\(ray, terminal_surface_environment_source\(ray, hit\)\);/);
   assert.match(
     source,
-    /let terminalEnvironment = terminal_surface_environment_contribution\(ray, hit\);/
+    /let terminalEnvironment = terminal_surface_environment_contribution\(\s+ray,\s+arrivingThroughput,\s+hit\s+\);/
   );
   assert.match(
     source,
@@ -734,7 +737,7 @@ test("wavefront compute applies environment ambient on terminal surface collisio
   );
   assert.match(
     source,
-    /let overflowEnvironment = terminal_surface_environment_contribution\(ray, hit\);/
+    /let overflowEnvironment = terminal_surface_environment_contribution\(\s+ray,\s+arrivingThroughput,\s+hit\s+\);/
   );
 });
 
@@ -761,13 +764,15 @@ test("wavefront compute estimates direct environment light before random continu
   assert.match(source, /nDotL \* misWeight \/ max\(lightSample\.pdf, 0\.000001\)/);
   assert.match(source, /let transmissionReflectChance = select\(/);
   assert.doesNotMatch(source, /mix\(reflectChance, max\(reflectChance, 1\.0 - transmission\), transmission > 0\.001\)/);
+  assert.match(source, /let segmentTransmittance = medium_transmittance\(ray\.mediumRefId, hit\.distance\);/);
+  assert.match(source, /let arrivingThroughput = ray\.throughput\.xyz \* segmentTransmittance;/);
   assert.match(
     source,
     /let shouldEstimateDirectEnvironment =\s+\(hit\.materialKind == 0u \|\| hit\.materialKind == 1u\) &&\s+hit\.material\.z >= 0\.95 &&\s+ray\.bounce < 2u;/
   );
   assert.match(
     source,
-    /let directEnvironment = surface_direct_environment_contribution\(ray, hit\);/
+    /let directEnvironment = surface_direct_environment_contribution\(\s+RayRecord\(/
   );
   assert.match(
     source,
@@ -775,10 +780,10 @@ test("wavefront compute estimates direct environment light before random continu
   );
   assert.ok(
     source.indexOf("let shouldEstimateDirectEnvironment =") <
-      source.indexOf("let directEnvironment = surface_direct_environment_contribution(ray, hit);")
+      source.indexOf("let directEnvironment = surface_direct_environment_contribution(")
   );
   assert.ok(
-    source.indexOf("let directEnvironment = surface_direct_environment_contribution(ray, hit);") <
+    source.indexOf("let directEnvironment = surface_direct_environment_contribution(") <
       source.indexOf("if (ray.bounce + 1u >= config.maxDepth)")
   );
 });
@@ -815,7 +820,7 @@ test("wavefront compute defers visible colour until terminal path resolve", () =
   assert.equal(config.deferredPathResolve, false);
   assert.match(source, /fn deferred_path_resolve_enabled\(\) -> bool/);
   assert.match(source, /fn clear_deferred_path\(rayId: u32\)/);
-  assert.match(source, /record_deferred_terminal_source\(ray, sourceRadiance\);/);
+  assert.match(source, /record_deferred_terminal_source\(ray, sourceRadiance \* segmentTransmittance\);/);
   assert.match(source, /sourceRadiance = sourceRadiance \* misWeight;/);
   assert.match(source, /fn resolve_deferred_path_radiance\(rayId: u32\) -> vec3<f32>/);
   assert.match(source, /let terminal = pathVertices\[path_vertex_index\(rayId, config\.maxDepth\)\];/);
@@ -829,6 +834,51 @@ test("wavefront compute defers visible colour until terminal path resolve", () =
   assert.match(source, /if \(config\.deferredPathResolve\) \{/);
   assert.match(source, /createGpuSubmissionBatcher\(\{/);
   assert.match(source, /encodeTileOutput\(batch\.reserve\(1\), tile, configOffset, parallelism\);/);
+});
+
+test("wavefront compute exposes medium-table contracts and Beer-Lambert transport hooks", () => {
+  const source = readRendererSource();
+  const types = readRendererTypes();
+  const config = createWavefrontPathTracingComputeConfig({
+    width: 32,
+    height: 32,
+    meshes: [
+      {
+        materialRefId: 3,
+        positions: [-1, 0, 0, 1, 0, 0, 0, 1, 0],
+        indices: [0, 1, 2],
+        materialKind: "transparent",
+        material: {
+          transmission: 1,
+          volume: {
+            thickness: 0.35,
+            attenuationColor: [0.72, 0.84, 0.96, 1],
+            attenuationDistance: 0.4,
+          },
+        },
+      },
+    ],
+  });
+
+  assert.match(types, /export interface WavefrontMediumInput/);
+  assert.match(types, /export interface WavefrontVolumeInput/);
+  assert.match(types, /readonly volume\?: WavefrontVolumeInput \| null;/);
+  assert.match(types, /readonly thickness: number;/);
+  assert.match(types, /readonly mediums\?: readonly WavefrontMediumInput\[\]/);
+  assert.match(types, /readonly mediumCount: number;/);
+  assert.match(source, /const MEDIUM_TABLE_ROWS = 2;/);
+  assert.match(source, /function deriveWavefrontMeshMedium/);
+  assert.match(source, /function createMediumTextureResource/);
+  assert.match(source, /@group\(0\) @binding\(32\) var mediumTableTexture: texture_2d<f32>/);
+  assert.match(source, /fn medium_transmittance\(mediumRefId: u32, distance: f32\) -> vec3<f32>/);
+  assert.match(source, /exp\(-extinction\.x \* distance\)/);
+  assert.match(source, /fn transmitted_medium_ref_id\(ray: RayRecord, hit: HitRecord\) -> u32/);
+  assert.equal(config.mediumCount, 2);
+  assert.deepEqual(config.mediums.map((medium) => medium.id), [0, 3]);
+  assert.equal(config.gpuMeshSource.meshes.records[0].thickness, 0.35);
+  assert.ok(config.mediums[1].absorption[0] > 0);
+  assert.ok(config.mediums[1].absorption[1] > 0);
+  assert.ok(config.mediums[1].absorption[2] > 0);
 });
 
 test("wavefront compute caches the generated BRDF LUT upload", () => {
@@ -1002,6 +1052,30 @@ test("wavefront mesh acceleration preserves triangle vertices and normals", () =
   assert.deepEqual(acceleration.nodes[0].bounds.max, [2, 2, 0]);
 });
 
+test("wavefront mesh normalization derives transport medium from volume inputs", () => {
+  const mesh = normalizeWavefrontMesh({
+    id: 21,
+    positions: [0, 0, 0, 2, 0, 0, 0, 2, 0],
+    indices: [0, 1, 2],
+    materialRefId: 14,
+    material: {
+      transmission: 1,
+      volume: {
+        thickness: 0.18,
+        attenuationColor: [0.7, 0.82, 0.94, 1],
+        attenuationDistance: 0.5,
+      },
+    },
+  });
+
+  assert.equal(mesh.mediumRefId, 14);
+  assert.equal(mesh.thickness, 0.18);
+  assert.equal(mesh.medium?.id, 14);
+  assert.ok((mesh.medium?.absorption[0] ?? 0) > 0);
+  assert.ok((mesh.medium?.absorption[1] ?? 0) > 0);
+  assert.ok((mesh.medium?.absorption[2] ?? 0) > 0);
+});
+
 test("wavefront GPU mesh source packs raw mesh buffers without CPU BVH output", () => {
   const meshes = [
     {
@@ -1051,6 +1125,7 @@ test("wavefront GPU material source packs per-mesh factors and atlases", () => {
       sheen: 0.2,
       clearcoat: 0.6,
       clearcoatRoughness: 0.15,
+      thickness: 0.42,
       material: {
         baseColorTexture: {
           width: 2,
@@ -1089,7 +1164,7 @@ test("wavefront GPU material source packs per-mesh factors and atlases", () => {
   assert.deepEqual(round(floats.slice(4, 8)), [1.5, 1, 0.5, 1]);
   assert.deepEqual(round(floats.slice(8, 12)), [0.35, 0.9, 0.8, 1.45]);
   assert.deepEqual(round(floats.slice(12, 16)), [0.2, 0.2, 0.2, 0.6]);
-  assert.deepEqual(round(floats.slice(16, 20)), [0.15, 1, 0, 0]);
+  assert.deepEqual(round(floats.slice(16, 20)), [0.15, 1, 0, 0.42]);
   assert.deepEqual(round(floats.slice(20, 24)), [1, 1, 1, 1]);
   assert.equal(Number(floats[44].toFixed(2)), 0.75);
   assert.ok(source.baseColorAtlas.width >= 4);
@@ -1387,10 +1462,12 @@ test("wavefront scene objects pack into stable GPU record layout", () => {
       {
         id: 7,
         type: "sphere",
+        mediumRefId: 9,
         center: [1, 2, 3],
         radius: 0.75,
         color: [0.1, 0.2, 0.3, 0.4],
         emission: [5, 4, 3, 1],
+        thickness: 0.28,
       },
     ],
     2
@@ -1405,9 +1482,11 @@ test("wavefront scene objects pack into stable GPU record layout", () => {
   assert.equal(uints[0], wavefrontSceneObjectKinds.sphere);
   assert.equal(uints[1], 7);
   assert.equal(uints[2], wavefrontMaterialKinds.emissive);
-  assert.deepEqual(round(floats.slice(4, 8)), [1, 2, 3, 0]);
-  assert.deepEqual(round(floats.slice(8, 12)), [0.75, 0.75, 0.75, 0]);
-  assert.deepEqual(round(floats.slice(16, 20)), [5, 4, 3, 1]);
+  assert.equal(uints[4], 9);
+  assert.deepEqual(round(floats.slice(8, 12)), [1, 2, 3, 0]);
+  assert.deepEqual(round(floats.slice(12, 16)), [0.75, 0.75, 0.75, 0]);
+  assert.deepEqual(round(floats.slice(20, 24)), [5, 4, 3, 1]);
+  assert.deepEqual(round(floats.slice(32, 36)), [0.08, 1, 0, 0.28]);
 });
 
 test("wavefront scene objects pack opacity in material channel z", () => {
@@ -1424,7 +1503,7 @@ test("wavefront scene objects pack opacity in material channel z", () => {
   ]);
   const floats = new Float32Array(packed.buffer);
 
-  assert.deepEqual(round(floats.slice(20, 24)), [0.91, 0, 0.35, 1.45]);
+  assert.deepEqual(round(floats.slice(24, 28)), [0.91, 0, 0.35, 1.45]);
 });
 
 test("wavefront compute helper reports unavailable WebGPU when navigator.gpu is missing", () => {
@@ -1557,6 +1636,11 @@ serialWebGpuTest("wavefront compute renderer drives GPU-only mesh BVH passes", a
           normals: [0, 0, 1, 0, 0.4, 0.9, 0.4, 0, 0.9],
           materialKind: "emissive",
           emission: [4, 3, 2, 1],
+          medium: {
+            id: 5,
+            attenuationColor: [0.82, 0.88, 0.94, 1],
+            attenuationDistance: 0.6,
+          },
         },
       ],
     });
@@ -1595,6 +1679,7 @@ serialWebGpuTest("wavefront compute renderer drives GPU-only mesh BVH passes", a
     assert.equal(frame.environmentMap.rotationRadians, 0.25);
     assert.equal(frame.environmentMap.ambientStrength, 0.44);
     assert.equal(frame.environmentMap.hasImportanceData, true);
+    assert.equal(frame.mediumCount, 2);
     assert.equal(frame.commandSubmissions, 2);
     assert.equal(frame.gpuParallelism.physicalCoreCount, null);
     assert.equal(frame.gpuParallelism.physicalCoreCountAvailable, false);
@@ -1645,6 +1730,7 @@ serialWebGpuTest("wavefront compute renderer drives GPU-only mesh BVH passes", a
     assert.equal(snapshot.environmentMap.width, 2);
     assert.equal(snapshot.environmentMap.mipLevelCount, 2);
     assert.equal(snapshot.environmentMap.hasImportanceData, true);
+    assert.equal(snapshot.mediumCount, 2);
     assert.equal(snapshot.accelerationBuilt, true);
     assert.equal(snapshot.accelerationBuildCount, 1);
     assert.equal(snapshot.deferredPathResolve, true);
@@ -1670,7 +1756,7 @@ serialWebGpuTest("wavefront compute renderer drives GPU-only mesh BVH passes", a
     assert.ok(device.renderPasses >= 1);
     assert.equal(device.drawCalls.includes(3), true);
     assert.ok(device.queue.submissions.length >= 1);
-    assert.equal(device.queue.textureWrites.length, 9);
+    assert.equal(device.queue.textureWrites.length, 10);
     assert.equal(device.queue.textureWrites[0].size.width, 2);
     assert.equal(device.queue.textureWrites[0].size.height, 1);
     assert.equal(device.queue.textureWrites[0].layout.bytesPerRow, 256);

--- a/tests/wavefront-compute.test.js
+++ b/tests/wavefront-compute.test.js
@@ -420,7 +420,7 @@ test("wavefront compute compatibility exports expose the canonical mesh shader",
   assert.match(shaderSource, /fn write_active_dispatch_args/);
   assert.doesNotMatch(shaderSource, /intersectSphere/);
   assert.match(types, /hitRecordBytes: 256;/);
-  assert.match(types, /sceneObjectRecordBytes: 144;/);
+  assert.match(types, /sceneObjectRecordBytes: 160;/);
   assert.match(types, /meshRangeRecordBytes: 240;/);
   assert.match(types, /triangleRecordBytes: 352;/);
   assert.match(types, /materialRecordBytes: 192;/);
@@ -867,7 +867,7 @@ test("wavefront compute exposes medium-table contracts and Beer-Lambert transpor
   assert.match(types, /readonly mediums\?: readonly WavefrontMediumInput\[\]/);
   assert.match(types, /readonly mediumCount: number;/);
   assert.match(source, /const MEDIUM_TABLE_ROWS = 2;/);
-  assert.match(source, /function deriveWavefrontMeshMedium/);
+  assert.match(source, /function deriveWavefrontTransportMedium/);
   assert.match(source, /function createMediumTextureResource/);
   assert.match(source, /@group\(0\) @binding\(32\) var mediumTableTexture: texture_2d<f32>/);
   assert.match(source, /fn medium_transmittance\(mediumRefId: u32, distance: f32\) -> vec3<f32>/);
@@ -1074,6 +1074,23 @@ test("wavefront mesh normalization derives transport medium from volume inputs",
   assert.ok((mesh.medium?.absorption[0] ?? 0) > 0);
   assert.ok((mesh.medium?.absorption[1] ?? 0) > 0);
   assert.ok((mesh.medium?.absorption[2] ?? 0) > 0);
+});
+
+test("wavefront mesh normalization honors explicit mediumRefId for inline media", () => {
+  const mesh = normalizeWavefrontMesh({
+    id: 22,
+    positions: [0, 0, 0, 2, 0, 0, 0, 2, 0],
+    indices: [0, 1, 2],
+    mediumRefId: 19,
+    medium: {
+      attenuationColor: [0.68, 0.76, 0.9, 1],
+      attenuationDistance: 0.35,
+    },
+  });
+
+  assert.equal(mesh.medium?.id, 19);
+  assert.equal(mesh.mediumRefId, 19);
+  assert.ok((mesh.medium?.absorption[0] ?? 0) > 0);
 });
 
 test("wavefront GPU mesh source packs raw mesh buffers without CPU BVH output", () => {
@@ -1456,6 +1473,42 @@ test("wavefront scene object normalization derives boxes from bounds", () => {
   assert.equal(object.metallic, 0.9);
 });
 
+test("wavefront scene object normalization derives medium ids from inline media", () => {
+  const object = normalizeWavefrontSceneObject({
+    id: 43,
+    type: "sphere",
+    radius: 1,
+    medium: {
+      attenuationColor: [0.72, 0.84, 0.96, 1],
+      attenuationDistance: 0.45,
+    },
+  });
+
+  assert.ok((object.medium?.id ?? 0) > 0);
+  assert.equal(object.mediumRefId, object.medium?.id);
+  assert.ok((object.medium?.absorption[0] ?? 0) > 0);
+});
+
+test("wavefront scene object normalization derives media from volume inputs", () => {
+  const object = normalizeWavefrontSceneObject({
+    id: 44,
+    type: "sphere",
+    radius: 1,
+    material: {
+      transmission: 1,
+      volume: {
+        thickness: 0.2,
+        attenuationColor: [0.7, 0.82, 0.94, 1],
+        attenuationDistance: 0.5,
+      },
+    },
+  });
+
+  assert.equal(object.mediumRefId, 44);
+  assert.equal(object.medium?.id, 44);
+  assert.ok((object.medium?.absorption[0] ?? 0) > 0);
+});
+
 test("wavefront scene objects pack into stable GPU record layout", () => {
   const packed = packWavefrontSceneObjects(
     [
@@ -1775,6 +1828,51 @@ serialWebGpuTest("wavefront compute renderer drives GPU-only mesh BVH passes", a
     assert.equal(canvas.context.configured, null);
     assert.equal(device.buffers.every((buffer) => buffer.destroyed), true);
     assert.equal(device.textures.every((texture) => texture.destroyed), true);
+  });
+});
+
+serialWebGpuTest("wavefront renderer rebuilds medium GPU resources when scene media changes", async () => {
+  await withWebGpuConstants(async () => {
+    const device = new FakeWavefrontDevice();
+    const renderer = await createWavefrontPathTracingComputeRenderer({
+      width: 8,
+      height: 8,
+      canvas: createFakeWavefrontCanvas(),
+      navigator: createFakeWavefrontNavigator(device),
+      sceneObjects: [],
+    });
+
+    const baselineTextureWrites = device.queue.textureWrites.length;
+    const baselineMediumTextures = device.textures.filter(
+      (texture) => texture.descriptor.label === "plasius.wavefront.mediumTable"
+    );
+    const nextConfig = renderer.updateSceneObjects([
+      {
+        id: 91,
+        type: "sphere",
+        radius: 0.75,
+        material: {
+          transmission: 1,
+          volume: {
+            thickness: 0.14,
+            attenuationColor: [0.74, 0.84, 0.96, 1],
+            attenuationDistance: 0.4,
+          },
+        },
+      },
+    ]);
+
+    assert.equal(nextConfig.mediumCount, 2);
+    assert.equal(device.queue.textureWrites.length, baselineTextureWrites + 1);
+    assert.equal(device.queue.textureWrites.at(-1)?.size.height, 2);
+    const updatedMediumTextures = device.textures.filter(
+      (texture) => texture.descriptor.label === "plasius.wavefront.mediumTable"
+    );
+    assert.equal(updatedMediumTextures.length, baselineMediumTextures.length + 1);
+    assert.equal(baselineMediumTextures[0].destroyed, true);
+    assert.equal(updatedMediumTextures.at(-1)?.destroyed, false);
+
+    renderer.destroy();
   });
 });
 


### PR DESCRIPTION
## Summary
- derive wavefront medium-table entries from authored mesh volume inputs
- preserve material shell thickness and scene-object medium references through GPU packing
- document the new volume/medium transport boundary with ADR and design notes

## Validation
- npm run typecheck
- npm run lint
- npm run build
- npm run test:coverage

Closes #47