### PR TITLE
chore: prepare v0.2.11 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 - **Added**
+  - (placeholder)
+
+- **Changed**
+  - (placeholder)
+
+- **Fixed**
+  - (placeholder)
+
+- **Security**
+  - (placeholder)
+
+## [0.2.11] - 2026-06-22
+
+- **Added**
   - Added ADR 0017 to document physical deferred-throughput continuation,
     invalid-throughput fallback, and rollout expectations for
     `renderer.transport.physicalEstimator`.
@@ -443,3 +457,4 @@ All notable changes to this project will be documented in this file.
 [0.1.12]: https://github.com/Plasius-LTD/gpu-renderer/releases/tag/v0.1.12
 [0.1.14]: https://github.com/Plasius-LTD/gpu-renderer/releases/tag/v0.1.14
 [0.2.1]: https://github.com/Plasius-LTD/gpu-renderer/releases/tag/v0.2.1
+[0.2.11]: https://github.com/Plasius-LTD/gpu-renderer/releases/tag/v0.2.11

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@plasius/gpu-renderer",
-  "version": "0.2.4",
+  "version": "0.2.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@plasius/gpu-renderer",
-      "version": "0.2.4",
+      "version": "0.2.11",
       "funding": [
         {
           "type": "patreon",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plasius/gpu-renderer",
-  "version": "0.2.4",
+  "version": "0.2.11",
   "description": "Framework-agnostic WebGPU renderer runtime for Plasius projects.",
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
## Summary
- land the release-prep metadata that `CD (Publish to npm)` already generated for `v0.2.11`
- unblock the protected-main release path for the merged `#73` / story `plasius-ltd-site#1094` work

## Context
The automated release-prep branch was created successfully by `cd.yml`, but org policy prevents GitHub Actions from opening or approving the required PR itself. This manual PR completes the repository-approved protected-main step without bypassing the release workflow.

## Validation
- metadata prepared by `CD (Publish to npm)` run https://github.com/Plasius-LTD/gpu-renderer/actions/runs/27923568003
- local repo validation on current `origin/main`: `npm test`, `npm run lint`, `npm run typecheck`, `npm run build`
