### PR TITLE
chore: prepare release v0.2.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,20 @@ All notable changes to this project will be documented in this file.
 - **Security**
   - (placeholder)
 
+## [0.2.13] - 2026-06-22
+
+- **Added**
+  - (placeholder)
+
+- **Changed**
+  - (placeholder)
+
+- **Fixed**
+  - (placeholder)
+
+- **Security**
+  - (placeholder)
+
 ## [0.2.12] - 2026-06-22
 
 - **Added**
@@ -479,3 +493,4 @@ All notable changes to this project will be documented in this file.
 [0.2.1]: https://github.com/Plasius-LTD/gpu-renderer/releases/tag/v0.2.1
 [0.2.11]: https://github.com/Plasius-LTD/gpu-renderer/releases/tag/v0.2.11
 [0.2.12]: https://github.com/Plasius-LTD/gpu-renderer/releases/tag/v0.2.12
+[0.2.13]: https://github.com/Plasius-LTD/gpu-renderer/releases/tag/v0.2.13

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@plasius/gpu-renderer",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@plasius/gpu-renderer",
-      "version": "0.2.12",
+      "version": "0.2.13",
       "funding": [
         {
           "type": "patreon",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plasius/gpu-renderer",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "description": "Framework-agnostic WebGPU renderer runtime for Plasius projects.",
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
## Summary
- prepare `v0.2.13` for publication from protected `main`
- update package metadata to `0.2.13`
- move the current `Unreleased` notes into `0.2.13`

The CD workflow will continue only after this release metadata is present on `main`.