### PR TITLE
[codex] Add wavefront transport numeric invariants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 - **Added**
-  - (placeholder)
+  - Added deterministic numeric transport-validation helpers and unit coverage
+    for BSDF PDF consistency, furnace-style reflectance bounds, and bounded
+    terminal-environment residual handling in the wavefront renderer.
 
 - **Changed**
   - (placeholder)

--- a/src/wavefront-compute.js
+++ b/src/wavefront-compute.js
@@ -2838,6 +2838,459 @@ function geometrySmith(nDotV, nDotL, roughness) {
   return geometrySchlickGgx(nDotV, roughness) * geometrySchlickGgx(nDotL, roughness);
 }
 
+function maxComponentVec3(value) {
+  return Math.max(value[0] ?? 0, value[1] ?? 0, value[2] ?? 0);
+}
+
+function clampVec3(value, min = 0, max = 1) {
+  const minVec = Array.isArray(min) ? min : [min, min, min];
+  const maxVec = Array.isArray(max) ? max : [max, max, max];
+  return [
+    clamp(Number(value?.[0]) || 0, minVec[0], maxVec[0]),
+    clamp(Number(value?.[1]) || 0, minVec[1], maxVec[1]),
+    clamp(Number(value?.[2]) || 0, minVec[2], maxVec[2]),
+  ];
+}
+
+function maxVec3(left, right) {
+  return [
+    Math.max(left[0] ?? 0, right[0] ?? 0),
+    Math.max(left[1] ?? 0, right[1] ?? 0),
+    Math.max(left[2] ?? 0, right[2] ?? 0),
+  ];
+}
+
+function multiplyVec3(left, right) {
+  return [
+    (left[0] ?? 0) * (right[0] ?? 0),
+    (left[1] ?? 0) * (right[1] ?? 0),
+    (left[2] ?? 0) * (right[2] ?? 0),
+  ];
+}
+
+function addVec3(left, right) {
+  return [
+    (left[0] ?? 0) + (right[0] ?? 0),
+    (left[1] ?? 0) + (right[1] ?? 0),
+    (left[2] ?? 0) + (right[2] ?? 0),
+  ];
+}
+
+function mixScalar(a, b, factor) {
+  return a * (1 - factor) + b * factor;
+}
+
+function mixVec3(left, right, factor) {
+  return [
+    mixScalar(left[0] ?? 0, right[0] ?? 0, factor),
+    mixScalar(left[1] ?? 0, right[1] ?? 0, factor),
+    mixScalar(left[2] ?? 0, right[2] ?? 0, factor),
+  ];
+}
+
+function sanitizeWavefrontPdf(value) {
+  if (!Number.isFinite(value) || value <= 0) {
+    return 0;
+  }
+  return value;
+}
+
+function sanitizeWavefrontThroughputComponent(value) {
+  if (!Number.isFinite(value) || value <= 0) {
+    return 0;
+  }
+  return Math.min(value, 65504);
+}
+
+function sanitizeWavefrontThroughput(value) {
+  return [
+    sanitizeWavefrontThroughputComponent(value?.[0]),
+    sanitizeWavefrontThroughputComponent(value?.[1]),
+    sanitizeWavefrontThroughputComponent(value?.[2]),
+  ];
+}
+
+function coerceWavefrontVec3(value, fallback) {
+  const source = Array.isArray(value) ? value : [];
+  return [
+    Number.isFinite(source[0]) ? Number(source[0]) : fallback[0],
+    Number.isFinite(source[1]) ? Number(source[1]) : fallback[1],
+    Number.isFinite(source[2]) ? Number(source[2]) : fallback[2],
+  ];
+}
+
+function clampWavefrontSampleRadiance(value) {
+  return [
+    clamp(Number(value?.[0]) || 0, 0, 4),
+    clamp(Number(value?.[1]) || 0, 0, 4),
+    clamp(Number(value?.[2]) || 0, 0, 4),
+  ];
+}
+
+function fresnelSchlick(cosine, f0) {
+  const factor = (1 - clamp(Number(cosine) || 0, 0, 1)) ** 5;
+  return [
+    (f0[0] ?? 0) + (1 - (f0[0] ?? 0)) * factor,
+    (f0[1] ?? 0) + (1 - (f0[1] ?? 0)) * factor,
+    (f0[2] ?? 0) + (1 - (f0[2] ?? 0)) * factor,
+  ];
+}
+
+function normalizeWavefrontReferenceHit(input = {}) {
+  const material = Array.isArray(input.material) ? input.material : [];
+  const materialResponse = Array.isArray(input.materialResponse) ? input.materialResponse : [];
+  const materialExtension = Array.isArray(input.materialExtension) ? input.materialExtension : [];
+  return Object.freeze({
+    color: Object.freeze(coerceWavefrontVec3(input.color, [0.8, 0.8, 0.8])),
+    shadingNormal: Object.freeze(
+      normalize(coerceWavefrontVec3(input.shadingNormal, [0, 1, 0]), [0, 1, 0])
+    ),
+    material: Object.freeze([
+      clamp(Number(material[0] ?? input.roughness ?? 0.45) || 0, 0, 1),
+      clamp(Number(material[1] ?? input.metallic ?? 0) || 0, 0, 1),
+      clamp(Number(material[2] ?? 1) || 1, 0, 1),
+      clamp(Number(material[3] ?? 1.45) || 1.45, 1, 3),
+    ]),
+    materialResponse: Object.freeze([
+      clamp(Number(materialResponse[0] ?? input.sheen ?? 0) || 0, 0, 1),
+      clamp(Number(materialResponse[1] ?? input.sheenTint ?? 0) || 0, 0, 1),
+      clamp(Number(materialResponse[2] ?? input.anisotropy ?? 0) || 0, 0, 1),
+      clamp(Number(materialResponse[3] ?? input.clearcoat ?? 0) || 0, 0, 1),
+    ]),
+    materialExtension: Object.freeze([
+      clamp(Number(materialExtension[0] ?? input.clearcoatRoughness ?? 0.08) || 0, 0, 1),
+      clamp(Number(materialExtension[1] ?? input.specularWeight ?? 1) || 0, 0, 1),
+      clamp(Number(materialExtension[2] ?? input.transmission ?? 0) || 0, 0, 1),
+      clamp(Number(materialExtension[3] ?? 0) || 0, 0, 1),
+    ]),
+    specularColor: Object.freeze(coerceWavefrontVec3(input.specularColor, [1, 1, 1])),
+    occlusion: clamp(Number(input.occlusion ?? 1) || 0, 0, 1),
+    materialKind: readNonNegativeInteger("materialKind", input.materialKind, 0),
+    position: Object.freeze(coerceWavefrontVec3(input.position, [0, 0, 0])),
+  });
+}
+
+function surfaceSpecularF0Reference(hit, surfaceColor) {
+  const metallic = clamp(hit.material[1], 0, 1);
+  const specularWeight = clamp(hit.materialExtension[1], 0, 1);
+  const specularColor = clampVec3(hit.specularColor, 0, 1);
+  const dielectricF0 = specularColor.map((value) => 0.04 * specularWeight * value);
+  return mixVec3(dielectricF0, surfaceColor, metallic);
+}
+
+function surfaceBsdfSamplingWeightsReference(hit) {
+  const metallic = clamp(hit.material[1], 0, 1);
+  const clearcoat = clamp(hit.materialResponse[3], 0, 1);
+  const specularWeight = clamp(hit.materialExtension[1], 0, 1);
+  const diffuseWeight = clamp(
+    (1 - metallic) * Math.max(1 - specularWeight * 0.5 - clearcoat * 0.25, 0.15),
+    0,
+    1
+  );
+  const specWeight = clamp(
+    Math.max(metallic, specularWeight * 0.75) * (1 - clearcoat * 0.5),
+    0,
+    1
+  );
+  const clearcoatWeight = clamp(clearcoat, 0, 1);
+  const totalWeight = Math.max(diffuseWeight + specWeight + clearcoatWeight, 0.000001);
+  return Object.freeze([
+    diffuseWeight / totalWeight,
+    specWeight / totalWeight,
+    clearcoatWeight / totalWeight,
+  ]);
+}
+
+function evaluateWavefrontSurfaceBsdfReference(hitInput, viewDirectionInput, lightDirectionInput, ambientColor = [0.018, 0.022, 0.026]) {
+  const hit = normalizeWavefrontReferenceHit(hitInput);
+  const normal = normalize(hit.shadingNormal, [0, 1, 0]);
+  const viewDirection = normalize(viewDirectionInput, normal);
+  const lightDirection = normalize(lightDirectionInput, normal);
+  const surfaceColor = clampVec3(maxVec3(hit.color, scale(asVec3(ambientColor, [0.018, 0.022, 0.026]), 0.35)), 0, 1);
+  const roughness = clamp(hit.material[0], 0, 1);
+  const metallic = clamp(hit.material[1], 0, 1);
+  const clearcoat = clamp(hit.materialResponse[3], 0, 1);
+  const clearcoatRoughness = clamp(hit.materialExtension[0], 0, 1);
+  const occlusion = clamp(hit.occlusion, 0, 1);
+  const nDotV = clamp(dot(normal, viewDirection), 0, 1);
+  const nDotL = clamp(dot(normal, lightDirection), 0, 1);
+  if (nDotV <= 0 || nDotL <= 0) {
+    return Object.freeze([0, 0, 0]);
+  }
+  const halfVector = normalize(add(viewDirection, lightDirection), normal);
+  const vDotH = clamp(dot(viewDirection, halfVector), 0, 1);
+  const f0 = surfaceSpecularF0Reference(hit, surfaceColor);
+  const fresnel = fresnelSchlick(vDotH, f0);
+  const nDotH = clamp(dot(normal, halfVector), 0, 1);
+  const distribution = distributionGgx(nDotH, roughness);
+  const geometry = geometrySmith(nDotV, nDotL, roughness);
+  const specular = fresnel.map(
+    (value) => (distribution * geometry * value) / Math.max(4 * nDotV * nDotL, 0.000001)
+  );
+  const diffuseWeight =
+    (1 - metallic) * (1 - clearcoat * 0.24) * (1 - clamp(maxComponentVec3(fresnel), 0, 0.98));
+  const diffuse = surfaceColor.map((value) => (value * diffuseWeight) / Math.PI);
+  const clearcoatHalf = normalize(add(viewDirection, lightDirection), normal);
+  const clearcoatVDotH = clamp(dot(viewDirection, clearcoatHalf), 0, 1);
+  const clearcoatDistribution = distributionGgx(
+    clamp(dot(normal, clearcoatHalf), 0, 1),
+    Math.max(clearcoatRoughness, 0.02)
+  );
+  const clearcoatGeometry = geometrySmith(nDotV, nDotL, Math.max(clearcoatRoughness, 0.02));
+  const clearcoatFresnel = fresnelSchlick(clearcoatVDotH, [0.04, 0.04, 0.04]);
+  const clearcoatTerm = clearcoatFresnel.map(
+    (value) =>
+      ((clearcoatDistribution * clearcoatGeometry * value) /
+        Math.max(4 * nDotV * nDotL, 0.000001)) *
+      clearcoat
+  );
+  const occlusionWeight = mixScalar(0.42, 1, occlusion);
+  return Object.freeze(
+    addVec3(addVec3(diffuse, specular), clearcoatTerm).map((value) => value * occlusionWeight)
+  );
+}
+
+function diffusePdfReference(normal, lightDirection) {
+  return clamp(dot(normal, lightDirection), 0, 1) / Math.PI;
+}
+
+function ggxPdfReference(normal, viewDirection, lightDirection, roughness) {
+  const halfVector = normalize(add(viewDirection, lightDirection), normal);
+  const nDotH = clamp(dot(normal, halfVector), 0, 1);
+  const vDotH = clamp(dot(viewDirection, halfVector), 0, 1);
+  const distribution = distributionGgx(nDotH, roughness);
+  return (distribution * nDotH) / Math.max(4 * vDotH, 0.000001);
+}
+
+function evaluateWavefrontSurfaceBsdfPdfReference(hitInput, viewDirectionInput, lightDirectionInput) {
+  const hit = normalizeWavefrontReferenceHit(hitInput);
+  const normal = normalize(hit.shadingNormal, [0, 1, 0]);
+  const viewDirection = normalize(viewDirectionInput, normal);
+  const lightDirection = normalize(lightDirectionInput, normal);
+  const roughness = clamp(hit.material[0], 0, 1);
+  const weights = surfaceBsdfSamplingWeightsReference(hit);
+  return (
+    weights[0] * diffusePdfReference(normal, lightDirection) +
+    weights[1] * ggxPdfReference(normal, viewDirection, lightDirection, Math.max(roughness, 0.02)) +
+    weights[2] *
+      ggxPdfReference(
+        normal,
+        viewDirection,
+        lightDirection,
+        Math.max(clamp(hit.materialExtension[0], 0, 1), 0.02)
+      )
+  );
+}
+
+function surfaceGlossinessReference(hitInput) {
+  const hit = normalizeWavefrontReferenceHit(hitInput);
+  const roughness = clamp(hit.material[0], 0, 1);
+  const metallic = clamp(hit.material[1], 0, 1);
+  const sheen = clamp(maxComponentVec3(hit.materialResponse), 0, 1);
+  const clearcoat = clamp(hit.materialResponse[3], 0, 1);
+  const specularWeight = clamp(hit.materialExtension[1], 0, 1);
+  const transmission = clamp(hit.materialExtension[2], 0, 1);
+  const baseGloss = Math.max(
+    clearcoat,
+    Math.max(sheen * 0.72, Math.max(specularWeight * (0.38 + metallic * 0.62), transmission))
+  );
+  return clamp(baseGloss * (1 - roughness * 0.72) + metallic * (1 - roughness) * 0.35, 0, 1);
+}
+
+function glossyEnvironmentDirectionReference(incidentDirection, normal, roughness, normalBlendScale) {
+  const reflectionDirection = reflectVector(incidentDirection, normal);
+  const blend = clamp(roughness * roughness * normalBlendScale, 0, 0.92);
+  return normalize(
+    add(scale(reflectionDirection, 1 - blend), scale(normal, blend)),
+    normal
+  );
+}
+
+function wavefrontPowerHeuristicReference(pdfA, pdfB) {
+  const a = sanitizeWavefrontPdf(pdfA);
+  const b = sanitizeWavefrontPdf(pdfB);
+  if (a <= 0) {
+    return 0;
+  }
+  const a2 = a * a;
+  const b2 = b * b;
+  return a2 / Math.max(a2 + b2, 0.000001);
+}
+
+function sunlitBaselineRadianceReference(configInput, normal) {
+  const config = configInput ?? {};
+  const baseline = Math.max(
+    0,
+    Number(config.environmentLighting?.sunlitBaseline ?? config.pathResolveBaseline ?? 0.16)
+  );
+  if (baseline <= 0.000001) {
+    return [0, 0, 0];
+  }
+  const sunDirection = asUnitVec3(
+    config.environmentLighting?.sunDirection,
+    DEFAULT_ENVIRONMENT_LIGHTING.sunDirection
+  );
+  const sunFacing = clamp(dot(normal, sunDirection), 0, 1);
+  const skyFacing = 0.35 + clamp(normal[1] * 0.5 + 0.5, 0, 1) * 0.65;
+  const directionalWeight = 0.38 + sunFacing * 0.62;
+  const sunTint = maxVec3(asVec3(config.environmentLighting?.sunColor, DEFAULT_ENVIRONMENT_LIGHTING.sunColor), [0, 0, 0]);
+  return clampWavefrontSampleRadiance(
+    sunTint.map((value) => value * baseline * skyFacing * directionalWeight * 0.04)
+  );
+}
+
+export function validateWavefrontBsdfSample({
+  hit,
+  viewDirection = [0, 1, 0],
+  lightDirection = [0, 1, 0],
+  sampledPdf,
+  lightPdf = 0,
+  ambientColor = [0.018, 0.022, 0.026],
+} = {}) {
+  const normalizedHit = normalizeWavefrontReferenceHit(hit);
+  const normal = normalize(normalizedHit.shadingNormal, [0, 1, 0]);
+  const resolvedViewDirection = normalize(viewDirection, normal);
+  const resolvedLightDirection = normalize(lightDirection, normal);
+  const bsdf = evaluateWavefrontSurfaceBsdfReference(
+    normalizedHit,
+    resolvedViewDirection,
+    resolvedLightDirection,
+    ambientColor
+  );
+  const expectedPdf = evaluateWavefrontSurfaceBsdfPdfReference(
+    normalizedHit,
+    resolvedViewDirection,
+    resolvedLightDirection
+  );
+  const resolvedSampledPdf =
+    sampledPdf === undefined ? expectedPdf : sanitizeWavefrontPdf(sampledPdf);
+  const nDotL = clamp(dot(normal, resolvedLightDirection), 0, 1);
+  const continuationThroughput =
+    resolvedSampledPdf <= 0.000001
+      ? [0, 0, 0]
+      : sanitizeWavefrontThroughput(
+          bsdf.map((value) => value * (nDotL / Math.max(resolvedSampledPdf, 0.000001)))
+        );
+  const pdfTolerance = Math.max(0.00005, expectedPdf * 0.05);
+  return Object.freeze({
+    bsdf: Object.freeze(bsdf),
+    expectedPdf,
+    sampledPdf: resolvedSampledPdf,
+    lightPdf: sanitizeWavefrontPdf(lightPdf),
+    misWeight: wavefrontPowerHeuristicReference(lightPdf, resolvedSampledPdf),
+    continuationThroughput: Object.freeze(continuationThroughput),
+    pdfMismatch: Math.abs(resolvedSampledPdf - expectedPdf) > pdfTolerance,
+  });
+}
+
+export function estimateWavefrontDirectionalHemisphericalReflectance(
+  hit,
+  viewDirection = [0, 1, 0],
+  options = {}
+) {
+  const normalizedHit = normalizeWavefrontReferenceHit(hit);
+  const normal = normalize(normalizedHit.shadingNormal, [0, 1, 0]);
+  const resolvedViewDirection = normalize(viewDirection, normal);
+  const sampleCount = Math.max(32, readPositiveInteger("sampleCount", options.sampleCount, 512));
+  let total = [0, 0, 0];
+  for (let index = 0; index < sampleCount; index += 1) {
+    const sample = hammersley(index, sampleCount);
+    const phi = sample[0] * 2 * Math.PI;
+    const cosTheta = sample[1];
+    const sinTheta = Math.sqrt(Math.max(1 - cosTheta * cosTheta, 0));
+    const lightDirection = localToWorld(
+      [Math.cos(phi) * sinTheta, Math.sin(phi) * sinTheta, cosTheta],
+      normal
+    );
+    const bsdf = evaluateWavefrontSurfaceBsdfReference(
+      normalizedHit,
+      resolvedViewDirection,
+      lightDirection,
+      options.ambientColor ?? [0.018, 0.022, 0.026]
+    );
+    const nDotL = clamp(dot(normal, lightDirection), 0, 1);
+    total = addVec3(total, bsdf.map((value) => value * nDotL * ((2 * Math.PI) / sampleCount)));
+  }
+  return Object.freeze(clampVec3(total, 0, 4));
+}
+
+export function computeWavefrontTerminalEnvironmentContributionReference(
+  configInput = {},
+  rayInput = {},
+  throughputInput = [1, 1, 1],
+  hitInput = {}
+) {
+  const config = configInput ?? {};
+  const hit = normalizeWavefrontReferenceHit(hitInput);
+  const normal = normalize(hit.shadingNormal, [0, 1, 0]);
+  const origin = add(hit.position, scale(normal, 0.003));
+  const roughness = clamp(hit.material[0], 0, 1);
+  const glossiness = surfaceGlossinessReference(hit);
+  const rayDirection = normalize(rayInput.direction ?? [0, -1, 0], [0, -1, 0]);
+  const viewDirection = normalize(scale(rayDirection, -1), normal);
+  const normalEnvironment = evaluateReferenceEnvironmentRadiance(config, origin, normal).slice(0, 3);
+  const reflectionDirection = glossyEnvironmentDirectionReference(
+    rayDirection,
+    normal,
+    roughness,
+    mixScalar(0.88, 0.38, glossiness)
+  );
+  const reflectionEnvironment = evaluateReferenceEnvironmentRadiance(
+    config,
+    origin,
+    reflectionDirection
+  ).slice(0, 3);
+  const surfaceColor = clampVec3(
+    maxVec3(hit.color, scale(asVec3(config.ambientColor, [0.018, 0.022, 0.026]), 0.35)),
+    0,
+    1
+  );
+  const f0 = surfaceSpecularF0Reference(hit, surfaceColor);
+  const [brdfScale, brdfBias] = integrateBrdfSample(
+    clamp(dot(normal, viewDirection), 0, 1),
+    roughness,
+    128
+  );
+  const specularEnvironment = multiplyVec3(
+    reflectionEnvironment,
+    addVec3(scale(f0, brdfScale), [brdfBias, brdfBias, brdfBias])
+  );
+  const sunlitFloor = sunlitBaselineRadianceReference(config, normal);
+  const ambientColor = asVec3(config.ambientColor, [0.018, 0.022, 0.026]);
+  const ambientFloor = maxVec3(ambientColor, scale(sunlitFloor, 0.82));
+  const environmentInfluence = Math.max(
+    0.12,
+    Number(config.environmentLighting?.sunlitBaseline ?? config.pathResolveBaseline ?? 0.16) * 0.42
+  );
+  const glossyEnvironment = maxVec3(
+    normalEnvironment,
+    maxVec3(
+      scale(reflectionEnvironment, mixScalar(0.24, 0.92, glossiness)),
+      specularEnvironment
+    )
+  );
+  const environmentFloor = maxVec3(
+    ambientFloor,
+    maxVec3(sunlitFloor, scale(glossyEnvironment, environmentInfluence))
+  );
+  const materialFloor = hit.materialKind === 0 || hit.materialKind === 3 ? 1 : 0.7;
+  const source = clampWavefrontSampleRadiance(scale(environmentFloor, materialFloor));
+  const occlusion = mixScalar(0.75, 1, clamp(hit.occlusion, 0, 1));
+  const contribution = clampWavefrontSampleRadiance(
+    scale(
+      multiplyVec3(
+        multiplyVec3(sanitizeWavefrontThroughput(throughputInput), maxVec3(hit.color, ambientColor)),
+        source
+      ),
+      occlusion
+    )
+  );
+  return Object.freeze({
+    source: Object.freeze(source),
+    contribution: Object.freeze(contribution),
+  });
+}
+
 function integrateBrdfSample(nDotV, roughness, sampleCount) {
   const viewDirection = [Math.sqrt(Math.max(0, 1 - nDotV * nDotV)), 0, nDotV];
   const normal = [0, 0, 1];

--- a/tests/wavefront-compute.test.js
+++ b/tests/wavefront-compute.test.js
@@ -30,6 +30,11 @@ import {
   wavefrontPathTracingComputeLimits,
   wavefrontSceneObjectKinds,
 } from "../src/index.js";
+import {
+  computeWavefrontTerminalEnvironmentContributionReference,
+  estimateWavefrontDirectionalHemisphericalReflectance,
+  validateWavefrontBsdfSample,
+} from "../src/wavefront-compute.js";
 
 const gpuConstants = Object.freeze({
   buffer: Object.freeze({
@@ -857,6 +862,156 @@ test("wavefront compute converts emissive area PDFs to solid-angle MIS measures"
   );
   assert.match(source, /let environmentSelectionProbability = select\(1\.0, 0\.5, config\.emissiveTriangleCount > 0u\);/);
   assert.match(source, /return DirectLightSample\(vec4<f32>\(lightDirection, 0\.0\), vec4<f32>\(radiance, 0\.0\), lightPdf, traceDistance, 0u, 1u\);/);
+});
+
+test("wavefront BSDF numeric helpers flag PDF mismatches and invalid MIS measures", () => {
+  const hit = {
+    color: [0.78, 0.66, 0.52],
+    shadingNormal: [0, 1, 0],
+    roughness: 0.34,
+    metallic: 0.18,
+    clearcoat: 0.12,
+    clearcoatRoughness: 0.08,
+    specularWeight: 1,
+    occlusion: 0.94,
+  };
+  const viewDirection = [0, 1, 0];
+  const lightDirection = [0.24, 0.94, 0.23];
+
+  const matched = validateWavefrontBsdfSample({
+    hit,
+    viewDirection,
+    lightDirection,
+    lightPdf: 0.17,
+  });
+  assert.equal(matched.pdfMismatch, false);
+  assert.ok(matched.expectedPdf > 0);
+  assert.ok(matched.misWeight > 0 && matched.misWeight < 1);
+  matched.continuationThroughput.forEach((value) => {
+    assert.ok(Number.isFinite(value));
+    assert.ok(value >= 0);
+  });
+
+  const mismatched = validateWavefrontBsdfSample({
+    hit,
+    viewDirection,
+    lightDirection,
+    sampledPdf: matched.expectedPdf * 0.25,
+    lightPdf: 0.17,
+  });
+  assert.equal(mismatched.pdfMismatch, true);
+
+  const invalid = validateWavefrontBsdfSample({
+    hit,
+    viewDirection,
+    lightDirection,
+    sampledPdf: Number.NaN,
+    lightPdf: Number.POSITIVE_INFINITY,
+  });
+  assert.equal(invalid.misWeight, 0);
+  assert.deepEqual(invalid.continuationThroughput, [0, 0, 0]);
+});
+
+test("wavefront BSDF numeric helpers keep furnace-style reflectance bounded", () => {
+  const viewDirection = [0, 1, 0];
+  const materials = [
+    {
+      color: [0.82, 0.74, 0.68],
+      shadingNormal: [0, 1, 0],
+      roughness: 0.65,
+      metallic: 0,
+      clearcoat: 0,
+      specularWeight: 1,
+      occlusion: 1,
+    },
+    {
+      color: [0.92, 0.87, 0.81],
+      shadingNormal: [0, 1, 0],
+      roughness: 0.22,
+      metallic: 1,
+      clearcoat: 0,
+      specularWeight: 1,
+      occlusion: 1,
+    },
+    {
+      color: [0.68, 0.74, 0.82],
+      shadingNormal: [0, 1, 0],
+      roughness: 0.28,
+      metallic: 0.08,
+      clearcoat: 0.65,
+      clearcoatRoughness: 0.05,
+      specularWeight: 1,
+      occlusion: 0.96,
+    },
+  ];
+
+  materials.forEach((material) => {
+    const reflectance = estimateWavefrontDirectionalHemisphericalReflectance(material, viewDirection, {
+      sampleCount: 1024,
+    });
+    reflectance.forEach((value) => {
+      assert.ok(Number.isFinite(value));
+      assert.ok(value >= 0);
+      assert.ok(value <= 1.05);
+    });
+  });
+});
+
+test("wavefront terminal environment helpers clamp residuals and keep invalid inputs finite", () => {
+  const config = createWavefrontPathTracingComputeConfig({
+    width: 16,
+    height: 16,
+    ambientColor: [0.24, 0.26, 0.3, 1],
+    environmentLighting: {
+      sunlitBaseline: 1.8,
+      intensity: 2.4,
+      sunColor: [3.6, 3.3, 2.9, 1],
+    },
+  });
+  const hit = {
+    color: [1.6, 1.4, 1.2],
+    shadingNormal: [0, 1, 0],
+    position: [0, 0.5, 0],
+    roughness: 0.05,
+    metallic: 0.92,
+    clearcoat: 0.4,
+    clearcoatRoughness: 0.04,
+    specularWeight: 1,
+    occlusion: 0.1,
+    materialKind: 1,
+  };
+  const ray = {
+    direction: [0.18, -0.96, 0.21],
+  };
+
+  const bounded = computeWavefrontTerminalEnvironmentContributionReference(
+    config,
+    ray,
+    [48, 36, 24],
+    hit
+  );
+  bounded.source.forEach((value) => {
+    assert.ok(Number.isFinite(value));
+    assert.ok(value >= 0);
+    assert.ok(value <= 4);
+  });
+  bounded.contribution.forEach((value) => {
+    assert.ok(Number.isFinite(value));
+    assert.ok(value >= 0);
+    assert.ok(value <= 4);
+  });
+
+  const invalid = computeWavefrontTerminalEnvironmentContributionReference(
+    config,
+    ray,
+    [Number.NaN, Number.POSITIVE_INFINITY, -1],
+    {
+      ...hit,
+      color: [Number.NaN, Number.POSITIVE_INFINITY, -1],
+      occlusion: Number.NaN,
+    }
+  );
+  assert.deepEqual(invalid.contribution, [0, 0, 0]);
 });
 
 test("wavefront compute samples material textures on the GPU at the resolved hit UV", () => {


### PR DESCRIPTION
## Summary
- add deterministic numeric transport-validation helpers in `src/wavefront-compute.js` for BSDF/PDF consistency, furnace-style reflectance bounds, and terminal-environment residual clamping
- add focused unit coverage for PDF mismatch detection, invalid MIS measures, furnace-style bounded reflectance, and finite terminal residual handling
- record the internal validation work in `CHANGELOG.md` under `Unreleased`

## Why
Task `gpu-renderer#60` requires fast numeric transport checks that fail before browser capture lanes when BSDF semantics, MIS measures, or terminal-residual handling drift.

## Impact
- renderer maintainers get deterministic regression coverage for transport invariants in the normal unit-test lane
- invalid PDFs and NaN/Inf throughput inputs are exercised explicitly instead of being left to browser-scene validation
- no package-root public API changes are introduced

## Validation
- `npm test -- --runInBand`
- `npm run typecheck`
- `npm run build`
- `npm run lint`
- `npm run test:coverage`
- `npm run pack:check`
