### PR TITLE
fix: preserve HDR wavefront radiance accounting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,18 @@ All notable changes to this project will be documented in this file.
   - (placeholder)
 
 - **Changed**
-  - (placeholder)
+  - Changed wavefront terminal and direct-light accumulation to preserve HDR
+    linear radiance through accumulation and deferred resolve, while sanitizing
+    only invalid or half-float-overflow samples before presentation.
 
 - **Fixed**
-  - (placeholder)
+  - Fixed the renderer's legacy per-sample `4.0` radiance clamp so HDR
+    fireflies are now measured through `radianceDiagnostics` and
+    `transportGuardrails` instead of being silently biased out of the linear
+    estimator path.
+  - Fixed medium handoff fallback so invalid medium ids and unsupported nested
+    medium transitions keep the current ray medium instead of propagating a
+    broken or pretend stack state.
 
 - **Security**
   - (placeholder)

--- a/README.md
+++ b/README.md
@@ -220,7 +220,9 @@ GPU ray, and applies Beer-Lambert transmittance to travelled segments on the
 GPU. Thickness is now preserved in material packing for later shell-volume
 work, but the current renderer still tracks only one active medium id per ray
 and does not yet implement nested media, spectral dispersion, or a branching
-reflection/refraction tree.
+reflection/refraction tree. Invalid medium ids fall back to the current ray
+medium, and entering a second medium while one is already active preserves the
+existing medium id until dedicated stack support is implemented.
 
 `samplesPerPixel` controls how many GPU primary-ray samples are accumulated per
 screen pixel within a single render. This multiplies dispatch work but does not
@@ -239,9 +241,7 @@ separate shadow/direct-light pass: the active ray still has to hit emissive
 geometry or miss into the environment before radiance is committed. Guided
 emissive hits carry a bounded estimator weight so finite light guidance does not
 over-expose low-sample renders before full material PDFs/MIS are implemented.
-High-energy samples are clamped in linear radiance space to keep low-sample
-preview output stable while production sampling, temporal accumulation, and
-better material PDFs are hardened. By default, `deferredPathResolve` records
+By default, `deferredPathResolve` records
 per-bounce material responses in a tile-bounded path buffer and records the
 terminal emissive/HDRI/environment source in the final path slot. The output
 pass then resolves that recorded path backward and adds the weighted sample to
@@ -262,10 +262,16 @@ whitewashed global ambient term. Extremely dark recorded bounce responses are
 also remapped to a small scene-brightness-driven luminance floor so bright
 low-sample scenes do not produce isolated black speckles when a valid terminal
 source was already found. Awaited `renderFrame({ readStats: true })` results now
-expose `terminalRadiance.totalLuminance`,
+keep linear accumulation unclamped, sanitize only invalid or half-float-
+overflow samples before presentation, and expose
+`terminalRadiance.totalLuminance`,
 `terminalRadiance.ambientResidualLuminance`, and
 `terminalRadiance.ambientResidualShare` so validation harnesses can track how
 much of the final resolved image came from terminal ambient residuals.
+The same stats also expose `radianceDiagnostics.invalidSamples` and
+`radianceDiagnostics.legacyClampEquivalentSamples`, so hardening scenes can
+measure NaN/Inf cleanup and legacy-4.0-equivalent fireflies without
+re-introducing a hidden estimator clamp.
 For static mesh scenes, the GPU acceleration build is submitted once and then
 reused by subsequent frames. Per-frame tracing writes one dynamic uniform slot
 per tile/sample or post-process pass and batches tile tracing, tile output,
@@ -292,13 +298,13 @@ GPU core counts, so `physicalCoreCount` remains `null`; use
 `largestEstimatedIndirectWorkgroupsPerDispatch` to confirm the renderer is
 issuing multi-workgroup GPU work. Awaited frame results also expose a
 `transportGuardrails` summary with jobs/frame, jobs/s, jobs/submission, command
-submissions, queue-overflow count, total tracked memory bytes, and device-loss
-status so validation harnesses can gate transport work without scraping ad hoc
-metrics from multiple fields. Treat any sustained >10% drop in jobs/submission
-or jobs/s versus the approved baseline as a release-validation failure unless a
-linked ticket explicitly approves the regression; `submission-batching` warns
-when the renderer falls back to roughly one GPU job per submission despite a
-higher pass ceiling.
+submissions, queue-overflow count, radiance diagnostics, total tracked memory
+bytes, and device-loss status so validation harnesses can gate transport work
+without scraping ad hoc metrics from multiple fields. Treat any sustained >10%
+drop in jobs/submission or jobs/s versus the approved baseline as a
+release-validation failure unless a linked ticket explicitly approves the
+regression; `submission-batching` warns when the renderer falls back to roughly
+one GPU job per submission despite a higher pass ceiling.
 submitting work that can occupy more than one GPU execution unit. After each
 primary-ray or compaction pass, the GPU writes the active-ray workgroup count
 into the counter buffer and the encoder copies it into an indirect-dispatch

--- a/docs/design/wavefront-volume-medium-transport.md
+++ b/docs/design/wavefront-volume-medium-transport.md
@@ -31,6 +31,17 @@ shared wavefront renderer without demo-local medium construction.
 5. Surface resolution multiplies travelled throughput by Beer-Lambert
    transmittance for the distance traversed in the current medium.
 
+## Current Fallback Contract
+
+- The renderer currently supports a single active medium per ray.
+- Invalid or unknown `mediumRefId` values fall back to the current ray medium
+  instead of propagating a broken lookup.
+- Nested medium stacks fall back to the current ray medium until dedicated
+  stack support is scoped; entering a second medium while another is active
+  preserves the existing medium id instead of pretending stack semantics exist.
+- Exiting the active medium returns the ray to vacuum (`0`) only when the
+  surface medium id matches the current ray medium id.
+
 ## Explicit Non-Goals
 
 - nested medium stacks;
@@ -41,5 +52,7 @@ shared wavefront renderer without demo-local medium construction.
 ## Validation
 
 - unit coverage for implicit medium derivation from volume inputs;
+- unit coverage for invalid `mediumRefId` fallback and single-slot nested-medium
+  fallback behavior;
 - stable packing tests for scene-object and material records;
 - renderer typecheck, build, lint, tests, and coverage.

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -810,6 +810,10 @@ export interface WavefrontPathTracingComputeFrameStats {
       maxFramePassesPerSubmission: number;
       queueOverflow: number;
       deviceLossStatus: "not-detected" | "pending" | "not-exposed" | "lost";
+      radianceDiagnostics: Readonly<{
+        invalidSamples: number;
+        legacyClampEquivalentSamples: number;
+      }>;
       memory: Readonly<{
         totalBytes: number;
         breakdown: WavefrontPathTracingMemoryEstimate | null;
@@ -844,6 +848,10 @@ export interface WavefrontPathTracingComputeFrameStats {
     totalLuminance: number;
     ambientResidualLuminance: number;
     ambientResidualShare: number;
+  }>;
+  readonly radianceDiagnostics?: Readonly<{
+    invalidSamples: number;
+    legacyClampEquivalentSamples: number;
   }>;
   readonly queueOverflow?: number;
 }

--- a/src/wavefront-compute.js
+++ b/src/wavefront-compute.js
@@ -47,6 +47,8 @@ const CONFIG_BUFFER_BYTES = 320;
 const COUNTER_DISPATCH_ARGS_OFFSET = 16;
 const INDIRECT_DISPATCH_ARGS_BYTES = 12;
 const COUNTER_BUFFER_BYTES = 64;
+const HALF_FLOAT_MAX = 65_504;
+const LEGACY_SAMPLE_RADIANCE_CLAMP = 4;
 const TERMINATION_LUMINANCE_SCALE = 1_000_000;
 const COUNTER_TERMINATION_EMISSIVE_OFFSET = 8;
 const COUNTER_TERMINATION_ENVIRONMENT_OFFSET = 9;
@@ -54,6 +56,8 @@ const COUNTER_TERMINATION_AMBIENT_MAX_DEPTH_OFFSET = 10;
 const COUNTER_TERMINATION_QUEUE_OVERFLOW_OFFSET = 11;
 const COUNTER_TERMINATION_AMBIENT_LUMINANCE_OFFSET = 12;
 const COUNTER_TERMINATION_TOTAL_LUMINANCE_OFFSET = 13;
+const COUNTER_RADIANCE_INVALID_OFFSET = 14;
+const COUNTER_RADIANCE_LEGACY_CLAMP_EQUIVALENT_OFFSET = 15;
 const TRACE_STORAGE_BUFFER_BINDINGS = 10;
 const BRDF_LUT_UPLOAD_CACHE = new Map();
 const HIT_TYPE_SURFACE = 0;
@@ -102,6 +106,10 @@ const EMPTY_TERMINATION_METRICS = Object.freeze({
     totalLuminance: 0,
     ambientResidualLuminance: 0,
     ambientResidualShare: 0,
+  }),
+  radianceDiagnostics: Object.freeze({
+    invalidSamples: 0,
+    legacyClampEquivalentSamples: 0,
   }),
 });
 
@@ -2919,12 +2927,31 @@ function coerceWavefrontVec3(value, fallback) {
   ];
 }
 
-function clampWavefrontSampleRadiance(value) {
+function sanitizeWavefrontLinearRadianceComponent(value) {
+  if (!Number.isFinite(value) || value <= 0) {
+    return 0;
+  }
+  return Math.min(value, HALF_FLOAT_MAX);
+}
+
+function sanitizeWavefrontLinearRadiance(value) {
   return [
-    clamp(Number(value?.[0]) || 0, 0, 4),
-    clamp(Number(value?.[1]) || 0, 0, 4),
-    clamp(Number(value?.[2]) || 0, 0, 4),
+    sanitizeWavefrontLinearRadianceComponent(value?.[0]),
+    sanitizeWavefrontLinearRadianceComponent(value?.[1]),
+    sanitizeWavefrontLinearRadianceComponent(value?.[2]),
   ];
+}
+
+function wavefrontSampleHasInvalidRadiance(value) {
+  return [value?.[0], value?.[1], value?.[2]].some(
+    (component) => !Number.isFinite(component) || component < 0
+  );
+}
+
+function wavefrontSampleExceedsLegacyClamp(value) {
+  return [value?.[0], value?.[1], value?.[2]].some(
+    (component) => Number.isFinite(component) && component > LEGACY_SAMPLE_RADIANCE_CLAMP
+  );
 }
 
 function fresnelSchlick(cosine, f0) {
@@ -3134,7 +3161,7 @@ function sunlitBaselineRadianceReference(configInput, normal) {
   const skyFacing = 0.35 + clamp(normal[1] * 0.5 + 0.5, 0, 1) * 0.65;
   const directionalWeight = 0.38 + sunFacing * 0.62;
   const sunTint = maxVec3(asVec3(config.environmentLighting?.sunColor, DEFAULT_ENVIRONMENT_LIGHTING.sunColor), [0, 0, 0]);
-  return clampWavefrontSampleRadiance(
+  return sanitizeWavefrontLinearRadiance(
     sunTint.map((value) => value * baseline * skyFacing * directionalWeight * 0.04)
   );
 }
@@ -3274,9 +3301,9 @@ export function computeWavefrontTerminalEnvironmentContributionReference(
     maxVec3(sunlitFloor, scale(glossyEnvironment, environmentInfluence))
   );
   const materialFloor = hit.materialKind === 0 || hit.materialKind === 3 ? 1 : 0.7;
-  const source = clampWavefrontSampleRadiance(scale(environmentFloor, materialFloor));
+  const source = sanitizeWavefrontLinearRadiance(scale(environmentFloor, materialFloor));
   const occlusion = mixScalar(0.75, 1, clamp(hit.occlusion, 0, 1));
-  const contribution = clampWavefrontSampleRadiance(
+  const contribution = sanitizeWavefrontLinearRadiance(
     scale(
       multiplyVec3(
         multiplyVec3(sanitizeWavefrontThroughput(throughputInput), maxVec3(hit.color, ambientColor)),
@@ -3288,6 +3315,14 @@ export function computeWavefrontTerminalEnvironmentContributionReference(
   return Object.freeze({
     source: Object.freeze(source),
     contribution: Object.freeze(contribution),
+    radianceDiagnostics: Object.freeze({
+      invalidSamples:
+        (wavefrontSampleHasInvalidRadiance(source) ? 1 : 0) +
+        (wavefrontSampleHasInvalidRadiance(contribution) ? 1 : 0),
+      legacyClampEquivalentSamples:
+        (wavefrontSampleExceedsLegacyClamp(source) ? 1 : 0) +
+        (wavefrontSampleExceedsLegacyClamp(contribution) ? 1 : 0),
+    }),
   });
 }
 
@@ -4128,8 +4163,8 @@ struct TerminationMetrics {
   ambientQueueOverflowCount: atomic<u32>,
   ambientResidualLuminanceScaled: atomic<u32>,
   totalTerminalLuminanceScaled: atomic<u32>,
-  _pad0: u32,
-  _pad1: u32,
+  invalidSampleCount: atomic<u32>,
+  legacyClampEquivalentCount: atomic<u32>,
 };
 
 const TERMINAL_SOURCE_KIND_EMISSIVE = 1u;
@@ -4454,7 +4489,7 @@ fn record_deferred_terminal_source(ray: RayRecord, sourceRadiance: vec3<f32>, so
     return;
   }
   pathVertices[path_vertex_index(ray.rayId, config.maxDepth)] =
-    vec4<f32>(clamp_sample_radiance(sourceRadiance), f32(sourceKind));
+    vec4<f32>(sanitize_linear_radiance(sourceRadiance), f32(sourceKind));
 }
 
 fn environment_map_uv(direction: vec3<f32>) -> vec2<f32> {
@@ -4968,11 +5003,14 @@ fn medium_transmittance(mediumRefId: u32, distance: f32) -> vec3<f32> {
 }
 
 fn transmitted_medium_ref_id(ray: RayRecord, hit: HitRecord) -> u32 {
-  if (hit.mediumRefId == 0u) {
+  if (!medium_valid(hit.mediumRefId)) {
     return ray.mediumRefId;
   }
   if (hit.frontFace == 1u) {
-    return hit.mediumRefId;
+    if (ray.mediumRefId == 0u || ray.mediumRefId == hit.mediumRefId) {
+      return hit.mediumRefId;
+    }
+    return ray.mediumRefId;
   }
   if (ray.mediumRefId == hit.mediumRefId) {
     return 0u;
@@ -5030,7 +5068,7 @@ fn sunlit_baseline_radiance(normal: vec3<f32>) -> vec3<f32> {
   let skyFacing = 0.35 + saturate(normal.y * 0.5 + 0.5) * 0.65;
   let directionalWeight = 0.38 + sunFacing * 0.62;
   let sunTint = max(config.environmentSunColor.xyz, vec3<f32>(0.0));
-  return clamp_sample_radiance(sunTint * baseline * skyFacing * directionalWeight * 0.04);
+  return sanitize_linear_radiance(sunTint * baseline * skyFacing * directionalWeight * 0.04);
 }
 
 fn terminal_surface_environment_source(ray: RayRecord, hit: HitRecord) -> vec3<f32> {
@@ -5068,7 +5106,7 @@ fn terminal_surface_environment_source(ray: RayRecord, hit: HitRecord) -> vec3<f
   );
   let environmentFloor = max(ambientFloor, max(sunlitFloor, glossyEnvironment * environmentInfluence));
   let materialFloor = select(0.7, 1.0, hit.materialKind == 0u || hit.materialKind == 3u);
-  return clamp_sample_radiance(environmentFloor * materialFloor);
+  return sanitize_linear_radiance(environmentFloor * materialFloor);
 }
 
 fn terminal_surface_environment_contribution(
@@ -5078,7 +5116,7 @@ fn terminal_surface_environment_contribution(
 ) -> vec3<f32> {
   let surfaceColor = max(hit.color.xyz, config.ambientColor.xyz);
   let occlusion = mix(0.75, 1.0, clamp(hit.occlusion, 0.0, 1.0));
-  return clamp_sample_radiance(
+  return sanitize_linear_radiance(
     throughput *
     surfaceColor *
     terminal_surface_environment_source(ray, hit) *
@@ -5282,7 +5320,7 @@ fn surface_direct_light_contribution(ray: RayRecord, hit: HitRecord) -> vec3<f32
     bsdf *
     incidentRadiance *
     (nDotL * misWeight / max(lightSample.pdf, 0.000001));
-  return clamp_sample_radiance(contribution);
+  return sanitize_linear_radiance(contribution);
 }
 
 fn default_mesh_range() -> MeshRange {
@@ -5869,8 +5907,37 @@ fn sample_weight() -> f32 {
   return max(config.projectionAndSampling.z, 0.000001);
 }
 
-fn clamp_sample_radiance(value: vec3<f32>) -> vec3<f32> {
-  return min(max(value, vec3<f32>(0.0)), vec3<f32>(4.0));
+fn sanitize_linear_radiance_component(value: f32) -> f32 {
+  let resolved = select(0.0, value, value == value);
+  return clamp(resolved, 0.0, 65504.0);
+}
+
+fn sanitize_linear_radiance(value: vec3<f32>) -> vec3<f32> {
+  return vec3<f32>(
+    sanitize_linear_radiance_component(value.x),
+    sanitize_linear_radiance_component(value.y),
+    sanitize_linear_radiance_component(value.z)
+  );
+}
+
+fn radiance_sample_is_invalid(value: vec3<f32>) -> bool {
+  return
+    value.x != value.x || value.y != value.y || value.z != value.z ||
+    value.x < 0.0 || value.y < 0.0 || value.z < 0.0 ||
+    abs(value.x) > 65504.0 || abs(value.y) > 65504.0 || abs(value.z) > 65504.0;
+}
+
+fn radiance_sample_exceeds_legacy_clamp(value: vec3<f32>) -> bool {
+  return value.x > 4.0 || value.y > 4.0 || value.z > 4.0;
+}
+
+fn record_radiance_diagnostics(sample: vec3<f32>) {
+  if (radiance_sample_is_invalid(sample)) {
+    atomicAdd(&counters.termination.invalidSampleCount, 1u);
+  }
+  if (radiance_sample_exceeds_legacy_clamp(sample)) {
+    atomicAdd(&counters.termination.legacyClampEquivalentCount, 1u);
+  }
 }
 
 fn tone_map_radiance(value: vec3<f32>) -> vec3<f32> {
@@ -5948,6 +6015,8 @@ fn generatePrimaryRays(@builtin(global_invocation_id) globalId: vec3<u32>) {
     atomicStore(&counters.termination.ambientQueueOverflowCount, 0u);
     atomicStore(&counters.termination.ambientResidualLuminanceScaled, 0u);
     atomicStore(&counters.termination.totalTerminalLuminanceScaled, 0u);
+    atomicStore(&counters.termination.invalidSampleCount, 0u);
+    atomicStore(&counters.termination.legacyClampEquivalentCount, 0u);
     write_active_dispatch_args(config.tilePixelCount);
   }
   if (index >= config.tilePixelCount) {
@@ -6297,8 +6366,9 @@ fn resolveSurfaceRecords(@builtin(global_invocation_id) globalId: vec3<u32>) {
         TERMINAL_SOURCE_KIND_EMISSIVE
       );
     } else {
-      contribution = clamp_sample_radiance(arrivingThroughput * sourceRadiance);
-      let weightedContribution = contribution * sample_weight();
+      let rawWeightedContribution = arrivingThroughput * sourceRadiance * sample_weight();
+      record_radiance_diagnostics(rawWeightedContribution);
+      let weightedContribution = sanitize_linear_radiance(rawWeightedContribution);
       record_termination_metrics(TERMINAL_SOURCE_KIND_EMISSIVE, weightedContribution);
       accumulation[ray.rayId] =
         accumulation[ray.rayId] + vec4<f32>(weightedContribution, 1.0);
@@ -6322,8 +6392,9 @@ fn resolveSurfaceRecords(@builtin(global_invocation_id) globalId: vec3<u32>) {
         TERMINAL_SOURCE_KIND_ENVIRONMENT
       );
     } else {
-      contribution = clamp_sample_radiance(arrivingThroughput * sourceRadiance);
-      let weightedContribution = contribution * sample_weight();
+      let rawWeightedContribution = arrivingThroughput * sourceRadiance * sample_weight();
+      record_radiance_diagnostics(rawWeightedContribution);
+      let weightedContribution = sanitize_linear_radiance(rawWeightedContribution);
       record_termination_metrics(TERMINAL_SOURCE_KIND_ENVIRONMENT, weightedContribution);
       accumulation[ray.rayId] =
         accumulation[ray.rayId] + vec4<f32>(weightedContribution, 1.0);
@@ -6350,8 +6421,11 @@ fn resolveSurfaceRecords(@builtin(global_invocation_id) globalId: vec3<u32>) {
       ),
       hit
     );
+    let rawDirectLight = directLight * sample_weight();
+    record_radiance_diagnostics(rawDirectLight);
+    let weightedDirectLight = sanitize_linear_radiance(rawDirectLight);
     accumulation[ray.rayId] =
-      accumulation[ray.rayId] + vec4<f32>(directLight * sample_weight(), 0.0);
+      accumulation[ray.rayId] + vec4<f32>(weightedDirectLight, 0.0);
   }
 
   if (ray.bounce + 1u >= config.maxDepth) {
@@ -6367,7 +6441,9 @@ fn resolveSurfaceRecords(@builtin(global_invocation_id) globalId: vec3<u32>) {
         arrivingThroughput,
         hit
       );
-      let weightedContribution = terminalEnvironment * sample_weight();
+      let rawWeightedContribution = terminalEnvironment * sample_weight();
+      record_radiance_diagnostics(rawWeightedContribution);
+      let weightedContribution = sanitize_linear_radiance(rawWeightedContribution);
       record_termination_metrics(TERMINAL_SOURCE_KIND_AMBIENT_MAX_DEPTH, weightedContribution);
       accumulation[ray.rayId] =
         accumulation[ray.rayId] + vec4<f32>(weightedContribution, 1.0);
@@ -6400,7 +6476,9 @@ fn resolveSurfaceRecords(@builtin(global_invocation_id) globalId: vec3<u32>) {
         arrivingThroughput,
         hit
       );
-      let weightedContribution = terminalEnvironment * sample_weight();
+      let rawWeightedContribution = terminalEnvironment * sample_weight();
+      record_radiance_diagnostics(rawWeightedContribution);
+      let weightedContribution = sanitize_linear_radiance(rawWeightedContribution);
       record_termination_metrics(TERMINAL_SOURCE_KIND_AMBIENT_MAX_DEPTH, weightedContribution);
       accumulation[ray.rayId] =
         accumulation[ray.rayId] + vec4<f32>(weightedContribution, 1.0);
@@ -6422,7 +6500,9 @@ fn resolveSurfaceRecords(@builtin(global_invocation_id) globalId: vec3<u32>) {
         arrivingThroughput,
         hit
       );
-      let weightedContribution = overflowEnvironment * sample_weight();
+      let rawWeightedContribution = overflowEnvironment * sample_weight();
+      record_radiance_diagnostics(rawWeightedContribution);
+      let weightedContribution = sanitize_linear_radiance(rawWeightedContribution);
       record_termination_metrics(
         TERMINAL_SOURCE_KIND_AMBIENT_QUEUE_OVERFLOW,
         weightedContribution
@@ -6480,7 +6560,7 @@ fn resolve_deferred_path_radiance(rayId: u32) -> vec3<f32> {
       radiance = radiance * throughput.xyz;
     }
   }
-  return clamp_sample_radiance(radiance);
+  return sanitize_linear_radiance(radiance);
 }
 
 @compute @workgroup_size(64)
@@ -6496,14 +6576,17 @@ fn accumulateTerminalRadiance(@builtin(global_invocation_id) globalId: vec3<u32>
   if (deferred_path_resolve_enabled()) {
     let terminal = pathVertices[path_vertex_index(index, config.maxDepth)];
     let resolved = resolve_deferred_path_radiance(index) * sample_weight();
-    record_termination_metrics(u32(terminal.w), resolved);
-    radiance = clamp_sample_radiance(radiance + resolved);
+    record_radiance_diagnostics(resolved);
+    let safeResolved = sanitize_linear_radiance(resolved);
+    record_termination_metrics(u32(terminal.w), safeResolved);
+    radiance = sanitize_linear_radiance(radiance + safeResolved);
     accumulation[index] = vec4<f32>(radiance, 1.0);
   }
 
-  textureStore(radianceImage, pixel, vec4<f32>(radiance, 1.0));
+  let linearOutput = sanitize_linear_radiance(radiance);
+  textureStore(radianceImage, pixel, vec4<f32>(linearOutput, 1.0));
   if (config.denoise == 0u) {
-    textureStore(outputImage, pixel, vec4<f32>(tone_map_radiance(radiance), 1.0));
+    textureStore(outputImage, pixel, vec4<f32>(tone_map_radiance(linearOutput), 1.0));
   }
 }
 
@@ -7540,6 +7623,9 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
     const totalLuminance =
       (countersView[COUNTER_TERMINATION_TOTAL_LUMINANCE_OFFSET] ?? 0) /
       TERMINATION_LUMINANCE_SCALE;
+    const invalidSamples = countersView[COUNTER_RADIANCE_INVALID_OFFSET] ?? 0;
+    const legacyClampEquivalentSamples =
+      countersView[COUNTER_RADIANCE_LEGACY_CLAMP_EQUIVALENT_OFFSET] ?? 0;
     const ambientResidualShare =
       totalLuminance > 0 ? ambientResidualLuminance / totalLuminance : 0;
     return Object.freeze({
@@ -7554,6 +7640,10 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
         totalLuminance,
         ambientResidualLuminance,
         ambientResidualShare,
+      }),
+      radianceDiagnostics: Object.freeze({
+        invalidSamples,
+        legacyClampEquivalentSamples,
       }),
     });
   }
@@ -8215,6 +8305,7 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
       bounces: [],
       termination: terminationMetrics.termination,
       terminalRadiance: terminationMetrics.terminalRadiance,
+      radianceDiagnostics: terminationMetrics.radianceDiagnostics,
       queueOverflow: terminationMetrics.queueOverflow,
     });
     return Object.freeze({

--- a/src/wavefront-frame-runtime.js
+++ b/src/wavefront-frame-runtime.js
@@ -176,6 +176,14 @@ export function createWavefrontTransportGuardrailSummary(frameStats, options = {
     options.deviceLossStatus ?? frameStats?.deviceLossStatus,
     awaitedGpuCompletion
   )
+  const invalidSamples = Math.max(
+    0,
+    Number(frameStats?.radianceDiagnostics?.invalidSamples ?? 0)
+  )
+  const legacyClampEquivalentSamples = Math.max(
+    0,
+    Number(frameStats?.radianceDiagnostics?.legacyClampEquivalentSamples ?? 0)
+  )
   const memory = summarizeWavefrontMemory(frameStats?.memory)
   const checks = Object.freeze([
     createTransportGuardrailCheck(
@@ -209,6 +217,15 @@ export function createWavefrontTransportGuardrailSummary(frameStats, options = {
           ? `Only ${completedPerSubmission.toFixed(2)} GPU jobs completed per command submission despite a ${maxFramePassesPerSubmission}-pass ceiling.`
           : `${completedPerFrame} GPU jobs completed across ${commandSubmissions} command submissions (${completedPerSubmission.toFixed(2)} jobs/submission).`
     ),
+    createTransportGuardrailCheck(
+      "radiance-diagnostics",
+      invalidSamples > 0 ? "fail" : legacyClampEquivalentSamples > 0 ? "warn" : "pass",
+      invalidSamples > 0
+        ? `Renderer recorded ${invalidSamples} invalid radiance sample(s); inspect transport math before trusting the frame.`
+        : legacyClampEquivalentSamples > 0
+          ? `${legacyClampEquivalentSamples} weighted sample(s) exceeded the legacy 4.0 preview clamp threshold; convergence stayed unbiased, but review firefly diagnostics before rollout.`
+          : "No invalid radiance samples or legacy-clamp-equivalent fireflies were recorded."
+    ),
   ])
   const status = checks.some((check) => check.status === "fail")
     ? "fail"
@@ -228,6 +245,10 @@ export function createWavefrontTransportGuardrailSummary(frameStats, options = {
       maxFramePassesPerSubmission,
       queueOverflow,
       deviceLossStatus,
+      radianceDiagnostics: Object.freeze({
+        invalidSamples,
+        legacyClampEquivalentSamples,
+      }),
       memory,
     }),
     checks,

--- a/tests/package.test.js
+++ b/tests/package.test.js
@@ -329,7 +329,11 @@ test("wavefront transport guardrails summarize throughput memory and queue healt
   assert.equal(guardrails.current.commandSubmissions, 2);
   assert.equal(guardrails.current.memory.totalBytes, 3200);
   assert.equal(guardrails.current.deviceLossStatus, "not-detected");
-  assert.equal(guardrails.checks.length, 3);
+  assert.deepEqual(guardrails.current.radianceDiagnostics, {
+    invalidSamples: 0,
+    legacyClampEquivalentSamples: 0,
+  });
+  assert.equal(guardrails.checks.length, 4);
   assert.ok(guardrails.checks.every((check) => check.status === "pass"));
   assert.match(
     guardrails.checks.find((check) => check.id === "submission-batching").details,
@@ -359,6 +363,41 @@ test("wavefront transport guardrails warn when queue overflow or pending complet
   assert.ok(guardrails.checks.some((check) => check.id === "queue-overflow" && check.status === "warn"));
   assert.ok(
     guardrails.checks.some((check) => check.id === "submission-batching" && check.status === "warn")
+  );
+});
+
+test("wavefront transport guardrails surface invalid and legacy-clamp-equivalent radiance samples", () => {
+  const guardrails = createWavefrontTransportGuardrailSummary({
+    commandSubmissions: 1,
+    maxFramePassesPerSubmission: 4,
+    queueOverflow: 0,
+    radianceDiagnostics: {
+      invalidSamples: 1,
+      legacyClampEquivalentSamples: 3,
+    },
+    gpuWorkerJobs: {
+      completedPerFrame: 4,
+      completedPerSecond: 80,
+      completedPerSubmission: 4,
+      directDispatchesCompleted: 4,
+      indirectDispatchesCompleted: 0,
+      frameTimeMs: 50,
+      awaitedGpuCompletion: true,
+    },
+  });
+
+  assert.equal(guardrails.status, "fail");
+  assert.deepEqual(guardrails.current.radianceDiagnostics, {
+    invalidSamples: 1,
+    legacyClampEquivalentSamples: 3,
+  });
+  assert.ok(
+    guardrails.checks.some(
+      (check) =>
+        check.id === "radiance-diagnostics" &&
+        check.status === "fail" &&
+        /invalid radiance sample/.test(check.details)
+    )
   );
 });
 

--- a/tests/wavefront-compute.test.js
+++ b/tests/wavefront-compute.test.js
@@ -836,7 +836,11 @@ test("wavefront compute samples all-material direct light with MIS before random
   );
   assert.match(
     source,
-    /accumulation\[ray\.rayId\] =\s+accumulation\[ray\.rayId\] \+\s+vec4<f32>\(directLight \* sample_weight\(\), 0\.0\);/
+    /let rawDirectLight = directLight \* sample_weight\(\);/
+  );
+  assert.match(
+    source,
+    /accumulation\[ray\.rayId\] =\s+accumulation\[ray\.rayId\] \+\s+vec4<f32>\(weightedDirectLight, 0\.0\);/
   );
   assert.ok(
     source.indexOf("let shouldEstimateDirectLight =") <
@@ -957,15 +961,15 @@ test("wavefront BSDF numeric helpers keep furnace-style reflectance bounded", ()
   });
 });
 
-test("wavefront terminal environment helpers clamp residuals and keep invalid inputs finite", () => {
+test("wavefront terminal environment helpers preserve HDR residuals and keep invalid inputs finite", () => {
   const config = createWavefrontPathTracingComputeConfig({
     width: 16,
     height: 16,
     ambientColor: [0.24, 0.26, 0.3, 1],
     environmentLighting: {
-      sunlitBaseline: 1.8,
-      intensity: 2.4,
-      sunColor: [3.6, 3.3, 2.9, 1],
+      sunlitBaseline: 8,
+      intensity: 3.5,
+      sunColor: [12, 10, 8, 1],
     },
   });
   const hit = {
@@ -993,13 +997,12 @@ test("wavefront terminal environment helpers clamp residuals and keep invalid in
   bounded.source.forEach((value) => {
     assert.ok(Number.isFinite(value));
     assert.ok(value >= 0);
-    assert.ok(value <= 4);
   });
   bounded.contribution.forEach((value) => {
     assert.ok(Number.isFinite(value));
     assert.ok(value >= 0);
-    assert.ok(value <= 4);
   });
+  assert.ok(Math.max(...bounded.source, ...bounded.contribution) > 4);
 
   const invalid = computeWavefrontTerminalEnvironmentContributionReference(
     config,
@@ -1060,16 +1063,36 @@ test("wavefront compute defers visible colour until terminal path resolve", () =
   assert.match(source, /let resolved = resolve_deferred_path_radiance\(index\) \* sample_weight\(\);/);
   assert.match(
     source,
-    /accumulation\[ray\.rayId\] =\s+accumulation\[ray\.rayId\] \+\s+vec4<f32>\(directLight \* sample_weight\(\), 0\.0\);/
+    /let rawDirectLight = directLight \* sample_weight\(\);/
   );
   assert.match(source, /if \(config\.deferredPathResolve\) \{/);
   assert.match(source, /createGpuSubmissionBatcher\(\{/);
   assert.match(source, /encodeTileOutput\(batch\.reserve\(1\), tile, configOffset, parallelism\);/);
 });
 
+test("wavefront compute records radiance diagnostics instead of silently applying the legacy sample clamp", () => {
+  const source = readRendererSource();
+  const types = readRendererTypes();
+
+  assert.match(source, /fn record_radiance_diagnostics\(sample: vec3<f32>\)/);
+  assert.match(source, /invalidSampleCount: atomic<u32>/);
+  assert.match(source, /legacyClampEquivalentCount: atomic<u32>/);
+  assert.match(source, /record_radiance_diagnostics\(rawWeightedContribution\);/);
+  assert.match(source, /record_radiance_diagnostics\(resolved\);/);
+  assert.doesNotMatch(source, /contribution = clamp_sample_radiance\(/);
+  assert.doesNotMatch(source, /radiance = clamp_sample_radiance\(radiance \+ resolved\);/);
+  assert.match(types, /readonly radianceDiagnostics\?: Readonly<\{/);
+  assert.match(types, /invalidSamples: number;/);
+  assert.match(types, /legacyClampEquivalentSamples: number;/);
+});
+
 test("wavefront compute exposes medium-table contracts and Beer-Lambert transport hooks", () => {
   const source = readRendererSource();
   const types = readRendererTypes();
+  const mediumDesign = readFileSync(
+    new URL("../docs/design/wavefront-volume-medium-transport.md", import.meta.url),
+    "utf8"
+  );
   const config = createWavefrontPathTracingComputeConfig({
     width: 32,
     height: 32,
@@ -1104,6 +1127,13 @@ test("wavefront compute exposes medium-table contracts and Beer-Lambert transpor
   assert.match(source, /fn medium_transmittance\(mediumRefId: u32, distance: f32\) -> vec3<f32>/);
   assert.match(source, /exp\(-extinction\.x \* distance\)/);
   assert.match(source, /fn transmitted_medium_ref_id\(ray: RayRecord, hit: HitRecord\) -> u32/);
+  assert.match(source, /if \(!medium_valid\(hit\.mediumRefId\)\) \{\s+return ray\.mediumRefId;\s+\}/);
+  assert.match(
+    source,
+    /if \(hit\.frontFace == 1u\) \{\s+if \(ray\.mediumRefId == 0u \|\| ray\.mediumRefId == hit\.mediumRefId\) \{\s+return hit\.mediumRefId;\s+\}\s+return ray\.mediumRefId;\s+\}/
+  );
+  assert.match(mediumDesign, /single active medium/i);
+  assert.match(mediumDesign, /nested medium stacks fall back to the current ray medium/i);
   assert.equal(config.mediumCount, 2);
   assert.deepEqual(config.mediums.map((medium) => medium.id), [0, 3]);
   assert.equal(config.gpuMeshSource.meshes.records[0].thickness, 0.35);


### PR DESCRIPTION
## Summary
- preserve unclamped HDR linear radiance accumulation while sanitizing only invalid or half-float-overflow samples
- expose radiance diagnostics in frame stats and transport guardrails instead of silently applying the legacy 4.0 clamp
- preserve the current ray medium when medium ids are invalid or nested-medium stack semantics are unavailable

## Testing
- node --test tests/wavefront-compute.test.js
- node --test tests/package.test.js
- npm run typecheck
- npm run build
- npm run test:coverage

Closes #64
Closes #65