### PR TITLE
fix: broaden wavefront direct-light MIS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ All notable changes to this project will be documented in this file.
   - Added `createWavefrontAdaptiveSamplingLevels(...)` so consumers can hand
     wavefront SPP adaptation to `@plasius/gpu-performance` without duplicating
     renderer-specific ladder construction in app or demo code.
+  - Added ADR 0016 for the mixed environment/emissive direct-light MIS
+    contract used by the wavefront display-quality renderer.
 
 - **Fixed**
   - Awaited wavefront frame waits now scale their submitted-work timeout by
@@ -118,6 +120,10 @@ All notable changes to this project will be documented in this file.
     conductor, clearcoat, and transmission paths so environment misses and
     explicit HDRI samples can use MIS instead of the older light-guidance
     heuristics.
+  - Changed wavefront explicit direct lighting to use a one-sample
+    environment/emissive mixture with solid-angle-normalized area-light PDFs
+    and BSDF-semantic eligibility instead of the older material-kind/bounce
+    gate.
 
 - **Fixed**
   - Fixed low-sample wavefront renders so non-emissive surface hits receive a

--- a/docs/adrs/adr-0016-mixed-direct-light-mis-for-wavefront-materials.md
+++ b/docs/adrs/adr-0016-mixed-direct-light-mis-for-wavefront-materials.md
@@ -1,0 +1,72 @@
+# ADR 0016: Mixed Direct-Light MIS For Wavefront Materials
+
+## Status
+
+Accepted
+
+## Context
+
+The display-quality wavefront renderer already supports HDRI importance
+sampling, BSDF PDFs, emissive-triangle guidance metadata, and deferred terminal
+path resolve. It still had two transport gaps:
+
+- explicit direct lighting only ran for a narrow diffuse/metal subset on the
+  first two bounces; and
+- emissive-triangle direct lighting did not publish a solid-angle PDF contract
+  that could be compared safely against BSDF PDFs in MIS.
+
+That left chrome, clearcoat, textured, and later-bounce glossy surfaces outside
+the explicit direct-light path, while emissive-area lights still relied mostly
+on heuristic continuation guidance rather than a measure-consistent estimator.
+
+## Decision
+
+`@plasius/gpu-renderer` will use a single direct-light sample contract for
+non-delta wavefront surface hits:
+
+- choose one explicit light sample per eligible hit from a bounded mixture of
+  environment lighting and emissive-triangle area lighting;
+- keep the environment path in solid-angle measure via the existing HDRI PDF
+  tables;
+- convert emissive-triangle area PDFs into solid-angle PDFs at the shading
+  point before comparing them against BSDF PDFs in MIS; and
+- gate explicit direct lighting from BSDF semantics, excluding delta-only
+  reflection and refraction paths instead of using material-kind-plus-bounce
+  special cases.
+
+## Alternatives Considered
+
+- Keep the old first-two-bounce diffuse/metal gate.
+  This was rejected because it preserved known bias and left multiple supported
+  material classes outside the direct-light estimator.
+- Add both an environment sample and an emissive sample on every hit.
+  This was rejected because the current performance guardrail allows only one
+  default NEE sample per hit without a separate performance decision.
+- Continue relying on emissive guidance without a direct-light PDF contract.
+  This was rejected because it cannot provide measure-consistent MIS against
+  BSDF PDFs.
+
+## Consequences
+
+- Direct lighting now reaches all non-delta supported material classes without
+  hard-coded bounce limits.
+- Emissive-area light MIS becomes comparable with the existing HDRI path.
+- The renderer keeps its one-sample direct-light budget while broadening
+  estimator coverage.
+- Perfect mirror and refraction paths remain continuation-only until the
+  renderer grows non-delta transmissive/direct-light handling.
+
+## Test Implications
+
+- Unit coverage must assert the presence of the mixed direct-light sample
+  contract, the emissive area-to-solid-angle PDF conversion, and the removal of
+  the old material-kind/bounce gate.
+- Existing renderer test, lint, build, coverage, and package validation gates
+  remain required.
+
+## Release Implications
+
+- Rollback remains the parent feature flag
+  `renderer.transport.physicalEstimator`.
+- No package-public API shape changes are required for this step; release risk
+  is renderer-behavioral rather than contract-breaking.

--- a/docs/adrs/index.md
+++ b/docs/adrs/index.md
@@ -15,3 +15,4 @@
 - [ADR 0013: HDRI Prefilter, BRDF LUT, And MIS For Wavefront Environment Lighting](./adr-0013-hdri-brdf-lut-and-mis-for-wavefront-environment-lighting.md)
 - [ADR 0014: Wavefront Volume And Medium Transport For Authored Materials](./adr-0014-wavefront-volume-medium-transport.md)
 - [ADR 0015: Default Display-Quality Mesh Acceleration To CPU-Built BVH Upload](./adr-0015-display-quality-cpu-upload-bvh-default.md)
+- [ADR 0016: Mixed Direct-Light MIS For Wavefront Materials](./adr-0016-mixed-direct-light-mis-for-wavefront-materials.md)

--- a/src/wavefront-compute.js
+++ b/src/wavefront-compute.js
@@ -4214,6 +4214,15 @@ struct EnvironmentSample {
   pdf: f32,
 };
 
+struct DirectLightSample {
+  direction: vec4<f32>,
+  radiance: vec4<f32>,
+  pdf: f32,
+  maxDistance: f32,
+  flags: u32,
+  valid: u32,
+};
+
 fn sample_environment_importance(sample: vec2<f32>) -> EnvironmentSample {
   if (!environment_importance_sampling_enabled()) {
     let direction = sample_uniform_sphere_direction(sample);
@@ -4232,6 +4241,34 @@ fn sample_environment_importance(sample: vec2<f32>) -> EnvironmentSample {
   let direction = vec3<f32>(cos(phi) * sinTheta, cos(theta), sin(phi) * sinTheta);
   let pdf = environment_direction_pdf(direction);
   return EnvironmentSample(direction, base_environment_radiance(direction), pdf);
+}
+
+fn triangle_surface_normal(triangle: TriangleRecord) -> vec3<f32> {
+  let edge1 = triangle.v1.xyz - triangle.v0.xyz;
+  let edge2 = triangle.v2.xyz - triangle.v0.xyz;
+  return safe_normalize(cross(edge1, edge2), vec3<f32>(0.0, 1.0, 0.0));
+}
+
+fn triangle_surface_area(triangle: TriangleRecord) -> f32 {
+  let edge1 = triangle.v1.xyz - triangle.v0.xyz;
+  let edge2 = triangle.v2.xyz - triangle.v0.xyz;
+  return max(length(cross(edge1, edge2)) * 0.5, 0.000001);
+}
+
+fn solid_angle_pdf_from_area_pdf(
+  areaPdf: f32,
+  shadingPoint: vec3<f32>,
+  lightPoint: vec3<f32>,
+  lightNormal: vec3<f32>
+) -> f32 {
+  let offset = lightPoint - shadingPoint;
+  let distanceSquared = max(dot(offset, offset), 0.000001);
+  let lightDirection = safe_normalize(offset, lightNormal);
+  let geometry = max(dot(lightNormal, -lightDirection), 0.0);
+  if (geometry <= 0.000001) {
+    return 0.0;
+  }
+  return areaPdf * distanceSquared / max(geometry, 0.000001);
 }
 
 fn power_heuristic(pdfA: f32, pdfB: f32) -> f32 {
@@ -4615,26 +4652,106 @@ fn scene_visibility_blocked(origin: vec3<f32>, direction: vec3<f32>, maxDistance
   return meshCandidate.hit == 1u && meshCandidate.distance < nearest;
 }
 
-fn surface_direct_environment_contribution(ray: RayRecord, hit: HitRecord) -> vec3<f32> {
+fn sample_emissive_triangle_light(hit: HitRecord, seed: u32) -> DirectLightSample {
+  if (config.emissiveTriangleCount == 0u) {
+    return DirectLightSample(vec4<f32>(0.0), vec4<f32>(0.0), 0.0, 0.0, 0u, 0u);
+  }
+  let lightSlot = min(
+    u32(random01(seed + 71u) * f32(config.emissiveTriangleCount)),
+    config.emissiveTriangleCount - 1u
+  );
+  let lightMetadata = bvhNodes[config.bvhNodeCapacity + lightSlot];
+  let triangleIndex = lightMetadata.childOrFirst;
+  if (triangleIndex >= config.triangleCount) {
+    return DirectLightSample(vec4<f32>(0.0), vec4<f32>(0.0), 0.0, 0.0, 0u, 0u);
+  }
+
+  let lightTriangle = triangles[triangleIndex];
+  let triangleArea = triangle_surface_area(lightTriangle);
+  let lightNormal = triangle_surface_normal(lightTriangle);
+  let r1 = random01(seed + 101u);
+  let r2 = random01(seed + 193u);
+  let root = sqrt(r1);
+  let b0 = 1.0 - root;
+  let b1 = root * (1.0 - r2);
+  let b2 = root * r2;
+  let lightPoint =
+    lightTriangle.v0.xyz * b0 +
+    lightTriangle.v1.xyz * b1 +
+    lightTriangle.v2.xyz * b2;
+  let lightDirection = safe_normalize(lightPoint - hit.position.xyz, lightNormal);
+  let traceDistance = max(distance(lightPoint, hit.position.xyz) - 0.01, 0.01);
+  let areaPdf = 1.0 / max(triangleArea * f32(config.emissiveTriangleCount), 0.000001);
+  let lightPdf = solid_angle_pdf_from_area_pdf(areaPdf, hit.position.xyz, lightPoint, lightNormal);
+  if (lightPdf <= 0.000001) {
+    return DirectLightSample(vec4<f32>(0.0), vec4<f32>(0.0), 0.0, 0.0, 0u, 0u);
+  }
+  let radiance = max(lightTriangle.emission.xyz, lightTriangle.color.xyz);
+  if (max_component(radiance) <= 0.000001) {
+    return DirectLightSample(vec4<f32>(0.0), vec4<f32>(0.0), 0.0, 0.0, 0u, 0u);
+  }
+  return DirectLightSample(vec4<f32>(lightDirection, 0.0), vec4<f32>(radiance, 0.0), lightPdf, traceDistance, 0u, 1u);
+}
+
+fn sample_direct_light(hit: HitRecord, ray: RayRecord, normal: vec3<f32>) -> DirectLightSample {
+  let environmentSelectionProbability = select(1.0, 0.5, config.emissiveTriangleCount > 0u);
+  let selector = random01(mix_seed(ray.sourcePixelId, ray.sampleId, ray.bounce, config.frameIndex, 41u));
+  if (selector < environmentSelectionProbability) {
+    let environmentSample = sample_environment_importance(vec2<f32>(
+      selector / max(environmentSelectionProbability, 0.000001),
+      random01(mix_seed(ray.sourcePixelId, ray.sampleId, ray.bounce, config.frameIndex, 43u))
+    ));
+    let lightDirection = safe_normalize(environmentSample.direction, normal);
+    let radiance = direct_environment_radiance(hit.position.xyz + normal * 0.003, lightDirection);
+    return DirectLightSample(
+      vec4<f32>(lightDirection, 0.0),
+      vec4<f32>(radiance, 0.0),
+      environmentSample.pdf * environmentSelectionProbability,
+      1000000.0,
+      0u,
+      1u
+    );
+  }
+  let emissiveSample = sample_emissive_triangle_light(hit, mix_seed(
+    ray.sourcePixelId,
+    ray.sampleId,
+    ray.bounce,
+    config.frameIndex,
+    47u
+  ));
+  if (emissiveSample.valid == 0u) {
+    return emissiveSample;
+  }
+  return DirectLightSample(
+    emissiveSample.direction,
+    emissiveSample.radiance,
+    emissiveSample.pdf * (1.0 - environmentSelectionProbability),
+    emissiveSample.maxDistance,
+    emissiveSample.flags,
+    emissiveSample.valid
+  );
+}
+
+fn surface_direct_light_contribution(ray: RayRecord, hit: HitRecord) -> vec3<f32> {
   let normal = safe_normalize(hit.shadingNormal.xyz, vec3<f32>(0.0, 1.0, 0.0));
   let origin = hit.position.xyz + normal * 0.003;
   let viewDirection = safe_normalize(-ray.direction.xyz, normal);
-  let lightSample = sample_environment_importance(vec2<f32>(
-    random01(mix_seed(ray.sourcePixelId, ray.sampleId, ray.bounce, config.frameIndex, 41u)),
-    random01(mix_seed(ray.sourcePixelId, ray.sampleId, ray.bounce, config.frameIndex, 43u))
-  ));
+  let lightSample = sample_direct_light(hit, ray, normal);
+  if (lightSample.valid == 0u) {
+    return vec3<f32>(0.0);
+  }
   if (lightSample.pdf <= 0.000001) {
     return vec3<f32>(0.0);
   }
-  let lightDirection = safe_normalize(lightSample.direction, normal);
+  let lightDirection = safe_normalize(lightSample.direction.xyz, normal);
   let nDotL = saturate(dot(normal, lightDirection));
   if (nDotL <= 0.000001) {
     return vec3<f32>(0.0);
   }
-  if (scene_visibility_blocked(origin, lightDirection, 1000000.0)) {
+  if (scene_visibility_blocked(origin, lightDirection, lightSample.maxDistance)) {
     return vec3<f32>(0.0);
   }
-  let incidentRadiance = direct_environment_radiance(origin, lightDirection);
+  let incidentRadiance = lightSample.radiance.xyz;
   if (max_component(incidentRadiance) <= 0.000001) {
     return vec3<f32>(0.0);
   }
@@ -5461,29 +5578,20 @@ fn refract_direction(unitDirection: vec3<f32>, normal: vec3<f32>, etaRatio: f32)
   return safe_normalize(rOutPerp + rOutParallel, reflect(unitDirection, normal));
 }
 
-fn sample_emissive_triangle_direction(hit: HitRecord, seed: u32, fallback: vec3<f32>) -> vec3<f32> {
-  if (config.emissiveTriangleCount == 0u) {
-    return fallback;
-  }
-  let lightSlot = min(u32(random01(seed + 71u) * f32(config.emissiveTriangleCount)), config.emissiveTriangleCount - 1u);
-  let lightMetadata = bvhNodes[config.bvhNodeCapacity + lightSlot];
-  let triangleIndex = lightMetadata.childOrFirst;
-  if (triangleIndex >= config.triangleCount) {
-    return fallback;
-  }
+fn surface_supports_direct_lighting(hit: HitRecord) -> bool {
+  let roughness = clamp(hit.material.x, 0.0, 1.0);
+  let transmission = clamp(hit.materialExtension.z, 0.0, 1.0);
+  let deltaMetal = hit.materialKind == 1u && roughness <= 0.02;
+  let refractive = hit.materialKind == 2u || hit.materialKind == 3u || transmission > 0.001;
+  return !(deltaMetal || refractive);
+}
 
-  let lightTriangle = triangles[triangleIndex];
-  let r1 = random01(seed + 101u);
-  let r2 = random01(seed + 193u);
-  let root = sqrt(r1);
-  let b0 = 1.0 - root;
-  let b1 = root * (1.0 - r2);
-  let b2 = root * r2;
-  let lightPoint =
-    lightTriangle.v0.xyz * b0 +
-    lightTriangle.v1.xyz * b1 +
-    lightTriangle.v2.xyz * b2;
-  return safe_normalize(lightPoint - hit.position.xyz, fallback);
+fn sample_emissive_triangle_direction(hit: HitRecord, seed: u32, fallback: vec3<f32>) -> vec3<f32> {
+  let lightSample = sample_emissive_triangle_light(hit, seed);
+  if (lightSample.valid == 0u) {
+    return fallback;
+  }
+  return safe_normalize(lightSample.direction.xyz, fallback);
 }
 
 fn sample_environment_portal_direction(hit: HitRecord, seed: u32, fallback: vec3<f32>) -> vec3<f32> {
@@ -5658,12 +5766,9 @@ fn resolveSurfaceRecords(@builtin(global_invocation_id) globalId: vec3<u32>) {
   );
   record_deferred_path_response(ray, response);
 
-  let shouldEstimateDirectEnvironment =
-    (hit.materialKind == 0u || hit.materialKind == 1u) &&
-    hit.material.z >= 0.95 &&
-    ray.bounce < 2u;
-  if (shouldEstimateDirectEnvironment) {
-    let directEnvironment = surface_direct_environment_contribution(
+  let shouldEstimateDirectLight = surface_supports_direct_lighting(hit);
+  if (shouldEstimateDirectLight) {
+    let directLight = surface_direct_light_contribution(
       RayRecord(
         ray.rayId,
         ray.parentRayId,
@@ -5680,7 +5785,7 @@ fn resolveSurfaceRecords(@builtin(global_invocation_id) globalId: vec3<u32>) {
       hit
     );
     accumulation[ray.rayId] =
-      accumulation[ray.rayId] + vec4<f32>(directEnvironment * sample_weight(), 0.0);
+      accumulation[ray.rayId] + vec4<f32>(directLight * sample_weight(), 0.0);
   }
 
   if (ray.bounce + 1u >= config.maxDepth) {

--- a/tests/wavefront-compute.test.js
+++ b/tests/wavefront-compute.test.js
@@ -742,11 +742,15 @@ test("wavefront compute applies environment ambient on terminal surface collisio
   );
 });
 
-test("wavefront compute estimates direct environment light before random continuation", () => {
+test("wavefront compute samples all-material direct light with MIS before random continuation", () => {
   const source = readRendererSource();
 
   assert.match(source, /fn direct_environment_radiance/);
   assert.match(source, /fn sample_environment_importance/);
+  assert.match(source, /struct DirectLightSample/);
+  assert.match(source, /fn sample_emissive_triangle_light/);
+  assert.match(source, /fn sample_direct_light/);
+  assert.match(source, /fn surface_supports_direct_lighting/);
   assert.match(source, /u32\(config\.environmentMapMeta\.x\)/);
   assert.match(source, /u32\(config\.environmentMapMeta\.y\)/);
   assert.match(source, /if \(count == 0u\) \{\s+return 0u;\s+\}/);
@@ -755,10 +759,10 @@ test("wavefront compute estimates direct environment light before random continu
   assert.match(source, /fn evaluate_surface_bsdf_pdf/);
   assert.match(source, /fn visibility_test_ray/);
   assert.match(source, /fn scene_visibility_blocked/);
-  assert.match(source, /fn surface_direct_environment_contribution/);
-  assert.match(source, /let lightSample = sample_environment_importance\(vec2<f32>\(/);
-  assert.match(source, /if \(scene_visibility_blocked\(origin, lightDirection, 1000000\.0\)\) \{/);
-  assert.match(source, /let incidentRadiance = direct_environment_radiance\(origin, lightDirection\);/);
+  assert.match(source, /fn surface_direct_light_contribution/);
+  assert.match(source, /let lightSample = sample_direct_light\(hit, ray, normal\);/);
+  assert.match(source, /if \(scene_visibility_blocked\(origin, lightDirection, lightSample\.maxDistance\)\) \{/);
+  assert.match(source, /let incidentRadiance = lightSample\.radiance\.xyz;/);
   assert.match(source, /let bsdf = evaluate_surface_bsdf\(hit, viewDirection, lightDirection\);/);
   assert.match(source, /let bsdfPdf = evaluate_surface_bsdf_pdf\(hit, viewDirection, lightDirection\);/);
   assert.match(source, /let misWeight = power_heuristic\(lightSample\.pdf, bsdfPdf\);/);
@@ -767,26 +771,43 @@ test("wavefront compute estimates direct environment light before random continu
   assert.doesNotMatch(source, /mix\(reflectChance, max\(reflectChance, 1\.0 - transmission\), transmission > 0\.001\)/);
   assert.match(source, /let segmentTransmittance = medium_transmittance\(ray\.mediumRefId, hit\.distance\);/);
   assert.match(source, /let arrivingThroughput = ray\.throughput\.xyz \* segmentTransmittance;/);
-  assert.match(
+  assert.match(source, /let shouldEstimateDirectLight = surface_supports_direct_lighting\(hit\);/);
+  assert.doesNotMatch(
     source,
-    /let shouldEstimateDirectEnvironment =\s+\(hit\.materialKind == 0u \|\| hit\.materialKind == 1u\) &&\s+hit\.material\.z >= 0\.95 &&\s+ray\.bounce < 2u;/
+    /\(hit\.materialKind == 0u \|\| hit\.materialKind == 1u\) &&\s+hit\.material\.z >= 0\.95 &&\s+ray\.bounce < 2u/
   );
   assert.match(
     source,
-    /let directEnvironment = surface_direct_environment_contribution\(\s+RayRecord\(/
+    /let directLight = surface_direct_light_contribution\(\s+RayRecord\(/
   );
   assert.match(
     source,
-    /accumulation\[ray\.rayId\] =\s+accumulation\[ray\.rayId\] \+\s+vec4<f32>\(directEnvironment \* sample_weight\(\), 0\.0\);/
+    /accumulation\[ray\.rayId\] =\s+accumulation\[ray\.rayId\] \+\s+vec4<f32>\(directLight \* sample_weight\(\), 0\.0\);/
   );
   assert.ok(
-    source.indexOf("let shouldEstimateDirectEnvironment =") <
-      source.indexOf("let directEnvironment = surface_direct_environment_contribution(")
+    source.indexOf("let shouldEstimateDirectLight =") <
+      source.indexOf("let directLight = surface_direct_light_contribution(")
   );
   assert.ok(
-    source.indexOf("let directEnvironment = surface_direct_environment_contribution(") <
+    source.indexOf("let directLight = surface_direct_light_contribution(") <
       source.indexOf("if (ray.bounce + 1u >= config.maxDepth)")
   );
+});
+
+test("wavefront compute converts emissive area PDFs to solid-angle MIS measures", () => {
+  const source = readRendererSource();
+
+  assert.match(source, /fn triangle_surface_area\(triangle: TriangleRecord\) -> f32/);
+  assert.match(source, /fn solid_angle_pdf_from_area_pdf\(/);
+  assert.match(source, /let geometry = max\(dot\(lightNormal, -lightDirection\), 0\.0\);/);
+  assert.match(source, /return areaPdf \* distanceSquared \/ max\(geometry, 0\.000001\);/);
+  assert.match(source, /let areaPdf = 1\.0 \/ max\(triangleArea \* f32\(config\.emissiveTriangleCount\), 0\.000001\);/);
+  assert.match(
+    source,
+    /let lightPdf = solid_angle_pdf_from_area_pdf\(areaPdf, hit\.position\.xyz, lightPoint, lightNormal\);/
+  );
+  assert.match(source, /let environmentSelectionProbability = select\(1\.0, 0\.5, config\.emissiveTriangleCount > 0u\);/);
+  assert.match(source, /return DirectLightSample\(vec4<f32>\(lightDirection, 0\.0\), vec4<f32>\(radiance, 0\.0\), lightPdf, traceDistance, 0u, 1u\);/);
 });
 
 test("wavefront compute samples material textures on the GPU at the resolved hit UV", () => {
@@ -830,7 +851,7 @@ test("wavefront compute defers visible colour until terminal path resolve", () =
   assert.match(source, /let resolved = resolve_deferred_path_radiance\(index\) \* sample_weight\(\);/);
   assert.match(
     source,
-    /accumulation\[ray\.rayId\] =\s+accumulation\[ray\.rayId\] \+\s+vec4<f32>\(directEnvironment \* sample_weight\(\), 0\.0\);/
+    /accumulation\[ray\.rayId\] =\s+accumulation\[ray\.rayId\] \+\s+vec4<f32>\(directLight \* sample_weight\(\), 0\.0\);/
   );
   assert.match(source, /if \(config\.deferredPathResolve\) \{/);
   assert.match(source, /createGpuSubmissionBatcher\(\{/);


### PR DESCRIPTION
## Summary
- broaden explicit direct lighting from the old material-kind/bounce gate to all non-delta BSDF surfaces
- mix environment and emissive-triangle direct samples behind one MIS-safe solid-angle PDF contract
- add regression coverage, changelog notes, and ADR 0016 for the new direct-light contract

## Validation
- npm test
- npm run test:coverage
- npm run lint
- npm run typecheck
- npm run build
- npm run pack:check

## Links
- Parent story: Plasius-LTD/plasius-ltd-site#1095
- Tasks: #56, #57