### PR TITLE
feat: add renderer transport guardrail summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ All notable changes to this project will be documented in this file.
   - Added `gpuWorkerJobs` diagnostics to wavefront frame stats so callers can
     inspect completed compute-dispatch jobs per frame, per second, and per
     command submission alongside the existing GPU parallelism figures.
+  - Added `transportGuardrails` summaries to awaited wavefront frame stats so
+    validation harnesses can read throughput, submission, queue-overflow,
+    memory, and device-loss health from one structured result.
   - Added `gpuParallelism` diagnostics to wavefront frame stats and snapshots so
     consumers can inspect adapter compute limits, direct workgroups,
     indirect-dispatch estimates, and whether a frame exposes multi-workgroup GPU
@@ -67,6 +70,9 @@ All notable changes to this project will be documented in this file.
     contract used by the wavefront display-quality renderer.
 
 - **Fixed**
+  - Raised the bounded wavefront `maxDepth` ceiling to 32 so offline/reference
+    renders can request 20-bounce paths without being clamped by renderer
+    configuration.
   - Fixed release metadata preparation on protected `main` so repositories that
     only require pull-request mediation can fall back to a `github.token` PR
     path instead of failing immediately on missing `RELEASE_PREP_TOKEN`.

--- a/README.md
+++ b/README.md
@@ -225,7 +225,9 @@ reflection/refraction tree.
 `samplesPerPixel` controls how many GPU primary-ray samples are accumulated per
 screen pixel within a single render. This multiplies dispatch work but does not
 increase the tile queue memory footprint, so 720p/1080p/4K targets remain
-bounded by `tileSize`. When `denoise` is enabled the renderer writes raw
+bounded by `tileSize`. `maxDepth` is bounded at 32 for offline/reference
+renders, allowing 20-bounce quality checks while keeping path-vertex memory
+explicit and predictable. When `denoise` is enabled the renderer writes raw
 linear radiance to an `rgba16float` texture first, then runs a two-stage
 full-frame GPU denoise through an `rgba16float` scratch texture before final
 tone mapping into the presented `rgba8unorm` output. Filtering in linear
@@ -288,6 +290,15 @@ counts, and upper-bound indirect work estimates. WebGPU does not expose physical
 GPU core counts, so `physicalCoreCount` remains `null`; use
 `exposesMultiWorkgroupParallelism`, `largestDirectWorkgroupsPerDispatch`, and
 `largestEstimatedIndirectWorkgroupsPerDispatch` to confirm the renderer is
+issuing multi-workgroup GPU work. Awaited frame results also expose a
+`transportGuardrails` summary with jobs/frame, jobs/s, jobs/submission, command
+submissions, queue-overflow count, total tracked memory bytes, and device-loss
+status so validation harnesses can gate transport work without scraping ad hoc
+metrics from multiple fields. Treat any sustained >10% drop in jobs/submission
+or jobs/s versus the approved baseline as a release-validation failure unless a
+linked ticket explicitly approves the regression; `submission-batching` warns
+when the renderer falls back to roughly one GPU job per submission despite a
+higher pass ceiling.
 submitting work that can occupy more than one GPU execution unit. After each
 primary-ray or compaction pass, the GPU writes the active-ray workgroup count
 into the counter buffer and the encoder copies it into an indirect-dispatch

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -785,6 +785,7 @@ export interface WavefrontPathTracingComputeFrameStats {
   readonly accelerationBuilt: boolean;
   readonly accelerationBuildCount: number;
   readonly commandSubmissions: number;
+  readonly deviceLossStatus?: "not-detected" | "pending" | "not-exposed" | "lost";
   readonly gpuWorkerJobs: Readonly<{
     completedPerFrame: number;
     completedPerSecond: number | null;
@@ -793,6 +794,32 @@ export interface WavefrontPathTracingComputeFrameStats {
     indirectDispatchesCompleted: number;
     frameTimeMs: number;
     awaitedGpuCompletion: boolean;
+  }>;
+  readonly transportGuardrails?: Readonly<{
+    status: "pass" | "warn" | "fail";
+    thresholds: Readonly<{
+      maxPerJobRegressionRatio: number;
+    }>;
+    current: Readonly<{
+      jobsPerFrame: number;
+      jobsPerSecond: number | null;
+      jobsPerSubmission: number;
+      commandSubmissions: number;
+      frameTimeMs: number;
+      awaitedGpuCompletion: boolean;
+      maxFramePassesPerSubmission: number;
+      queueOverflow: number;
+      deviceLossStatus: "not-detected" | "pending" | "not-exposed" | "lost";
+      memory: Readonly<{
+        totalBytes: number;
+        breakdown: WavefrontPathTracingMemoryEstimate | null;
+      }>;
+    }>;
+    checks: readonly Readonly<{
+      id: string;
+      status: "pass" | "warn" | "fail";
+      details: string;
+    }>[];
   }>;
   readonly frameConfigSlots: number;
   readonly gpuParallelism: WavefrontGpuParallelismDiagnostics;

--- a/src/wavefront-compute.js
+++ b/src/wavefront-compute.js
@@ -2,6 +2,7 @@ import {
   createGpuParallelismCounters,
   createGpuParallelismDiagnostics,
   createGpuSubmissionBatcher,
+  createWavefrontTransportGuardrailSummary,
   createGpuWorkerJobDiagnostics,
   recordDirectDispatch,
   recordIndirectDispatch,
@@ -10,6 +11,7 @@ import {
 const DEFAULT_WIDTH = 1280;
 const DEFAULT_HEIGHT = 720;
 const DEFAULT_MAX_DEPTH = 6;
+const MAX_PATH_TRACING_DEPTH = 32;
 const DEFAULT_TILE_SIZE = 128;
 const DEFAULT_SAMPLES_PER_PIXEL = 1;
 const MAX_SAMPLES_PER_PIXEL = 256;
@@ -1915,7 +1917,7 @@ export function estimateWavefrontPathTracingMemory(options = {}) {
   const maxDepth = clamp(
     readPositiveInteger("maxDepth", options.maxDepth, DEFAULT_MAX_DEPTH),
     1,
-    16
+    MAX_PATH_TRACING_DEPTH
   );
   const sceneObjectCapacity = readPositiveInteger(
     "sceneObjectCapacity",
@@ -1994,7 +1996,11 @@ export function createWavefrontPathTracingComputeConfig(options = {}) {
   const canvas = options.canvas;
   const width = readPositiveInteger("width", options.width, getCanvasDimension(canvas, "width", DEFAULT_WIDTH));
   const height = readPositiveInteger("height", options.height, getCanvasDimension(canvas, "height", DEFAULT_HEIGHT));
-  const maxDepth = clamp(readPositiveInteger("maxDepth", options.maxDepth, DEFAULT_MAX_DEPTH), 1, 16);
+  const maxDepth = clamp(
+    readPositiveInteger("maxDepth", options.maxDepth, DEFAULT_MAX_DEPTH),
+    1,
+    MAX_PATH_TRACING_DEPTH
+  );
   const tileSize = clamp(readPositiveInteger("tileSize", options.tileSize, DEFAULT_TILE_SIZE), 16, 512);
   const samplesPerPixel = clamp(
     readPositiveInteger("samplesPerPixel", options.samplesPerPixel, DEFAULT_SAMPLES_PER_PIXEL),
@@ -7721,8 +7727,15 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
       lastCompletedFrameTimeMs = frameTimeMs;
       lastCompletedSamplesPerPixel = frameStats.renderedSamplesPerPixel ?? frameStats.samplesPerPixel;
     }
+    const deviceLossStatus =
+      awaitGPUCompletion
+        ? "not-detected"
+        : typeof device.lost?.then === "function"
+          ? "pending"
+          : "not-exposed";
     frameStats = Object.freeze({
       ...frameStats,
+      deviceLossStatus,
       gpuWorkerJobs: createGpuWorkerJobDiagnostics(
         frameStats.gpuParallelism,
         frameStats.commandSubmissions,
@@ -7736,7 +7749,7 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
     const probe =
       renderOptions.readOutputProbe === false ? null : await readOutputProbe(renderOptions.probe);
     const maxChannel = probe ? Math.max(...probe.rgba.slice(0, 3)) : 0;
-    return Object.freeze({
+    const completedFrame = Object.freeze({
       ...frameStats,
       outputProbe: probe
         ? Object.freeze({
@@ -7750,6 +7763,10 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
       termination: terminationMetrics.termination,
       terminalRadiance: terminationMetrics.terminalRadiance,
       queueOverflow: terminationMetrics.queueOverflow,
+    });
+    return Object.freeze({
+      ...completedFrame,
+      transportGuardrails: createWavefrontTransportGuardrailSummary(completedFrame),
     });
   }
 

--- a/src/wavefront-frame-runtime.js
+++ b/src/wavefront-frame-runtime.js
@@ -117,6 +117,123 @@ export function createGpuWorkerJobDiagnostics(
   })
 }
 
+export const defaultWavefrontTransportGuardrailThresholds = Object.freeze({
+  maxPerJobRegressionRatio: 0.1,
+})
+
+function summarizeWavefrontMemory(memory) {
+  const entries = Object.entries(memory ?? {}).filter(
+    ([key, value]) => key.endsWith("Bytes") && Number.isFinite(value)
+  )
+  const totalBytes = entries.reduce((total, [, value]) => total + Number(value), 0)
+  return Object.freeze({
+    totalBytes,
+    breakdown: memory ?? null,
+  })
+}
+
+function normalizeDeviceLossStatus(status, awaitedGpuCompletion) {
+  if (status === "lost") {
+    return "lost"
+  }
+  if (status === "not-exposed") {
+    return "not-exposed"
+  }
+  if (status === "pending") {
+    return "pending"
+  }
+  return awaitedGpuCompletion ? "not-detected" : "pending"
+}
+
+function createTransportGuardrailCheck(id, status, details) {
+  return Object.freeze({
+    id,
+    status,
+    details,
+  })
+}
+
+export function createWavefrontTransportGuardrailSummary(frameStats, options = {}) {
+  const workerJobs = frameStats?.gpuWorkerJobs ?? {}
+  const commandSubmissions = Math.max(0, Number(frameStats?.commandSubmissions ?? 0))
+  const completedPerFrame = Math.max(0, Number(workerJobs.completedPerFrame ?? 0))
+  const completedPerSecond =
+    Number.isFinite(workerJobs.completedPerSecond) && workerJobs.completedPerSecond > 0
+      ? Number(workerJobs.completedPerSecond)
+      : null
+  const completedPerSubmission =
+    commandSubmissions > 0
+      ? completedPerFrame / commandSubmissions
+      : Math.max(0, Number(workerJobs.completedPerSubmission ?? completedPerFrame))
+  const frameTimeMs = Math.max(0, Number(workerJobs.frameTimeMs ?? 0))
+  const awaitedGpuCompletion = workerJobs.awaitedGpuCompletion !== false
+  const queueOverflow = Math.max(0, Number(frameStats?.queueOverflow ?? 0))
+  const maxFramePassesPerSubmission = Math.max(
+    0,
+    Number(frameStats?.maxFramePassesPerSubmission ?? 0)
+  )
+  const deviceLossStatus = normalizeDeviceLossStatus(
+    options.deviceLossStatus ?? frameStats?.deviceLossStatus,
+    awaitedGpuCompletion
+  )
+  const memory = summarizeWavefrontMemory(frameStats?.memory)
+  const checks = Object.freeze([
+    createTransportGuardrailCheck(
+      "device-loss",
+      deviceLossStatus === "lost" ? "fail" : deviceLossStatus === "pending" ? "warn" : "pass",
+      deviceLossStatus === "lost"
+        ? "The WebGPU device was lost during or immediately after the frame."
+        : deviceLossStatus === "pending"
+          ? "GPU work was not awaited, so device-loss status is still pending."
+          : deviceLossStatus === "not-exposed"
+            ? "This environment does not expose device-lost diagnostics."
+            : "No device loss was detected for this frame."
+    ),
+    createTransportGuardrailCheck(
+      "queue-overflow",
+      queueOverflow > 0 ? "warn" : "pass",
+      queueOverflow > 0
+        ? `Queue overflow terminated ${queueOverflow} paths during the frame.`
+        : "No queue-overflow termination was recorded."
+    ),
+    createTransportGuardrailCheck(
+      "submission-batching",
+      commandSubmissions <= 0
+        ? "warn"
+        : maxFramePassesPerSubmission > 1 && completedPerSubmission <= 1
+          ? "warn"
+          : "pass",
+      commandSubmissions <= 0
+        ? "No command submissions were recorded for the frame."
+        : maxFramePassesPerSubmission > 1 && completedPerSubmission <= 1
+          ? `Only ${completedPerSubmission.toFixed(2)} GPU jobs completed per command submission despite a ${maxFramePassesPerSubmission}-pass ceiling.`
+          : `${completedPerFrame} GPU jobs completed across ${commandSubmissions} command submissions (${completedPerSubmission.toFixed(2)} jobs/submission).`
+    ),
+  ])
+  const status = checks.some((check) => check.status === "fail")
+    ? "fail"
+    : checks.some((check) => check.status === "warn")
+      ? "warn"
+      : "pass"
+  return Object.freeze({
+    status,
+    thresholds: defaultWavefrontTransportGuardrailThresholds,
+    current: Object.freeze({
+      jobsPerFrame: completedPerFrame,
+      jobsPerSecond: completedPerSecond,
+      jobsPerSubmission: completedPerSubmission,
+      commandSubmissions,
+      frameTimeMs,
+      awaitedGpuCompletion,
+      maxFramePassesPerSubmission,
+      queueOverflow,
+      deviceLossStatus,
+      memory,
+    }),
+    checks,
+  })
+}
+
 export function createGpuSubmissionBatcher({
   device,
   frameIndex,

--- a/tests/package.test.js
+++ b/tests/package.test.js
@@ -20,6 +20,7 @@ import {
   createGpuParallelismCounters,
   createGpuSubmissionBatcher,
   createGpuWorkerJobDiagnostics,
+  createWavefrontTransportGuardrailSummary,
   recordDirectDispatch,
   recordIndirectDispatch,
 } from "../src/wavefront-frame-runtime.js";
@@ -296,6 +297,100 @@ test("wavefront frame runtime tracks dispatch diagnostics without renderer state
   assert.equal(diagnostics.completedPerFrame, 2);
   assert.equal(diagnostics.completedPerSubmission, 1);
   assert.equal(diagnostics.completedPerSecond, 200);
+});
+
+test("wavefront transport guardrails summarize throughput memory and queue health", () => {
+  const guardrails = createWavefrontTransportGuardrailSummary({
+    commandSubmissions: 2,
+    maxFramePassesPerSubmission: 8,
+    queueOverflow: 0,
+    deviceLossStatus: "not-detected",
+    memory: {
+      queueBytes: 1024,
+      hitBytes: 2048,
+      configBytes: 128,
+    },
+    gpuWorkerJobs: {
+      completedPerFrame: 18,
+      completedPerSecond: 360,
+      completedPerSubmission: 9,
+      directDispatchesCompleted: 12,
+      indirectDispatchesCompleted: 6,
+      frameTimeMs: 50,
+      awaitedGpuCompletion: true,
+    },
+  });
+
+  assert.equal(guardrails.status, "pass");
+  assert.equal(guardrails.thresholds.maxPerJobRegressionRatio, 0.1);
+  assert.equal(guardrails.current.jobsPerFrame, 18);
+  assert.equal(guardrails.current.jobsPerSecond, 360);
+  assert.equal(guardrails.current.jobsPerSubmission, 9);
+  assert.equal(guardrails.current.commandSubmissions, 2);
+  assert.equal(guardrails.current.memory.totalBytes, 3200);
+  assert.equal(guardrails.current.deviceLossStatus, "not-detected");
+  assert.equal(guardrails.checks.length, 3);
+  assert.ok(guardrails.checks.every((check) => check.status === "pass"));
+  assert.match(
+    guardrails.checks.find((check) => check.id === "submission-batching").details,
+    /9\.00 jobs\/submission/
+  );
+});
+
+test("wavefront transport guardrails warn when queue overflow or pending completion hide stability risk", () => {
+  const guardrails = createWavefrontTransportGuardrailSummary({
+    commandSubmissions: 0,
+    maxFramePassesPerSubmission: 4,
+    queueOverflow: 3,
+    gpuWorkerJobs: {
+      completedPerFrame: 0,
+      completedPerSecond: null,
+      completedPerSubmission: 0,
+      directDispatchesCompleted: 0,
+      indirectDispatchesCompleted: 0,
+      frameTimeMs: 12,
+      awaitedGpuCompletion: false,
+    },
+  });
+
+  assert.equal(guardrails.status, "warn");
+  assert.equal(guardrails.current.deviceLossStatus, "pending");
+  assert.equal(guardrails.current.queueOverflow, 3);
+  assert.ok(guardrails.checks.some((check) => check.id === "queue-overflow" && check.status === "warn"));
+  assert.ok(
+    guardrails.checks.some((check) => check.id === "submission-batching" && check.status === "warn")
+  );
+});
+
+test("wavefront transport guardrails warn when submissions collapse to one job each", () => {
+  const guardrails = createWavefrontTransportGuardrailSummary({
+    commandSubmissions: 2,
+    maxFramePassesPerSubmission: 8,
+    queueOverflow: 0,
+    deviceLossStatus: "not-detected",
+    memory: {
+      queueBytes: 1024,
+    },
+    gpuWorkerJobs: {
+      completedPerFrame: 2,
+      completedPerSecond: 40,
+      completedPerSubmission: 1,
+      directDispatchesCompleted: 2,
+      indirectDispatchesCompleted: 0,
+      frameTimeMs: 50,
+      awaitedGpuCompletion: true,
+    },
+  });
+
+  assert.equal(guardrails.status, "warn");
+  assert.ok(
+    guardrails.checks.some(
+      (check) =>
+        check.id === "submission-batching" &&
+        check.status === "warn" &&
+        /despite a 8-pass ceiling/.test(check.details)
+    )
+  );
 });
 
 test("wavefront frame runtime batches submissions against a per-submit pass ceiling", () => {

--- a/tests/wavefront-compute.test.js
+++ b/tests/wavefront-compute.test.js
@@ -410,6 +410,27 @@ test("wavefront compute config keeps 4K queues tile-bounded", () => {
   assert.ok(config.memory.hitBytes < 134_217_728);
 });
 
+test("wavefront compute config supports high quality reference depths", () => {
+  const config = createWavefrontPathTracingComputeConfig({
+    width: 3840,
+    height: 2160,
+    tileSize: 128,
+    maxDepth: 20,
+  });
+  const clamped = createWavefrontPathTracingComputeConfig({
+    width: 640,
+    height: 360,
+    maxDepth: 64,
+  });
+
+  assert.equal(config.maxDepth, 20);
+  assert.equal(
+    config.memory.pathVertexBytes,
+    128 * 128 * 21 * wavefrontPathTracingComputeLimits.pathVertexRecordBytes
+  );
+  assert.equal(clamped.maxDepth, 32);
+});
+
 test("wavefront compute compatibility exports expose the canonical mesh shader", () => {
   const shaderSource = createWavefrontPathTracingComputeShaderSource();
   const types = readRendererTypes();
@@ -2133,6 +2154,17 @@ serialWebGpuTest("wavefront renderFrame waits for submitted GPU work before repo
       frame.gpuWorkerJobs.completedPerSubmission,
       frame.gpuWorkerJobs.completedPerFrame / frame.commandSubmissions
     );
+    assert.equal(frame.deviceLossStatus, "not-detected");
+    assert.equal(frame.transportGuardrails.status, "pass");
+    assert.equal(
+      frame.transportGuardrails.current.jobsPerSubmission,
+      frame.gpuWorkerJobs.completedPerSubmission
+    );
+    assert.equal(
+      frame.transportGuardrails.current.commandSubmissions,
+      frame.commandSubmissions
+    );
+    assert.ok(frame.transportGuardrails.current.memory.totalBytes > 0);
 
     renderer.destroy();
   });
@@ -2194,6 +2226,8 @@ serialWebGpuTest("wavefront renderFrame awaits completed 8 spp work without timi
     assert.equal(device.queue.submittedWorkDoneCalls, 1);
     assert.equal(frame.gpuWorkerJobs.awaitedGpuCompletion, true);
     assert.ok(frame.gpuWorkerJobs.completedPerFrame > frame.commandSubmissions);
+    assert.equal(frame.transportGuardrails.status, "pass");
+    assert.ok(frame.transportGuardrails.current.jobsPerSubmission > 1);
 
     renderer.destroy();
   });


### PR DESCRIPTION
## Summary
- add structured `transportGuardrails` summaries to awaited wavefront frame stats
- expose device-loss, queue-overflow, submission-batching, and memory guardrail checks
- raise the bounded offline/reference `maxDepth` ceiling to 32 and document the new guardrail surface

## Validation
- `npm run test:coverage`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm run pack:check`
- `npm run audit:npm`

## Links
- Plasius-LTD/plasius-ltd-site#1098
- Plasius-LTD/gpu-renderer#61
- Plasius-LTD/gpu-renderer#62
