### PR TITLE
fix: unblock protected-main release-prep fallback

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -374,11 +374,20 @@ jobs:
               echo "Release metadata pushed directly to ${BASE_BRANCH}."
             else
               BRANCH="release/${TAG}"
+              AUTH_TOKEN="${RELEASE_PREP_TOKEN:-${GITHUB_TOKEN}}"
               if [ -z "${RELEASE_PREP_TOKEN:-}" ]; then
-                echo "RELEASE_PREP_TOKEN is required when branch protection forces release metadata through a PR; github.token-created PRs do not reliably trigger required workflows." >&2
-                exit 1
+                PROTECTION_JSON="$(gh api "repos/${GITHUB_REPOSITORY}/branches/${BASE_BRANCH}/protection" 2>/dev/null || true)"
+                if [ -n "${PROTECTION_JSON}" ]; then
+                  REQUIRED_APPROVALS="$(printf '%s' "${PROTECTION_JSON}" | jq -r '.required_pull_request_reviews.required_approving_review_count // 0')"
+                  REQUIRED_STATUS_CHECKS="$(printf '%s' "${PROTECTION_JSON}" | jq -r '(.required_status_checks.contexts // []) | length')"
+                  if [ "${REQUIRED_APPROVALS}" -gt 0 ] || [ "${REQUIRED_STATUS_CHECKS}" -gt 0 ]; then
+                    echo "RELEASE_PREP_TOKEN is required when branch protection needs approval or status-check execution on the release-prep PR." >&2
+                    exit 1
+                  fi
+                fi
+                echo "Falling back to github.token for release-prep PR because ${BASE_BRANCH} only requires PR mediation."
               fi
-              git remote set-url origin "https://x-access-token:${RELEASE_PREP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+              git remote set-url origin "https://x-access-token:${AUTH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
               git fetch origin "refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}" || true
               git push --force-with-lease --set-upstream origin "HEAD:${BRANCH}"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,9 @@ All notable changes to this project will be documented in this file.
     contract used by the wavefront display-quality renderer.
 
 - **Fixed**
+  - Fixed release metadata preparation on protected `main` so repositories that
+    only require pull-request mediation can fall back to a `github.token` PR
+    path instead of failing immediately on missing `RELEASE_PREP_TOKEN`.
   - Fixed deferred wavefront continuation to record sanitized physical
     throughput segments instead of heuristic path-response colours, with
     explicit delta-lobe tagging and bounded terminal fallback for invalid


### PR DESCRIPTION
## Summary
- allow release-prep PR fallback to use `github.token` when branch protection only requires pull-request mediation
- keep the stricter `RELEASE_PREP_TOKEN` requirement when approvals or status checks are required on the release-prep PR
- document the release-flow fix in `CHANGELOG.md`

## Validation
- `npm ci`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm run pack:check`
- `npm run audit:npm`
- `npm run test:coverage`

## Context
- fixes blocker `#74` so the merged `#73` renderer work can complete release through the approved `cd.yml` path
