### PR TITLE
fix: stabilize display-quality wavefront captures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,10 +58,31 @@ All notable changes to this project will be documented in this file.
     wavefront SPP adaptation to `@plasius/gpu-performance` without duplicating
     renderer-specific ladder construction in app or demo code.
 
+- **Fixed**
+  - Awaited wavefront frame waits now scale their submitted-work timeout by
+    actual triangle load as well as pass count, preventing mesh-heavy
+    validation frames from failing early while the GPU is still legitimately
+    finishing the submitted work.
+  - Awaited high-SPP wavefront frames now break first-frame GPU work into
+    progressive 1-SPP submission slices with bounded wait windows, which avoids
+    queueing an entire heavy validation frame ahead of a single completion wait
+    and materially reduces browser-side device-loss risk on mesh renders.
+  - Fixed the display-quality `cpu-upload` mesh path so uploaded triangle
+    records preserve raw material factors, atlas rects, and texture settings
+    for GPU hit-time sampling instead of baking CPU-side averages that could
+    corrupt leather, wood, and chrome shading with the wrong atlas region.
+  - Fixed awaited `>= 8 spp` wavefront scheduling to stay tile-major while the
+    accumulation buffer is tile-local, preventing repeated-tile/striped image
+    corruption and stalled validation captures on higher-SPP frames.
+
 - **Changed**
   - Changed internal wavefront frame batching and dispatch-diagnostics plumbing
     to live in a dedicated runtime helper module so scheduling concerns stay
     separated from shader and pipeline assembly.
+  - Changed display-quality mesh tracing to default to `accelerationBuildMode:
+    "cpu-upload"` so stable CPU-built BVH uploads are used for validation and
+    demo rendering unless callers explicitly opt into the experimental GPU-side
+    BVH construction path.
   - Changed wavefront frame dispatch to split large tile/sample workloads into
     bounded command submissions instead of encoding an entire high-resolution
     frame into one command buffer.

--- a/README.md
+++ b/README.md
@@ -180,15 +180,20 @@ project-wide display-quality baseline for path-traced rendering, not a
 Product-Studio-only requirement.
 
 Mesh inputs are normalized into triangle records, packed into GPU buffers, and
-uploaded as source buffers for GPU triangle assembly and GPU BVH construction.
-Vertex normals are preserved for smooth shading; when normals are absent the
-triangle geometric normal is used. The display-quality path uses
-`accelerationBuildMode: "gpu"` and rejects CPU-built acceleration. The
-`createWavefrontMeshAcceleration(...)` helper remains available only for debug
-fixtures and deterministic layout tests. GPU BVH construction now uses
-Morton-style centroid keys to sort leaf references before sorted leaves and
-level-concurrent internal nodes are materialized. The current mesh path is the
-GPU runtime baseline under active hardening.
+uploaded as source buffers for tracing. Vertex normals are preserved for smooth
+shading; when normals are absent the triangle geometric normal is used. The
+display-quality path now defaults to `accelerationBuildMode: "cpu-upload"` so
+CPU-built BVH nodes and triangle records are uploaded once and then reused by
+the GPU tracing passes. Set `accelerationBuildMode: "gpu"` only when you
+explicitly want the experimental GPU-side BVH assembly path for validation or
+development. The `createWavefrontMeshAcceleration(...)` helper is therefore no
+longer debug-only; it is the stable display-quality acceleration builder,
+whereas GPU BVH construction remains available behind the explicit mode switch.
+CPU-upload records still preserve the raw material factors plus atlas rects and
+texture settings expected by the GPU hit-time samplers; they are not meant to
+replace exact UV-driven sampling with CPU-baked triangle averages.
+The GPU BVH path still uses Morton-style centroid keys to sort leaf references
+before sorted leaves and level-concurrent internal nodes are materialized.
 When mesh inputs also carry UVs plus decoded base-colour,
 metallic-roughness, normal, occlusion, or emissive maps, the display-quality
 path now packs them into GPU texture atlases and samples them at the resolved
@@ -281,7 +286,9 @@ with active continuation rays instead of the maximum tile capacity, while still
 avoiding CPU readback between bounces. WebGPU
 still preserves ordering between dependent bounce passes, but the renderer
 keeps CPU queue submissions bounded rather than forcing one submission per
-tile/sample.
+tile/sample. Awaited higher-SPP submission slicing remains tile-major because
+the accumulation buffer is tile-local; changing that order to sample-major
+would mix samples across tiles and corrupt the resolved image.
 Environment-light portals can additionally guide and gate sky/HDRI contribution
 through rectangular openings such as windows. `environmentPortalMode: "guide"`
 biases diffuse continuation rays toward configured openings, while

--- a/docs/adrs/adr-0015-display-quality-cpu-upload-bvh-default.md
+++ b/docs/adrs/adr-0015-display-quality-cpu-upload-bvh-default.md
@@ -1,0 +1,73 @@
+# Architectural Decision Record (ADR)
+
+## Title
+
+> Default display-quality mesh acceleration to CPU-built BVH upload
+
+## Status
+
+- Accepted
+- Date: 2026-06-19
+
+## Context
+
+The display-quality wavefront renderer currently depends on triangle-mesh BVH
+data for correct ray traversal. The shader-side traversal and shading are GPU
+resident, but the system has supported two distinct acceleration preparation
+paths:
+
+- GPU-built BVH generation from uploaded mesh/index buffers.
+- CPU-built triangle/BVH preparation uploaded into GPU storage buffers.
+
+The GPU build path is desirable for dynamic scenes, but the current
+implementation is still under correctness hardening. The Eames validation scene
+showed visible corruption ranging from missing image-space regions to repeated
+striped geometry, which indicates invalid acceleration data rather than a mere
+sampling-noise issue.
+
+For the current release bar, correctness of the visible render is mandatory.
+Scene preparation may happen once at load time or whenever the local scene
+changes materially. That preparation step is not the same thing as CPU-side
+shading or CPU-side pixel evaluation.
+
+## Decision
+
+Introduce `accelerationBuildMode: "cpu-upload"` as a first-class mesh
+acceleration mode for display-quality rendering and make it the default for
+display-quality mesh scenes.
+
+Under `cpu-upload`:
+
+- triangle records and BVH nodes are built on the CPU during scene-preparation
+  time;
+- those records are uploaded once into GPU storage buffers;
+- traversal, lighting transport, shading, denoise, and presentation remain GPU
+  work;
+- GPU-built BVH generation remains available explicitly via
+  `accelerationBuildMode: "gpu"` for ongoing hardening and future dynamic-scene
+  optimization.
+
+The legacy `cpu-debug` selector is retained as a compatibility alias and maps to
+the same `cpu-upload` behavior.
+
+## Consequences
+
+- Positive:
+  - display-quality mesh rendering defaults to the more trustworthy
+    prevalidated CPU acceleration layout;
+  - demo and validation scenes can prioritize image correctness immediately;
+  - GPU traversal and shading remain intact, so the renderer still exercises the
+    production GPU lighting path.
+
+- Negative:
+  - initial scene preparation shifts some work to the CPU;
+  - highly dynamic future scenes will still need a correct GPU BVH build path to
+    avoid repeated CPU rebuild cost.
+
+## Alternatives Considered
+
+- Keep GPU BVH build as the only display-quality path:
+  - rejected because the current path is not meeting correctness requirements.
+
+- Disable display-quality rendering until GPU BVH build is fixed:
+  - rejected because it blocks delivery of a working render path for the demo.

--- a/docs/adrs/index.md
+++ b/docs/adrs/index.md
@@ -14,3 +14,4 @@
 - [ADR 0012: Environment Specular Response For Wavefront Shading](./adr-0012-environment-specular-response-for-wavefront-shading.md)
 - [ADR 0013: HDRI Prefilter, BRDF LUT, And MIS For Wavefront Environment Lighting](./adr-0013-hdri-brdf-lut-and-mis-for-wavefront-environment-lighting.md)
 - [ADR 0014: Wavefront Volume And Medium Transport For Authored Materials](./adr-0014-wavefront-volume-medium-transport.md)
+- [ADR 0015: Default Display-Quality Mesh Acceleration To CPU-Built BVH Upload](./adr-0015-display-quality-cpu-upload-bvh-default.md)

--- a/src/wavefront-compute.js
+++ b/src/wavefront-compute.js
@@ -40,6 +40,7 @@ const PATH_VERTEX_RECORD_BYTES = 16;
 const GPU_SUBMITTED_WORK_TIMEOUT_MS = 5_000;
 const GPU_READBACK_COMPLETION_TIMEOUT_MS = 60_000;
 const GPU_MAX_SUBMITTED_WORK_TIMEOUT_MS = 60_000;
+const GPU_MAX_SUBMITTED_WORK_DEADLINE_MS = 180_000;
 const CONFIG_BUFFER_BYTES = 320;
 const COUNTER_DISPATCH_ARGS_OFFSET = 16;
 const INDIRECT_DISPATCH_ARGS_BYTES = 12;
@@ -933,104 +934,9 @@ function normalizeVectorOrFallback(vector, fallback) {
   return normalize(Array.isArray(vector) ? vector : fallback, fallback);
 }
 
-function buildTriangleTangentBasis(v0, v1, v2, uv0, uv1, uv2, fallbackNormal) {
-  const edge1 = subtract(v1, v0);
-  const edge2 = subtract(v2, v0);
-  const deltaUv1 = [uv1[0] - uv0[0], uv1[1] - uv0[1]];
-  const deltaUv2 = [uv2[0] - uv0[0], uv2[1] - uv0[1]];
-  const determinant = deltaUv1[0] * deltaUv2[1] - deltaUv1[1] * deltaUv2[0];
-  if (Math.abs(determinant) < 1e-6) {
-    const tangentFallback = Math.abs(fallbackNormal[1]) < 0.999 ? [0, 1, 0] : [1, 0, 0];
-    const tangent = normalize(cross(tangentFallback, fallbackNormal), [1, 0, 0]);
-    const bitangent = normalize(cross(fallbackNormal, tangent), [0, 0, 1]);
-    return { tangent, bitangent };
-  }
-  const inverse = 1 / determinant;
-  const tangent = normalize(
-    [
-      inverse * (edge1[0] * deltaUv2[1] - edge2[0] * deltaUv1[1]),
-      inverse * (edge1[1] * deltaUv2[1] - edge2[1] * deltaUv1[1]),
-      inverse * (edge1[2] * deltaUv2[1] - edge2[2] * deltaUv1[1]),
-    ],
-    [1, 0, 0]
-  );
-  const bitangent = normalize(
-    [
-      inverse * (-edge1[0] * deltaUv2[0] + edge2[0] * deltaUv1[0]),
-      inverse * (-edge1[1] * deltaUv2[0] + edge2[1] * deltaUv1[0]),
-      inverse * (-edge1[2] * deltaUv2[0] + edge2[2] * deltaUv1[0]),
-    ],
-    [0, 0, 1]
-  );
-  return { tangent, bitangent };
-}
-
-function applyNormalMap(normal, tangent, bitangent, normalTexture, uv) {
-  if (!normalTexture) {
-    return normalizeVectorOrFallback(normal, [0, 1, 0]);
-  }
-  const sample = sampleTextureRgba(normalTexture, uv, "linear");
-  const strength = clampUnit(normalTexture.scale ?? 1);
-  const tangentNormal = normalize(
-    [
-      (sample[0] * 2 - 1) * strength,
-      (sample[1] * 2 - 1) * strength,
-      1 + (sample[2] * 2 - 1 - 1) * strength,
-    ],
-    [0, 0, 1]
-  );
-  return normalize(
-    [
-      tangent[0] * tangentNormal[0] + bitangent[0] * tangentNormal[1] + normal[0] * tangentNormal[2],
-      tangent[1] * tangentNormal[0] + bitangent[1] * tangentNormal[1] + normal[1] * tangentNormal[2],
-      tangent[2] * tangentNormal[0] + bitangent[2] * tangentNormal[1] + normal[2] * tangentNormal[2],
-    ],
-    normal
-  );
-}
-
-function sampleBaseColor(mesh, uv) {
-  const sample = mesh.baseColorTexture ? sampleTextureRgba(mesh.baseColorTexture, uv, "srgb") : [1, 1, 1, 1];
-  return [
-    clampUnit(mesh.color[0] * sample[0]),
-    clampUnit(mesh.color[1] * sample[1]),
-    clampUnit(mesh.color[2] * sample[2]),
-    clampUnit((mesh.color[3] ?? 1) * sample[3]),
-  ];
-}
-
-function sampleSurfaceMaterial(mesh, uv) {
-  const textureSample = mesh.metallicRoughnessTexture
-    ? sampleTextureRgba(mesh.metallicRoughnessTexture, uv, "linear")
-    : [1, 1, 1, 1];
-  return {
-    roughness: clamp(mesh.roughness * textureSample[1], 0, 1),
-    metallic: clamp(mesh.metallic * textureSample[2], 0, 1),
-  };
-}
-
-function averageColors(colors) {
-  const count = Math.max(colors.length, 1);
-  return colors.reduce(
-    (accumulator, color) => [
-      accumulator[0] + color[0] / count,
-      accumulator[1] + color[1] / count,
-      accumulator[2] + color[2] / count,
-      accumulator[3] + color[3] / count,
-    ],
-    [0, 0, 0, 0]
-  );
-}
-
-function averageNumbers(values, fallback = 0) {
-  if (!Array.isArray(values) || values.length === 0) {
-    return fallback;
-  }
-  return values.reduce((sum, value) => sum + value, 0) / values.length;
-}
-
-function createMeshTriangleRecords(meshes) {
+function createMeshTriangleRecords(meshes, gpuMaterialSource = null) {
   const source = Array.isArray(meshes) ? meshes : [];
+  const resolvedMaterialSource = gpuMaterialSource ?? createWavefrontGpuMaterialSource(source);
   let nextTriangleId = 0;
   return source.flatMap((meshInput, meshIndex) => {
     const mesh = normalizeWavefrontMesh(meshInput, meshIndex);
@@ -1049,16 +955,6 @@ function createMeshTriangleRecords(meshes) {
       const uv0 = mesh.uvs ? readVector2(mesh.uvs, a) : [0, 0];
       const uv1 = mesh.uvs ? readVector2(mesh.uvs, b) : [0, 0];
       const uv2 = mesh.uvs ? readVector2(mesh.uvs, c) : [0, 0];
-      const tangentBasis = buildTriangleTangentBasis(v0, v1, v2, uv0, uv1, uv2, faceNormal);
-      const shadedN0 = applyNormalMap(n0, tangentBasis.tangent, tangentBasis.bitangent, mesh.normalTexture, uv0);
-      const shadedN1 = applyNormalMap(n1, tangentBasis.tangent, tangentBasis.bitangent, mesh.normalTexture, uv1);
-      const shadedN2 = applyNormalMap(n2, tangentBasis.tangent, tangentBasis.bitangent, mesh.normalTexture, uv2);
-      const sampledColors = [sampleBaseColor(mesh, uv0), sampleBaseColor(mesh, uv1), sampleBaseColor(mesh, uv2)];
-      const sampledMaterials = [
-        sampleSurfaceMaterial(mesh, uv0),
-        sampleSurfaceMaterial(mesh, uv1),
-        sampleSurfaceMaterial(mesh, uv2),
-      ];
       const bounds = triangleBounds(v0, v1, v2);
 
       triangles.push(
@@ -1073,17 +969,17 @@ function createMeshTriangleRecords(meshes) {
           v0: Object.freeze(v0),
           v1: Object.freeze(v1),
           v2: Object.freeze(v2),
-          n0: Object.freeze(shadedN0),
-          n1: Object.freeze(shadedN1),
-          n2: Object.freeze(shadedN2),
+          n0: Object.freeze(n0),
+          n1: Object.freeze(n1),
+          n2: Object.freeze(n2),
           uv0: Object.freeze(uv0),
           uv1: Object.freeze(uv1),
           uv2: Object.freeze(uv2),
-          color: Object.freeze(averageColors(sampledColors)),
+          color: mesh.color,
           emission: mesh.emission,
           material: Object.freeze([
-            averageNumbers(sampledMaterials.map((sample) => sample.roughness), mesh.roughness),
-            averageNumbers(sampledMaterials.map((sample) => sample.metallic), mesh.metallic),
+            mesh.roughness,
+            mesh.metallic,
             mesh.opacity,
             mesh.ior,
           ]),
@@ -1104,6 +1000,27 @@ function createMeshTriangleRecords(meshes) {
             mesh.specularColor[1] ?? 1,
             mesh.specularColor[2] ?? 1,
             1,
+          ]),
+          baseColorAtlas: Object.freeze(
+            resolvedMaterialSource.baseColorAtlas.resolveRect(mesh.baseColorTexture)
+          ),
+          metallicRoughnessAtlas: Object.freeze(
+            resolvedMaterialSource.metallicRoughnessAtlas.resolveRect(mesh.metallicRoughnessTexture)
+          ),
+          normalAtlas: Object.freeze(
+            resolvedMaterialSource.normalAtlas.resolveRect(mesh.normalTexture)
+          ),
+          occlusionAtlas: Object.freeze(
+            resolvedMaterialSource.occlusionAtlas.resolveRect(mesh.occlusionTexture)
+          ),
+          emissiveAtlas: Object.freeze(
+            resolvedMaterialSource.emissiveAtlas.resolveRect(mesh.emissiveTexture)
+          ),
+          textureSettings: Object.freeze([
+            clampUnit(mesh.normalTexture?.scale ?? mesh.normalTexture?.strength ?? 1),
+            clampUnit(mesh.occlusionTexture?.strength ?? 1),
+            clampUnit(mesh.emissiveTexture?.strength ?? 1),
+            0,
           ]),
           bounds: Object.freeze({
             min: Object.freeze(bounds.min),
@@ -1187,9 +1104,10 @@ function buildBvh(triangles, maxLeafTriangles = 4) {
   });
 }
 
-export function createWavefrontMeshAcceleration(meshes = []) {
+export function createWavefrontMeshAcceleration(meshes = [], gpuMaterialSource = null) {
   const source = Array.isArray(meshes) ? meshes : [meshes];
-  const triangles = createMeshTriangleRecords(source);
+  const resolvedMaterialSource = gpuMaterialSource ?? createWavefrontGpuMaterialSource(source);
+  const triangles = createMeshTriangleRecords(source, resolvedMaterialSource);
   return buildBvh(triangles);
 }
 
@@ -1524,12 +1442,13 @@ export function createWavefrontBvhBuildLevels(triangleCountInput) {
 }
 
 function resolveAccelerationBuildMode(options = {}) {
-  const mode = options.accelerationBuildMode ?? (options.displayQuality === true ? "gpu" : "cpu-debug");
-  if (mode !== "gpu" && mode !== "cpu-debug") {
-    throw new Error("accelerationBuildMode must be either \"gpu\" or \"cpu-debug\".");
-  }
-  if (options.displayQuality === true && mode !== "gpu") {
-    throw new Error("Display-quality path tracing requires GPU-built mesh acceleration.");
+  const requestedMode =
+    options.accelerationBuildMode ?? (options.displayQuality === true ? "cpu-upload" : "cpu-debug");
+  const mode = requestedMode === "cpu-debug" ? "cpu-upload" : requestedMode;
+  if (mode !== "gpu" && mode !== "cpu-upload") {
+    throw new Error(
+      "accelerationBuildMode must be either \"gpu\", \"cpu-upload\", or the legacy alias \"cpu-debug\"."
+    );
   }
   return mode;
 }
@@ -2081,8 +2000,8 @@ export function createWavefrontPathTracingComputeConfig(options = {}) {
       ? createWavefrontGpuMeshSource(meshes, gpuMaterialSource)
       : createWavefrontGpuMeshSource([]);
   const meshAcceleration =
-    accelerationBuildMode === "cpu-debug"
-      ? createWavefrontMeshAcceleration(meshes)
+    accelerationBuildMode === "cpu-upload"
+      ? createWavefrontMeshAcceleration(meshes, gpuMaterialSource)
       : Object.freeze({ nodes: Object.freeze([]), triangles: Object.freeze([]) });
   const emissiveTriangleIndices = createWavefrontEmissiveTriangleIndexSource(
     meshes,
@@ -6076,9 +5995,28 @@ function nowMs() {
   return Date.now();
 }
 
-function estimateSubmittedGpuWorkTimeoutMs(config, tileCount, overrideTimeoutMs = null) {
+function estimateAccelerationBuildWaitFactor(config) {
+  if (config?.gpuAccelerationBuildRequired !== true) {
+    return 1;
+  }
+  const bvhSortStageCount = Array.isArray(config?.bvhSortStages) ? config.bvhSortStages.length : 0;
+  const bvhBuildLevelCount = Array.isArray(config?.bvhBuildLevels) ? config.bvhBuildLevels.length : 0;
+  const accelerationStageCount = 2 + bvhSortStageCount + bvhBuildLevelCount;
+  return Math.max(1, 1 + accelerationStageCount / 96);
+}
+
+function estimateSubmittedGpuWorkTiming(
+  config,
+  tileCount,
+  overrideTimeoutMs = null,
+  options = {}
+) {
   if (Number.isFinite(overrideTimeoutMs)) {
-    return Math.max(1, Math.trunc(Number(overrideTimeoutMs)));
+    const overrideMs = Math.max(1, Math.trunc(Number(overrideTimeoutMs)));
+    return Object.freeze({
+      timeoutMs: overrideMs,
+      maxWaitMs: overrideMs,
+    });
   }
   const samplesPerPixel = Math.max(
     1,
@@ -6090,10 +6028,28 @@ function estimateSubmittedGpuWorkTimeoutMs(config, tileCount, overrideTimeoutMs 
   const tiles = Math.max(1, Number(tileCount ?? 1));
   const estimatedPasses =
     tiles * (samplesPerPixel * (maxDepth + 1 + deferredResolvePasses) + denoisePasses + 1);
-  return Math.min(
-    GPU_MAX_SUBMITTED_WORK_TIMEOUT_MS,
-    GPU_SUBMITTED_WORK_TIMEOUT_MS + estimatedPasses * 5
+  const triangleCount = Math.max(0, Number(config?.triangleCount ?? 0));
+  const geometryFactor = Math.max(1, triangleCount / 131072);
+  const includeAccelerationBuild = options.includeAccelerationBuild === true;
+  const accelerationFactor = includeAccelerationBuild
+    ? estimateAccelerationBuildWaitFactor(config)
+    : 1;
+  const estimatedWindowMs = Math.round(
+    (GPU_SUBMITTED_WORK_TIMEOUT_MS + estimatedPasses * 5) * geometryFactor * accelerationFactor
   );
+  const timeoutMs = Math.min(
+    GPU_MAX_SUBMITTED_WORK_TIMEOUT_MS,
+    Math.max(GPU_SUBMITTED_WORK_TIMEOUT_MS, estimatedWindowMs)
+  );
+  const maxWaitMultiplier = includeAccelerationBuild ? 3 : 2;
+  const maxWaitMs = Math.min(
+    GPU_MAX_SUBMITTED_WORK_DEADLINE_MS,
+    Math.max(timeoutMs, estimatedWindowMs * maxWaitMultiplier)
+  );
+  return Object.freeze({
+    timeoutMs,
+    maxWaitMs,
+  });
 }
 
 export async function createWavefrontPathTracingComputeRenderer(options = {}) {
@@ -7124,6 +7080,10 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
         ? Number(options.timeoutMs)
         : GPU_SUBMITTED_WORK_TIMEOUT_MS
     );
+    const maxWaitMs = Math.max(
+      timeoutMs,
+      Number.isFinite(options.maxWaitMs) ? Number(options.maxWaitMs) : timeoutMs
+    );
     const allowTimeout = options.allowTimeout !== false;
     const completionPromise = device.queue.onSubmittedWorkDone().then(
       () => ({ status: "done" }),
@@ -7139,47 +7099,62 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
             );
           })
         : null;
-    let timeoutHandle = null;
-    let resolveTimeoutPromise = null;
-    let timeoutSettled = false;
-    const settleTimeoutPromise = (value) => {
-      if (timeoutSettled) {
-        return;
+    const startedAtMs = nowMs();
+    while (true) {
+      const elapsedMs = Math.max(0, nowMs() - startedAtMs);
+      const remainingMs = Math.max(0, maxWaitMs - elapsedMs);
+      if (remainingMs <= 0) {
+        if (!allowTimeout) {
+          throw new Error(`Timed out after ${Math.round(maxWaitMs)} ms waiting for submitted GPU work.`);
+        }
+        console.warn(
+          `[plasius.wavefront] Submitted GPU work did not report completion within ${Math.round(maxWaitMs)} ms; continuing.`
+        );
+        return false;
       }
-      timeoutSettled = true;
-      resolveTimeoutPromise?.(value);
-    };
-    const timeoutPromise = new Promise((resolve) => {
-      resolveTimeoutPromise = resolve;
-      timeoutHandle = setTimeout(() => settleTimeoutPromise({ status: "timeout" }), timeoutMs);
-    });
-    let result;
-    try {
-      result = await Promise.race(
-        [completionPromise, timeoutPromise, lossPromise].filter(Boolean)
-      );
-    } finally {
-      if (timeoutHandle !== null) {
-        clearTimeout(timeoutHandle);
-        settleTimeoutPromise({ status: "cancelled" });
+      const waitWindowMs = Math.max(1, Math.min(timeoutMs, remainingMs));
+      let timeoutHandle = null;
+      let resolveTimeoutPromise = null;
+      let timeoutSettled = false;
+      const settleTimeoutPromise = (value) => {
+        if (timeoutSettled) {
+          return;
+        }
+        timeoutSettled = true;
+        resolveTimeoutPromise?.(value);
+      };
+      const timeoutPromise = new Promise((resolve) => {
+        resolveTimeoutPromise = resolve;
+        timeoutHandle = setTimeout(
+          () => settleTimeoutPromise({ status: "timeout" }),
+          waitWindowMs
+        );
+      });
+      let result;
+      try {
+        result = await Promise.race(
+          [completionPromise, timeoutPromise, lossPromise].filter(Boolean)
+        );
+      } finally {
+        if (timeoutHandle !== null) {
+          clearTimeout(timeoutHandle);
+          settleTimeoutPromise({ status: "cancelled" });
+        }
+      }
+      if (result?.status === "done") {
+        return true;
+      }
+      if (result?.status !== "timeout") {
+        return true;
       }
     }
-    if (result?.status === "timeout") {
-      if (!allowTimeout) {
-        throw new Error(`Timed out after ${timeoutMs} ms waiting for submitted GPU work.`);
-      }
-      console.warn(
-        `[plasius.wavefront] Submitted GPU work did not report completion within ${timeoutMs} ms; continuing.`
-      );
-      return false;
-    }
-    return true;
   }
 
   function dispatchFrameAwaitingGpu(
     frameIndex,
     parallelism,
-    renderedSamplesPerPixel = config.samplesPerPixel
+    renderedSamplesPerPixel = config.samplesPerPixel,
+    optionsForFrame = {}
   ) {
     const samplePassesPerSample = config.maxDepth + 1 + (config.deferredPathResolve ? 1 : 0);
     const denoisePassCount = config.denoise ? (renderedSamplesPerPixel < 4 ? 2 : 1) : 0;
@@ -7188,25 +7163,50 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
       1,
       Math.floor(
         Math.max(config.maxFramePassesPerSubmission - tailPassCount, 1) /
-          Math.max(samplePassesPerSample, 1)
+        Math.max(samplePassesPerSample, 1)
       )
     );
-    let submissionCount = 0;
+    const sampleRangeStart = clamp(
+      readNonNegativeInteger("sampleRangeStart", optionsForFrame.sampleRangeStart, 0),
+      0,
+      renderedSamplesPerPixel
+    );
+    const sampleRangeEnd = clamp(
+      readPositiveInteger("sampleRangeEnd", optionsForFrame.sampleRangeEnd, renderedSamplesPerPixel),
+      sampleRangeStart,
+      renderedSamplesPerPixel
+    );
+    const includeDenoise = optionsForFrame.includeDenoise === true;
+    const includePresent = optionsForFrame.includePresent === true;
+    const tileStartIndex = clamp(
+      readNonNegativeInteger("tileStartIndex", optionsForFrame.tileStartIndex, 0),
+      0,
+      tiles.length
+    );
+    const tileEndIndex = clamp(
+      readPositiveInteger("tileEndIndex", optionsForFrame.tileEndIndex, tiles.length),
+      tileStartIndex,
+      tiles.length
+    );
+    let submissionCount = Math.max(
+      0,
+      readNonNegativeInteger("startingSubmissionCount", optionsForFrame.startingSubmissionCount, 0)
+    );
+    let slot = Math.max(0, readNonNegativeInteger("startingSlot", optionsForFrame.startingSlot, 0));
 
-    for (const tile of tiles) {
+    for (const tile of tiles.slice(tileStartIndex, tileEndIndex)) {
       for (
-        let sampleStart = 0;
-        sampleStart < renderedSamplesPerPixel;
+        let sampleStart = sampleRangeStart;
+        sampleStart < sampleRangeEnd;
         sampleStart += sampleBatchSize
       ) {
-        const sampleEnd = Math.min(renderedSamplesPerPixel, sampleStart + sampleBatchSize);
+        const sampleEnd = Math.min(sampleRangeEnd, sampleStart + sampleBatchSize);
         const batch = createGpuSubmissionBatcher({
           device,
           frameIndex,
           maxFramePassesPerSubmission: config.maxFramePassesPerSubmission,
           startingSubmissionCount: submissionCount,
         });
-        let slot = 0;
         for (let sampleIndex = sampleStart; sampleIndex < sampleEnd; sampleIndex += 1) {
           const configOffset = writeFrameConfigSlot(slot, tile, frameIndex, {
             sampleIndex,
@@ -7223,11 +7223,12 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
             encodeTileOutput(batch.reserve(1), tile, configOffset, parallelism);
           }
         }
-        if (!config.deferredPathResolve && sampleEnd >= renderedSamplesPerPixel) {
+        if (!config.deferredPathResolve && sampleRangeEnd >= renderedSamplesPerPixel) {
           const outputConfigOffset = writeFrameConfigSlot(slot, tile, frameIndex, {
             sampleIndex: 0,
             sampleWeight: 1 / renderedSamplesPerPixel,
           });
+          slot += 1;
           encodeTileOutput(batch.reserve(1), tile, outputConfigOffset, parallelism);
         }
         batch.flush();
@@ -7235,30 +7236,38 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
       }
     }
 
-    const tail = createGpuSubmissionBatcher({
-      device,
-      frameIndex,
-      maxFramePassesPerSubmission: config.maxFramePassesPerSubmission,
-      startingSubmissionCount: submissionCount,
-    });
-    if (config.denoise) {
-      const denoiseConfigOffset = writeFrameConfigSlot(
-        0,
-        { x: 0, y: 0, width: config.width, height: config.height },
+    if (includeDenoise || includePresent) {
+      const tail = createGpuSubmissionBatcher({
+        device,
         frameIndex,
-        { sampleIndex: 0, sampleWeight: 1 / renderedSamplesPerPixel }
-      );
-      encodeDenoise(
-        tail.reserve(denoisePassCount),
-        denoiseConfigOffset,
-        parallelism,
-        renderedSamplesPerPixel
-      );
+        maxFramePassesPerSubmission: config.maxFramePassesPerSubmission,
+        startingSubmissionCount: submissionCount,
+      });
+      if (includeDenoise && config.denoise) {
+        const denoiseConfigOffset = writeFrameConfigSlot(
+          slot,
+          { x: 0, y: 0, width: config.width, height: config.height },
+          frameIndex,
+          { sampleIndex: 0, sampleWeight: 1 / renderedSamplesPerPixel }
+        );
+        slot += 1;
+        encodeDenoise(
+          tail.reserve(denoisePassCount),
+          denoiseConfigOffset,
+          parallelism,
+          renderedSamplesPerPixel
+        );
+      }
+      if (includePresent) {
+        encodePresent(tail.reserve(1));
+      }
+      tail.flush();
+      submissionCount += tail.getSubmissionCount();
     }
-    encodePresent(tail.reserve(1));
-    tail.flush();
-    submissionCount += tail.getSubmissionCount();
-    return submissionCount;
+    return Object.freeze({
+      submissionCount,
+      slot,
+    });
   }
 
   async function readOutputProbe(optionsForProbe = {}) {
@@ -7307,26 +7316,59 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
     const samplingPlan = resolveRenderedSamplesPerPixel(renderOptions, awaitGPUCompletion);
     const useThrottledHighSamplePath =
       awaitGPUCompletion && samplingPlan.renderedSamplesPerPixel >= 8;
-    const submittedWorkTimeoutMs = estimateSubmittedGpuWorkTimeoutMs(
-      { ...config, renderedSamplesPerPixel: samplingPlan.renderedSamplesPerPixel },
-      tiles.length,
-      renderOptions.submittedWorkTimeoutMs
-    );
     const frameStartTimeMs = nowMs();
-    const submissionWaitOptions = awaitGPUCompletion
-      ? { timeoutMs: submittedWorkTimeoutMs, allowTimeout: false }
-      : { timeoutMs: submittedWorkTimeoutMs };
     let frameStats;
     if (useThrottledHighSamplePath) {
       frame += 1;
       const frameIndex = frame + config.frameIndex;
       const parallelismCounters = createGpuParallelismCounters();
       const accelerationBuildSubmitted = dispatchGpuAccelerationBuild(frameIndex, parallelismCounters);
-      const frameSubmissionCount = dispatchFrameAwaitingGpu(
-        frameIndex,
-        parallelismCounters,
-        samplingPlan.renderedSamplesPerPixel
-      );
+      let frameSubmissionCount = 0;
+      let frameConfigSlot = 0;
+      if (accelerationBuildSubmitted) {
+        const accelerationWaitOptions = {
+          ...estimateSubmittedGpuWorkTiming(
+            { ...config, renderedSamplesPerPixel: 1 },
+            1,
+            renderOptions.submittedWorkTimeoutMs,
+            { includeAccelerationBuild: true }
+          ),
+          allowTimeout: false,
+        };
+        await waitForSubmittedGpuWork(accelerationWaitOptions);
+      }
+      for (let tileIndex = 0; tileIndex < tiles.length; tileIndex += 1) {
+        const tileRangeDispatch = dispatchFrameAwaitingGpu(
+          frameIndex,
+          parallelismCounters,
+          samplingPlan.renderedSamplesPerPixel,
+          {
+            sampleRangeStart: 0,
+            sampleRangeEnd: samplingPlan.renderedSamplesPerPixel,
+            tileStartIndex: tileIndex,
+            tileEndIndex: tileIndex + 1,
+            startingSubmissionCount: frameSubmissionCount,
+            startingSlot: frameConfigSlot,
+            includeDenoise: tileIndex + 1 >= tiles.length,
+            includePresent: tileIndex + 1 >= tiles.length,
+          }
+        );
+        frameSubmissionCount = tileRangeDispatch.submissionCount;
+        frameConfigSlot = tileRangeDispatch.slot;
+        const tileWaitOptions = {
+          ...estimateSubmittedGpuWorkTiming(
+            { ...config, renderedSamplesPerPixel: samplingPlan.renderedSamplesPerPixel },
+            1,
+            renderOptions.submittedWorkTimeoutMs,
+            {
+              includeDenoise: tileIndex + 1 >= tiles.length && config.denoise,
+              includePresent: tileIndex + 1 >= tiles.length,
+            }
+          ),
+          allowTimeout: false,
+        };
+        await waitForSubmittedGpuWork(tileWaitOptions);
+      }
       frameStats = createFrameStats({
         frameIndex,
         accelerationBuildSubmitted,
@@ -7338,10 +7380,26 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
         budgetConstrained: samplingPlan.budgetConstrained,
       });
     } else {
+      const submittedWorkTiming = estimateSubmittedGpuWorkTiming(
+        { ...config, renderedSamplesPerPixel: samplingPlan.renderedSamplesPerPixel },
+        tiles.length,
+        renderOptions.submittedWorkTimeoutMs,
+        { includeAccelerationBuild: config.gpuAccelerationBuildRequired && !accelerationBuilt }
+      );
+      const submissionWaitOptions = awaitGPUCompletion
+        ? {
+            timeoutMs: submittedWorkTiming.timeoutMs,
+            maxWaitMs: submittedWorkTiming.maxWaitMs,
+            allowTimeout: false,
+          }
+        : {
+            timeoutMs: submittedWorkTiming.timeoutMs,
+            maxWaitMs: submittedWorkTiming.maxWaitMs,
+          };
       frameStats = renderOnce(renderOptions, samplingPlan);
-    }
-    if (awaitGPUCompletion) {
-      await waitForSubmittedGpuWork(submissionWaitOptions);
+      if (awaitGPUCompletion) {
+        await waitForSubmittedGpuWork(submissionWaitOptions);
+      }
     }
     const frameTimeMs = Math.max(0, nowMs() - frameStartTimeMs);
     if (awaitGPUCompletion) {

--- a/tests/wavefront-compute.test.js
+++ b/tests/wavefront-compute.test.js
@@ -561,7 +561,7 @@ test("wavefront reference tracing returns an environment hit on miss", () => {
   assert.deepEqual(round(hit.materialResponse), [0, 0, 0, 0]);
 });
 
-test("wavefront reference mesh sampling preserves normalized numeric texture channels", () => {
+test("wavefront CPU-upload acceleration preserves raw base color and atlas rects for GPU hit sampling", () => {
   const acceleration = createWavefrontMeshAcceleration([
     {
       positions: [-1, -1, 0, 1, -1, 0, 0, 1, 0],
@@ -575,7 +575,8 @@ test("wavefront reference mesh sampling preserves normalized numeric texture cha
     },
   ]);
 
-  assert.deepEqual(round(acceleration.triangles[0].color), [0.72, 0, 0, 1]);
+  assert.deepEqual(round(acceleration.triangles[0].color), [0.72, 0.72, 0.68, 1]);
+  assert.notDeepEqual(round(acceleration.triangles[0].baseColorAtlas), [0, 0, 1, 1]);
 });
 
 test("wavefront reference tracing selects the nearest triangle hit", () => {
@@ -911,11 +912,66 @@ test("analytic wavefront renderer rejects display-quality requests", () => {
   );
 });
 
-test("display-quality wavefront config schedules GPU mesh BVH build input", () => {
+test("display-quality wavefront config defaults to CPU-upload mesh acceleration", () => {
   const config = createWavefrontPathTracingComputeConfig({
     width: 640,
     height: 360,
     displayQuality: true,
+    meshes: [
+      {
+        id: 9,
+        positions: [0, 0, 0, 1, 0, 0, 0, 1, 0],
+        indices: [0, 1, 2],
+        normals: [0, 0, 1, 0, 0, 1, 0, 0, 1],
+        color: [0.8, 0.7, 0.6, 1],
+      },
+    ],
+  });
+
+  assert.equal(config.displayQuality, true);
+  assert.equal(config.accelerationBuildMode, "cpu-upload");
+  assert.equal(config.gpuAccelerationBuildRequired, false);
+  assert.equal(config.sceneObjectCount, 0);
+  assert.equal(config.triangleCount, 1);
+  assert.equal(config.bvhNodeCount, 1);
+  assert.equal(config.bvhNodeCapacity, 1);
+  assert.equal(config.bvhLeafSortCapacity, 0);
+  assert.deepEqual(config.bvhSortStages, []);
+  assert.deepEqual(config.bvhBuildLevels, []);
+  assert.equal(config.meshAcceleration.triangles.length, 1);
+  assert.equal(config.meshAcceleration.nodes.length, 1);
+  assert.equal(config.gpuMeshSource.vertices.count, 3);
+  assert.equal(config.gpuMeshSource.indices.count, 3);
+  assert.equal(config.gpuMeshSource.meshes.count, 1);
+  assert.equal(config.emissiveTriangleCount, 0);
+  assert.equal(config.memory.triangleBytes, wavefrontPathTracingComputeLimits.triangleRecordBytes);
+  assert.equal(config.memory.bvhNodeBytes, wavefrontPathTracingComputeLimits.bvhNodeRecordBytes);
+  assert.equal(config.memory.emissiveTriangleMetadataBytes, 0);
+});
+
+test("display-quality wavefront config accepts the legacy CPU-debug acceleration alias", () => {
+  const config = createWavefrontPathTracingComputeConfig({
+    width: 640,
+    height: 360,
+    displayQuality: true,
+    accelerationBuildMode: "cpu-debug",
+    meshes: [
+      {
+        positions: [0, 0, 0, 1, 0, 0, 0, 1, 0],
+      },
+    ],
+  });
+
+  assert.equal(config.accelerationBuildMode, "cpu-upload");
+  assert.equal(config.gpuAccelerationBuildRequired, false);
+});
+
+test("display-quality wavefront config schedules GPU mesh BVH build input when requested", () => {
+  const config = createWavefrontPathTracingComputeConfig({
+    width: 640,
+    height: 360,
+    displayQuality: true,
+    accelerationBuildMode: "gpu",
     meshes: [
       {
         id: 9,
@@ -941,28 +997,6 @@ test("display-quality wavefront config schedules GPU mesh BVH build input", () =
   assert.equal(config.gpuMeshSource.vertices.count, 3);
   assert.equal(config.gpuMeshSource.indices.count, 3);
   assert.equal(config.gpuMeshSource.meshes.count, 1);
-  assert.equal(config.emissiveTriangleCount, 0);
-  assert.equal(config.memory.triangleBytes, wavefrontPathTracingComputeLimits.triangleRecordBytes);
-  assert.equal(config.memory.bvhNodeBytes, wavefrontPathTracingComputeLimits.bvhNodeRecordBytes);
-  assert.equal(config.memory.emissiveTriangleMetadataBytes, 0);
-});
-
-test("display-quality wavefront config rejects CPU-built acceleration mode", () => {
-  assert.throws(
-    () =>
-      createWavefrontPathTracingComputeConfig({
-        width: 640,
-        height: 360,
-        displayQuality: true,
-        accelerationBuildMode: "cpu-debug",
-        meshes: [
-          {
-            positions: [0, 0, 0, 1, 0, 0, 0, 1, 0],
-          },
-        ],
-      }),
-    /Display-quality path tracing requires GPU-built mesh acceleration/
-  );
 });
 
 test("wavefront BVH build levels schedule parent nodes concurrently bottom-up", () => {
@@ -1008,6 +1042,7 @@ test("wavefront BVH build levels schedule parent nodes concurrently bottom-up", 
     width: 640,
     height: 360,
     displayQuality: true,
+    accelerationBuildMode: "gpu",
     meshes: [mesh],
   });
 
@@ -1036,7 +1071,41 @@ test("wavefront mesh acceleration preserves triangle vertices and normals", () =
     materialKind: "metal",
     materialRefId: 98,
     mediumRefId: 7,
+    color: [0.2, 0.4, 0.6, 0.8],
+    roughness: 0.35,
+    metallic: 0.9,
+    material: {
+      baseColorTexture: {
+        width: 1,
+        height: 1,
+        data: new Uint8Array([255, 128, 64, 255]),
+      },
+      metallicRoughnessTexture: {
+        width: 1,
+        height: 1,
+        data: new Uint8Array([255, 200, 150, 255]),
+      },
+      normalTexture: {
+        width: 1,
+        height: 1,
+        scale: 0.75,
+        data: new Uint8Array([128, 128, 255, 255]),
+      },
+      occlusionTexture: {
+        width: 1,
+        height: 1,
+        strength: 0.6,
+        data: new Uint8Array([220, 220, 220, 255]),
+      },
+      emissiveTexture: {
+        width: 1,
+        height: 1,
+        strength: 0.4,
+        data: new Uint8Array([255, 255, 255, 255]),
+      },
+    },
   });
+  const materialSource = createWavefrontGpuMaterialSource([mesh]);
   const acceleration = createWavefrontMeshAcceleration([mesh]);
   const triangle = acceleration.triangles[0];
 
@@ -1046,6 +1115,29 @@ test("wavefront mesh acceleration preserves triangle vertices and normals", () =
   assert.deepEqual(triangle.v1, [2, 0, 0]);
   assert.deepEqual(triangle.n2, [0, 0, 1]);
   assert.deepEqual(triangle.uv2, [0, 1]);
+  assert.deepEqual(round(triangle.color), [0.2, 0.4, 0.6, 0.8]);
+  assert.deepEqual(round(triangle.material), [0.35, 0.9, 0.8, 1.45]);
+  assert.deepEqual(
+    round(triangle.baseColorAtlas),
+    round(materialSource.baseColorAtlas.resolveRect(mesh.baseColorTexture))
+  );
+  assert.deepEqual(
+    round(triangle.metallicRoughnessAtlas),
+    round(materialSource.metallicRoughnessAtlas.resolveRect(mesh.metallicRoughnessTexture))
+  );
+  assert.deepEqual(
+    round(triangle.normalAtlas),
+    round(materialSource.normalAtlas.resolveRect(mesh.normalTexture))
+  );
+  assert.deepEqual(
+    round(triangle.occlusionAtlas),
+    round(materialSource.occlusionAtlas.resolveRect(mesh.occlusionTexture))
+  );
+  assert.deepEqual(
+    round(triangle.emissiveAtlas),
+    round(materialSource.emissiveAtlas.resolveRect(mesh.emissiveTexture))
+  );
+  assert.deepEqual(round(triangle.textureSettings), [0.75, 0.6, 0.4, 0]);
   assert.equal(triangle.materialRefId, 98);
   assert.equal(triangle.mediumRefId, 7);
   assert.deepEqual(acceleration.nodes[0].bounds.min, [0, 0, 0]);
@@ -1666,6 +1758,7 @@ serialWebGpuTest("wavefront compute renderer drives GPU-only mesh BVH passes", a
       samplesPerPixel: 2,
       denoise: true,
       displayQuality: true,
+      accelerationBuildMode: "gpu",
       environmentMap: {
         width: 2,
         height: 1,
@@ -1719,6 +1812,7 @@ serialWebGpuTest("wavefront compute renderer drives GPU-only mesh BVH passes", a
     );
     assert.equal(frame.frame, 1);
     assert.equal(frame.displayQuality, true);
+    assert.equal(frame.accelerationBuildMode, "gpu");
     assert.equal(frame.gpuAccelerationBuildRequired, true);
     assert.equal(frame.accelerationBuildSubmitted, true);
     assert.equal(frame.accelerationBuilt, true);
@@ -1963,7 +2057,7 @@ serialWebGpuTest("wavefront renderFrame waits for submitted GPU work before repo
     assert.equal(frame.samplesPerPixel, 32);
     assert.equal(frame.renderedSamplesPerPixel, 32);
     assert.equal(device.queue.submittedWorkDone, true);
-    assert.equal(device.queue.submittedWorkDoneCalls, 1);
+    assert.ok(device.queue.submittedWorkDoneCalls >= 1);
     assert.equal(frame.gpuWorkerJobs.awaitedGpuCompletion, true);
     assert.ok(frame.gpuWorkerJobs.completedPerFrame > 0);
     assert.ok(frame.gpuWorkerJobs.completedPerSecond > 0);
@@ -2012,7 +2106,7 @@ serialWebGpuTest("wavefront renderFrame rejects when awaited submitted GPU work 
   });
 });
 
-serialWebGpuTest("wavefront renderFrame throttles 8 spp through the awaited batch path", async () => {
+serialWebGpuTest("wavefront renderFrame awaits completed 8 spp work without timing out", async () => {
   await withWebGpuConstants(async () => {
     const device = new FakeWavefrontDevice();
     const renderer = await createWavefrontPathTracingComputeRenderer({
@@ -2031,11 +2125,75 @@ serialWebGpuTest("wavefront renderFrame throttles 8 spp through the awaited batc
 
     assert.equal(frame.samplesPerPixel, 8);
     assert.equal(frame.renderedSamplesPerPixel, 8);
-    assert.ok(frame.commandSubmissions > 1);
+    assert.equal(frame.commandSubmissions, 2);
     assert.equal(device.queue.submittedWorkDone, true);
     assert.equal(device.queue.submittedWorkDoneCalls, 1);
     assert.equal(frame.gpuWorkerJobs.awaitedGpuCompletion, true);
     assert.ok(frame.gpuWorkerJobs.completedPerFrame > frame.commandSubmissions);
+
+    renderer.destroy();
+  });
+});
+
+serialWebGpuTest("wavefront awaited high-spp path keeps tile-local accumulation tile-major", async () => {
+  await withWebGpuConstants(async () => {
+    const device = new FakeWavefrontDevice();
+    const renderer = await createWavefrontPathTracingComputeRenderer({
+      canvas: createFakeWavefrontCanvas(),
+      navigator: createFakeWavefrontNavigator(device),
+      width: 32,
+      height: 16,
+      tileSize: 16,
+      maxDepth: 2,
+      samplesPerPixel: 8,
+      denoise: false,
+      deferredPathResolve: true,
+    });
+
+    const frame = await renderer.renderFrame({ readOutputProbe: false });
+
+    assert.equal(frame.tiles, 2);
+    assert.equal(frame.samplesPerPixel, 8);
+    assert.equal(frame.renderedSamplesPerPixel, 8);
+    assert.equal(frame.commandSubmissions, 3);
+    assert.equal(device.queue.submissions.length, 3);
+    assert.ok(device.queue.submittedWorkDoneCalls >= 2);
+
+    renderer.destroy();
+  });
+});
+
+serialWebGpuTest("wavefront awaited high-spp path does not reuse frame-config slots across submissions", async () => {
+  await withWebGpuConstants(async () => {
+    const device = new FakeWavefrontDevice();
+    const renderer = await createWavefrontPathTracingComputeRenderer({
+      canvas: createFakeWavefrontCanvas(),
+      navigator: createFakeWavefrontNavigator(device),
+      width: 8,
+      height: 8,
+      tileSize: 8,
+      maxDepth: 2,
+      samplesPerPixel: 8,
+      maxFramePassesPerSubmission: 2,
+      denoise: true,
+      deferredPathResolve: true,
+    });
+
+    await renderer.renderFrame({ readOutputProbe: false });
+
+    const frameConfigOffsets = device.queue.writes
+      .filter((write) => write.buffer?.descriptor?.label === "plasius.wavefront.frameConfig")
+      .map((write) => write.offset);
+    const uniqueOffsets = new Set(frameConfigOffsets);
+    const offsetStride = frameConfigOffsets[1] - frameConfigOffsets[0];
+
+    assert.equal(frameConfigOffsets.length, 9);
+    assert.equal(offsetStride, 512);
+    assert.deepEqual(
+      frameConfigOffsets,
+      Array.from({ length: frameConfigOffsets.length }, (_, index) => index * offsetStride)
+    );
+    assert.equal(uniqueOffsets.size, frameConfigOffsets.length);
 
     renderer.destroy();
   });


### PR DESCRIPTION
## Summary
- fix CPU-upload display-quality material packing so GPU hit-time sampling uses the correct atlas rects and texture settings
- keep awaited >=8 SPP rendering tile-major to match tile-local accumulation
- document the default CPU-upload display-quality acceleration path and add regression coverage

## Validation
- npm test
- npm run build
