### PR TITLE
[codex] add wavefront sample dimensions and denoise gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,16 +12,20 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 - **Added**
-  - (placeholder)
+  - Added a named wavefront sample-dimension registry plus low-discrepancy 2D
+    sampling helpers for camera jitter, BSDF continuation, and direct/emissive
+    light selection.
+  - Added machine-checkable high-SPP denoise-independence thresholds for
+    structural artifacts, invalid samples, baseline noise, and sheen/chrome/wood
+    detail retention.
 
 - **Changed**
-  - (placeholder)
+  - Changed wavefront jitter/light sampling to use explicit sample-dimension
+    constants instead of ad hoc numeric offsets in shader code.
 
 - **Fixed**
-  - (placeholder)
-
-- **Security**
-  - (placeholder)
+  - Prevented denoise-on output from qualifying a high-SPP validation report
+    when the paired denoise-off result still contains structural artifacts.
 
 ## [0.2.18] - 2026-06-22
 

--- a/README.md
+++ b/README.md
@@ -234,7 +234,16 @@ linear radiance to an `rgba16float` texture first, then runs a two-stage
 full-frame GPU denoise through an `rgba16float` scratch texture before final
 tone mapping into the presented `rgba8unorm` output. Filtering in linear
 radiance space lets the denoise pass cross tile boundaries without compressing
-energy/detail before the final resolve. The renderer also stores compact
+energy/detail before the final resolve. High-SPP wavefront sampling now routes
+camera jitter, BSDF continuation, emissive-light selection, and environment
+selection through named sample dimensions in
+`src/wavefront-sampling-dimensions.js`, using low-discrepancy 2D pairs where
+they improve convergence without adding CPU-side sample tables. The companion
+`src/wavefront-denoise-validation.js` acceptance helper keeps denoise-off
+validation explicit with structural-artifact, invalid-sample, baseline-noise,
+and sheen/chrome/wood detail-retention thresholds so the
+`renderer.denoise.highSppIndependence` rollout can stay reviewable and
+rollbackable. The renderer also stores compact
 emissive-triangle metadata in the existing BVH buffer tail and uses it to guide
 diffuse continuation rays toward finite mesh light geometry. This is not a
 separate shadow/direct-light pass: the active ray still has to hit emissive

--- a/docs/adrs/adr-0019-wavefront-sample-dimensions-and-denoise-independence.md
+++ b/docs/adrs/adr-0019-wavefront-sample-dimensions-and-denoise-independence.md
@@ -1,0 +1,68 @@
+# ADR 0019: Wavefront Sample Dimensions and Denoise-Independence Gates
+
+## Status
+
+Accepted
+
+## Context
+
+Task `Plasius-LTD/gpu-renderer#66` requires the renderer to stop relying on ad
+hoc numeric seed offsets for camera jitter, light selection, and BSDF sampling.
+Task `Plasius-LTD/gpu-renderer#67` requires denoise-off high-SPP validation to
+become machine-checkable so denoise cannot hide structural transport failures.
+
+Before this change:
+
+- WGSL call sites embedded raw dimension integers directly into `mix_seed(...)`
+  or `seed + N` expressions.
+- Reviewers could not easily see whether two sampling sites reused a dimension
+  accidentally.
+- High-SPP denoise validation existed only as implicit harness expectations
+  spread across renderer and lighting discussions.
+
+## Decision
+
+`@plasius/gpu-renderer` now treats sampling dimensions and denoise-independence
+rules as explicit, testable renderer contracts:
+
+- `src/wavefront-sampling-dimensions.js` owns the canonical dimension registry.
+- WGSL imports those named constants and uses shared `sample_dimension_1d(...)`
+  / `sample_dimension_2d(...)` helpers instead of raw numeric offsets.
+- 2D camera/jitter/light samples use a shader-cheap low-discrepancy pair built
+  from stratified X plus Van der Corput Y, both scrambled by the canonical
+  dimension seed.
+- `src/wavefront-denoise-validation.js` owns the acceptance thresholds for
+  denoise-off structural artifacts, invalid-sample share, baseline noise
+  regression, and sheen/chrome/wood detail retention.
+
+## Alternatives Considered
+
+- Keep hashed random sampling but rename only the existing integers.
+  Rejected because it leaves high-value 2D sampling sites without any
+  convergence improvement.
+- Introduce CPU-generated blue-noise tables.
+  Rejected because the task explicitly requires shader-cheap sampling and no
+  CPU-side sampling textures/tables.
+- Leave denoise-independence checks in ad hoc markdown or issue comments.
+  Rejected because release gates need deterministic, versioned thresholds.
+
+## Consequences
+
+- Camera jitter, guided light picks, BSDF lobe sampling, emissive triangle
+  barycentrics, and direct-environment selection now expose their sampling
+  intent by name.
+- Review/test failures catch duplicate or missing dimensions before they become
+  visual regressions.
+- Renderer validation can reject a denoise-on "pass" when the paired
+  denoise-off result still contains structural artifacts or excessive material
+  blur.
+- Future sampling sites should extend the registry first rather than reusing
+  raw numbers inline.
+
+## Validation Baseline
+
+- `node --test tests/wavefront-compute.test.js`
+- `npm run test:coverage`
+- `npm run lint`
+- `npm run typecheck`
+- `npm run build`

--- a/src/wavefront-denoise-validation.js
+++ b/src/wavefront-denoise-validation.js
@@ -1,0 +1,96 @@
+const measuredMaterials = Object.freeze(["sheen", "chrome", "wood"]);
+
+export const defaultHighSppDenoiseAcceptanceThresholds = Object.freeze({
+  maxStructuralArtifactShare: 0,
+  maxInvalidSampleShare: 0,
+  maxNoiseVsBaselineRatio: 1,
+  minDetailRetentionRatio: 0.92,
+  measuredMaterials,
+});
+
+function readShare(name, value) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric) || numeric < 0) {
+    throw new Error(`${name} must be a non-negative finite number.`);
+  }
+  return numeric;
+}
+
+function readDetailContrast(source, material) {
+  const numeric = Number(source?.[material]);
+  if (!Number.isFinite(numeric) || numeric <= 0) {
+    throw new Error(`${material} detail contrast must be a positive finite number.`);
+  }
+  return numeric;
+}
+
+export function evaluateHighSppDenoiseAcceptance(
+  report,
+  thresholds = defaultHighSppDenoiseAcceptanceThresholds
+) {
+  const denoiseOffStructuralArtifactShare = readShare(
+    "denoiseOff.structuralArtifactShare",
+    report?.denoiseOff?.structuralArtifactShare
+  );
+  const denoiseOffInvalidSampleShare = readShare(
+    "denoiseOff.invalidSampleShare",
+    report?.denoiseOff?.invalidSampleShare
+  );
+  const denoiseOffNoise = readShare(
+    "denoiseOff.luminanceStdDev",
+    report?.denoiseOff?.luminanceStdDev
+  );
+  const baselineNoise = readShare(
+    "baselineDenoiseOff.luminanceStdDev",
+    report?.baselineDenoiseOff?.luminanceStdDev
+  );
+  const denoiseOnStructuralArtifactShare = readShare(
+    "denoiseOn.structuralArtifactShare",
+    report?.denoiseOn?.structuralArtifactShare
+  );
+
+  const failures = [];
+  if (denoiseOffStructuralArtifactShare > thresholds.maxStructuralArtifactShare) {
+    failures.push(
+      `denoise-off structural artifact share ${denoiseOffStructuralArtifactShare} exceeded ${thresholds.maxStructuralArtifactShare}.`
+    );
+    if (denoiseOnStructuralArtifactShare <= thresholds.maxStructuralArtifactShare) {
+      failures.push("denoise-on output cannot mask a failing denoise-off structural artifact.");
+    }
+  }
+  if (denoiseOffInvalidSampleShare > thresholds.maxInvalidSampleShare) {
+    failures.push(
+      `denoise-off invalid sample share ${denoiseOffInvalidSampleShare} exceeded ${thresholds.maxInvalidSampleShare}.`
+    );
+  }
+
+  const noiseVsBaselineRatio = baselineNoise === 0 ? 1 : denoiseOffNoise / baselineNoise;
+  if (noiseVsBaselineRatio > thresholds.maxNoiseVsBaselineRatio) {
+    failures.push(
+      `denoise-off noise ratio ${noiseVsBaselineRatio.toFixed(4)} exceeded ${thresholds.maxNoiseVsBaselineRatio}.`
+    );
+  }
+
+  const detailRetention = Object.fromEntries(
+    thresholds.measuredMaterials.map((material) => {
+      const denoiseOffDetail = readDetailContrast(report?.denoiseOff?.detailContrast, material);
+      const denoiseOnDetail = readDetailContrast(report?.denoiseOn?.detailContrast, material);
+      const retentionRatio = denoiseOnDetail / denoiseOffDetail;
+      if (retentionRatio < thresholds.minDetailRetentionRatio) {
+        failures.push(
+          `${material} detail retention ${retentionRatio.toFixed(4)} fell below ${thresholds.minDetailRetentionRatio}.`
+        );
+      }
+      return [material, retentionRatio];
+    })
+  );
+
+  return Object.freeze({
+    pass: failures.length === 0,
+    failures: Object.freeze(failures),
+    denoiseOffStructuralArtifactShare,
+    denoiseOffInvalidSampleShare,
+    noiseVsBaselineRatio,
+    detailRetention: Object.freeze(detailRetention),
+  });
+}

--- a/src/wavefront-reference.js
+++ b/src/wavefront-reference.js
@@ -6,15 +6,17 @@ import {
   clamp,
   cross,
   dot,
-  mixSeed,
   normalize,
-  random01FromSeed,
   readFiniteNumber,
   readNonNegativeInteger,
   readPositiveInteger,
   scale,
   subtract,
 } from "./wavefront-core.js";
+import {
+  sampleWavefrontDimension2D,
+  WAVEFRONT_SAMPLE_DIMENSIONS,
+} from "./wavefront-sampling-dimensions.js";
 import {
   distributionGgx,
   geometrySmith,
@@ -120,8 +122,14 @@ export function createWavefrontReferenceRay(config, options = {}) {
   const pixelX = tile.x + localX;
   const pixelY = tile.y + localY;
   const sourcePixelId = pixelY * config.width + pixelX;
-  const jitterX = random01FromSeed(mixSeed(sourcePixelId, sampleIndex, 0, frameIndex, 1)) - 0.5;
-  const jitterY = random01FromSeed(mixSeed(sourcePixelId, sampleIndex, 0, frameIndex, 2)) - 0.5;
+  const [jitterX, jitterY] = sampleWavefrontDimension2D(
+    sourcePixelId,
+    sampleIndex,
+    0,
+    frameIndex,
+    WAVEFRONT_SAMPLE_DIMENSIONS.cameraJitter,
+    config.samplesPerPixel ?? 1
+  ).map((value) => value - 0.5);
   const ndcX = ((pixelX + 0.5 + jitterX * jitterScale) / config.width) * 2 - 1;
   const ndcY = 1 - ((pixelY + 0.5 + jitterY * jitterScale) / config.height) * 2;
   const viewX = ndcX * config.camera.tanHalfFovY * config.camera.aspect;

--- a/src/wavefront-sampling-dimensions.js
+++ b/src/wavefront-sampling-dimensions.js
@@ -1,0 +1,90 @@
+import { hashUint32, mixSeed, random01FromSeed } from "./wavefront-core.js";
+
+const sampleDimensionEntries = Object.freeze([
+  ["cameraJitter", 1],
+  ["transmissionSelector", 11],
+  ["guidedLightSelector", 12],
+  ["guidedEmissiveSelection", 13],
+  ["guidedEmissiveSurface", 14],
+  ["guidedPortalSelection", 15],
+  ["guidedPortalSurface", 16],
+  ["bsdfLobeSelector", 21],
+  ["diffuseHemisphere", 22],
+  ["specularHalfVector", 23],
+  ["clearcoatHalfVector", 24],
+  ["fallbackHemisphere", 25],
+  ["emissiveLightSelection", 31],
+  ["emissiveLightSurface", 32],
+  ["directLightSelector", 41],
+  ["directEnvironment", 42],
+]);
+
+function toWgslConstName(name) {
+  return `SAMPLE_DIM_${name.replace(/([a-z0-9])([A-Z])/g, "$1_$2").toUpperCase()}`;
+}
+
+const usedDimensions = new Set();
+for (const [, dimension] of sampleDimensionEntries) {
+  if (usedDimensions.has(dimension)) {
+    throw new Error(`Duplicate wavefront sample dimension ${dimension}.`);
+  }
+  usedDimensions.add(dimension);
+}
+
+export const WAVEFRONT_SAMPLE_DIMENSIONS = Object.freeze(
+  Object.fromEntries(sampleDimensionEntries)
+);
+
+export function listWavefrontSampleDimensions() {
+  return sampleDimensionEntries.map(([name, dimension]) =>
+    Object.freeze({
+      name,
+      dimension,
+      wgslName: toWgslConstName(name),
+    })
+  );
+}
+
+export const WAVEFRONT_SAMPLE_DIMENSIONS_WGSL = listWavefrontSampleDimensions()
+  .map(({ wgslName, dimension }) => `const ${wgslName}: u32 = ${dimension}u;`)
+  .join("\n");
+
+function fract(value) {
+  return value - Math.floor(value);
+}
+
+export function radicalInverseVdc(value) {
+  let bits = value >>> 0;
+  bits = ((bits << 16) | (bits >>> 16)) >>> 0;
+  bits = (((bits & 0x55555555) << 1) | ((bits & 0xaaaaaaaa) >>> 1)) >>> 0;
+  bits = (((bits & 0x33333333) << 2) | ((bits & 0xcccccccc) >>> 2)) >>> 0;
+  bits = (((bits & 0x0f0f0f0f) << 4) | ((bits & 0xf0f0f0f0) >>> 4)) >>> 0;
+  bits = (((bits & 0x00ff00ff) << 8) | ((bits & 0xff00ff00) >>> 8)) >>> 0;
+  return bits / 0x100000000;
+}
+
+export function sampleWavefrontDimension1D(pixelId, sampleId, bounce, frameIndex, dimension) {
+  return random01FromSeed(mixSeed(pixelId, sampleId, bounce, frameIndex, dimension));
+}
+
+export function sampleWavefrontDimension2D(
+  pixelId,
+  sampleId,
+  bounce,
+  frameIndex,
+  dimension,
+  strataCount
+) {
+  const strata = Math.max(1, Number.isFinite(strataCount) ? Math.trunc(strataCount) : 1);
+  const jitter = sampleWavefrontDimension1D(
+    pixelId,
+    sampleId,
+    bounce,
+    frameIndex,
+    dimension
+  );
+  const scramble = hashUint32(mixSeed(pixelId, sampleId, bounce, frameIndex, dimension));
+  const stratified = fract((((sampleId >>> 0) % strata) + jitter) / strata);
+  const lowDiscrepancy = fract(radicalInverseVdc((sampleId >>> 0) ^ scramble) + jitter);
+  return Object.freeze([stratified, lowDiscrepancy]);
+}

--- a/src/wavefront-shader-bvh.js
+++ b/src/wavefront-shader-bvh.js
@@ -259,8 +259,16 @@ fn make_ray(pixelIndex: u32) -> RayRecord {
   let py = config.tileY + localY;
   let sampleId = u32(config.projectionAndSampling.w);
   let sourcePixelId = py * config.canvasWidth + px;
-  let jitterX = random01(mix_seed(sourcePixelId, sampleId, 0u, config.frameIndex, 1u)) - 0.5;
-  let jitterY = random01(mix_seed(sourcePixelId, sampleId, 0u, config.frameIndex, 2u)) - 0.5;
+  let jitter = sample_dimension_2d(
+    sourcePixelId,
+    sampleId,
+    0u,
+    config.frameIndex,
+    SAMPLE_DIM_CAMERA_JITTER,
+    config.samplesPerPixel
+  ) - vec2<f32>(0.5);
+  let jitterX = jitter.x;
+  let jitterY = jitter.y;
   let ndcX = ((f32(px) + 0.5 + jitterX * 0.35) / f32(config.canvasWidth)) * 2.0 - 1.0;
   let ndcY = 1.0 - ((f32(py) + 0.5 + jitterY * 0.35) / f32(config.canvasHeight)) * 2.0;
   let viewX = ndcX * config.projectionAndSampling.x * config.projectionAndSampling.y;

--- a/src/wavefront-shader-kernels.js
+++ b/src/wavefront-shader-kernels.js
@@ -299,13 +299,6 @@ fn offset_origin(
   return position + offsetNormal * offsetDistance;
 }
 
-fn random_unit_vector(seed: u32) -> vec3<f32> {
-  let z = random01(seed) * 2.0 - 1.0;
-  let a = random01(seed + 11u) * 6.28318530718;
-  let r = sqrt(max(0.0, 1.0 - z * z));
-  return vec3<f32>(r * cos(a), r * sin(a), z);
-}
-
 fn schlick(cosine: f32, refractionRatio: f32) -> f32 {
   var r0 = (1.0 - refractionRatio) / (1.0 + refractionRatio);
   r0 = r0 * r0;
@@ -327,30 +320,63 @@ fn surface_supports_direct_lighting(hit: HitRecord) -> bool {
   return !(deltaMetal || refractive);
 }
 
-fn sample_emissive_triangle_direction(hit: HitRecord, seed: u32, fallback: vec3<f32>) -> vec3<f32> {
-  let lightSample = sample_emissive_triangle_light(hit, seed);
+fn sample_emissive_triangle_direction(
+  hit: HitRecord,
+  pixelId: u32,
+  sampleId: u32,
+  bounce: u32,
+  frameIndex: u32,
+  fallback: vec3<f32>
+) -> vec3<f32> {
+  let lightSample = sample_emissive_triangle_light(
+    hit,
+    pixelId,
+    sampleId,
+    bounce,
+    frameIndex,
+    SAMPLE_DIM_GUIDED_EMISSIVE_SELECTION,
+    SAMPLE_DIM_GUIDED_EMISSIVE_SURFACE
+  );
   if (lightSample.valid == 0u) {
     return fallback;
   }
   return safe_normalize(lightSample.direction.xyz, fallback);
 }
 
-fn sample_environment_portal_direction(hit: HitRecord, seed: u32, fallback: vec3<f32>) -> vec3<f32> {
+fn sample_environment_portal_direction(
+  hit: HitRecord,
+  pixelId: u32,
+  sampleId: u32,
+  bounce: u32,
+  frameIndex: u32,
+  fallback: vec3<f32>
+) -> vec3<f32> {
   if (config.environmentPortalCount == 0u || config.environmentPortalMode == 0u) {
     return fallback;
   }
   let portalSlot = min(
-    u32(random01(seed + 211u) * f32(config.environmentPortalCount)),
+    u32(
+      sample_dimension_1d(pixelId, sampleId, bounce, frameIndex, SAMPLE_DIM_GUIDED_PORTAL_SELECTION) *
+      f32(config.environmentPortalCount)
+    ),
     config.environmentPortalCount - 1u
   );
   let portal = environmentPortals[portalSlot];
-  let u = (random01(seed + 223u) * 2.0 - 1.0) * portal.tangent.w;
-  let v = (random01(seed + 227u) * 2.0 - 1.0) * portal.bitangent.w;
+  let portalUv = sample_dimension_2d(
+    pixelId,
+    sampleId,
+    bounce,
+    frameIndex,
+    SAMPLE_DIM_GUIDED_PORTAL_SURFACE,
+    config.samplesPerPixel
+  ) * 2.0 - vec2<f32>(1.0);
+  let u = portalUv.x * portal.tangent.w;
+  let v = portalUv.y * portal.bitangent.w;
   let portalTarget = portal.position.xyz + portal.tangent.xyz * u + portal.bitangent.xyz * v;
   return safe_normalize(portalTarget - hit.position.xyz, fallback);
 }
 
-fn scatter_direction(ray: RayRecord, hit: HitRecord, seed: u32) -> ScatterResult {
+fn scatter_direction(ray: RayRecord, hit: HitRecord) -> ScatterResult {
   let normal = surface_shading_normal(hit);
   let viewDirection = safe_normalize(-ray.direction.xyz, normal);
   let roughness = clamp(hit.material.x, 0.0, 1.0);
@@ -377,7 +403,14 @@ fn scatter_direction(ray: RayRecord, hit: HitRecord, seed: u32) -> ScatterResult
       max(reflectChance, 1.0 - transmission),
       transmission > 0.001
     );
-    if (cannotRefract || random01(seed + 23u) < transmissionReflectChance) {
+    let transmissionSelector = sample_dimension_1d(
+      ray.sourcePixelId,
+      ray.sampleId,
+      ray.bounce,
+      config.frameIndex,
+      SAMPLE_DIM_TRANSMISSION_SELECTOR
+    );
+    if (cannotRefract || transmissionSelector < transmissionReflectChance) {
       return ScatterResult(
         vec4<f32>(reflect(ray.direction.xyz, normal), 0.0),
         1.0,
@@ -398,9 +431,22 @@ fn scatter_direction(ray: RayRecord, hit: HitRecord, seed: u32) -> ScatterResult
   let guidedEmissiveAvailable = config.emissiveTriangleCount > 0u;
   let guidedPortalAvailable =
     config.environmentPortalCount > 0u && config.environmentPortalMode != 0u;
-  let guidedSelector = random01(seed + 17u);
+  let guidedSelector = sample_dimension_1d(
+    ray.sourcePixelId,
+    ray.sampleId,
+    ray.bounce,
+    config.frameIndex,
+    SAMPLE_DIM_GUIDED_LIGHT_SELECTOR
+  );
   if (guidedEmissiveAvailable && guidedSelector < 0.18) {
-    let guidedDirection = sample_emissive_triangle_direction(hit, seed + 101u, normal);
+    let guidedDirection = sample_emissive_triangle_direction(
+      hit,
+      ray.sourcePixelId,
+      ray.sampleId,
+      ray.bounce,
+      config.frameIndex,
+      normal
+    );
     if (dot(normal, guidedDirection) > 0.000001) {
       let guidedPdf = max(evaluate_surface_bsdf_pdf(hit, viewDirection, guidedDirection), 0.000001);
       return ScatterResult(
@@ -413,7 +459,14 @@ fn scatter_direction(ray: RayRecord, hit: HitRecord, seed: u32) -> ScatterResult
     }
   }
   if (guidedPortalAvailable && guidedSelector < 0.32) {
-    let guidedDirection = sample_environment_portal_direction(hit, seed + 131u, normal);
+    let guidedDirection = sample_environment_portal_direction(
+      hit,
+      ray.sourcePixelId,
+      ray.sampleId,
+      ray.bounce,
+      config.frameIndex,
+      normal
+    );
     if (dot(normal, guidedDirection) > 0.000001) {
       let guidedPdf = max(evaluate_surface_bsdf_pdf(hit, viewDirection, guidedDirection), 0.000001);
       return ScatterResult(
@@ -427,26 +480,56 @@ fn scatter_direction(ray: RayRecord, hit: HitRecord, seed: u32) -> ScatterResult
   }
 
   let weights = surface_bsdf_sampling_weights(hit);
-  let selector = random01(seed + 31u);
+  let selector = sample_dimension_1d(
+    ray.sourcePixelId,
+    ray.sampleId,
+    ray.bounce,
+    config.frameIndex,
+    SAMPLE_DIM_BSDF_LOBE_SELECTOR
+  );
   var lightDirection = normal;
   var lobeKind = SCATTER_LOBE_DIFFUSE;
   if (selector < weights.x) {
+    let diffuseSample = sample_dimension_2d(
+      ray.sourcePixelId,
+      ray.sampleId,
+      ray.bounce,
+      config.frameIndex,
+      SAMPLE_DIM_DIFFUSE_HEMISPHERE,
+      config.samplesPerPixel
+    );
     lightDirection = cosine_sample_hemisphere(
-      vec2<f32>(random01(seed + 37u), random01(seed + 41u)),
+      diffuseSample,
       normal
     );
     lobeKind = SCATTER_LOBE_DIFFUSE;
   } else if (selector < weights.x + weights.y) {
+    let specularSample = sample_dimension_2d(
+      ray.sourcePixelId,
+      ray.sampleId,
+      ray.bounce,
+      config.frameIndex,
+      SAMPLE_DIM_SPECULAR_HALF_VECTOR,
+      config.samplesPerPixel
+    );
     let halfVector = importance_sample_ggx(
-      vec2<f32>(random01(seed + 47u), random01(seed + 53u)),
+      specularSample,
       max(roughness, 0.02),
       normal
     );
     lightDirection = safe_normalize(reflect(-viewDirection, halfVector), normal);
     lobeKind = SCATTER_LOBE_SPECULAR;
   } else {
+    let clearcoatSample = sample_dimension_2d(
+      ray.sourcePixelId,
+      ray.sampleId,
+      ray.bounce,
+      config.frameIndex,
+      SAMPLE_DIM_CLEARCOAT_HALF_VECTOR,
+      config.samplesPerPixel
+    );
     let halfVector = importance_sample_ggx(
-      vec2<f32>(random01(seed + 59u), random01(seed + 61u)),
+      clearcoatSample,
       max(clamp(hit.materialExtension.x, 0.0, 1.0), 0.02),
       normal
     );
@@ -454,8 +537,16 @@ fn scatter_direction(ray: RayRecord, hit: HitRecord, seed: u32) -> ScatterResult
     lobeKind = SCATTER_LOBE_CLEARCOAT;
   }
   if (dot(normal, lightDirection) <= 0.000001) {
+    let fallbackSample = sample_dimension_2d(
+      ray.sourcePixelId,
+      ray.sampleId,
+      ray.bounce,
+      config.frameIndex,
+      SAMPLE_DIM_FALLBACK_HEMISPHERE,
+      config.samplesPerPixel
+    );
     lightDirection = cosine_sample_hemisphere(
-      vec2<f32>(random01(seed + 67u), random01(seed + 71u)),
+      fallbackSample,
       normal
     );
     lobeKind = SCATTER_LOBE_DIFFUSE;
@@ -574,8 +665,7 @@ fn resolveSurfaceRecords(@builtin(global_invocation_id) globalId: vec3<u32>) {
     return;
   }
 
-  let seed = mix_seed(ray.sourcePixelId, ray.sampleId, ray.bounce, config.frameIndex, 11u);
-  let scatter = scatter_direction(ray, hit, seed);
+  let scatter = scatter_direction(ray, hit);
   let continuationNormal = surface_shading_normal(hit);
   let continuationViewDirection = safe_normalize(-ray.direction.xyz, continuationNormal);
   let continuationLightDirection = safe_normalize(scatter.direction.xyz, continuationNormal);

--- a/src/wavefront-shader-layout.js
+++ b/src/wavefront-shader-layout.js
@@ -1,3 +1,5 @@
+import { WAVEFRONT_SAMPLE_DIMENSIONS_WGSL } from "./wavefront-sampling-dimensions.js";
+
 export const WAVEFRONT_SHADER_LAYOUT_WGSL = `
 const RAY_FLAG_GUIDED_EMISSIVE: u32 = 1u;
 const RAY_FLAG_DELTA_SAMPLE: u32 = 2u;
@@ -6,6 +8,7 @@ const SCATTER_LOBE_SPECULAR: u32 = 2u;
 const SCATTER_LOBE_CLEARCOAT: u32 = 3u;
 const SCATTER_LOBE_DELTA_REFLECTION: u32 = 4u;
 const SCATTER_LOBE_DELTA_TRANSMISSION: u32 = 5u;
+${WAVEFRONT_SAMPLE_DIMENSIONS_WGSL}
 
 struct RayRecord {
   rayId: u32,
@@ -312,6 +315,42 @@ fn mix_seed(pixelId: u32, sampleId: u32, bounce: u32, frameIndex: u32, dimension
 
 fn random01(seed: u32) -> f32 {
   return f32(hash_u32(seed) & 0x00ffffffu) / 16777215.0;
+}
+
+fn radical_inverse_vdc(bits: u32) -> f32 {
+  var value = bits;
+  value = (value << 16u) | (value >> 16u);
+  value = ((value & 0x55555555u) << 1u) | ((value & 0xaaaaaaaau) >> 1u);
+  value = ((value & 0x33333333u) << 2u) | ((value & 0xccccccccu) >> 2u);
+  value = ((value & 0x0f0f0f0fu) << 4u) | ((value & 0xf0f0f0f0u) >> 4u);
+  value = ((value & 0x00ff00ffu) << 8u) | ((value & 0xff00ff00u) >> 8u);
+  return f32(value) * 2.3283064365386963e-10;
+}
+
+fn sample_dimension_1d(
+  pixelId: u32,
+  sampleId: u32,
+  bounce: u32,
+  frameIndex: u32,
+  dimension: u32
+) -> f32 {
+  return random01(mix_seed(pixelId, sampleId, bounce, frameIndex, dimension));
+}
+
+fn sample_dimension_2d(
+  pixelId: u32,
+  sampleId: u32,
+  bounce: u32,
+  frameIndex: u32,
+  dimension: u32,
+  strataCount: u32
+) -> vec2<f32> {
+  let strata = max(strataCount, 1u);
+  let jitter = sample_dimension_1d(pixelId, sampleId, bounce, frameIndex, dimension);
+  let scramble = hash_u32(mix_seed(pixelId, sampleId, bounce, frameIndex, dimension));
+  let stratified = fract((f32(sampleId % strata) + jitter) / f32(strata));
+  let lowDiscrepancy = fract(radical_inverse_vdc(sampleId ^ scramble) + jitter);
+  return vec2<f32>(stratified, lowDiscrepancy);
 }
 
 fn safe_normalize(value: vec3<f32>, fallback: vec3<f32>) -> vec3<f32> {

--- a/src/wavefront-shader-lighting.js
+++ b/src/wavefront-shader-lighting.js
@@ -713,12 +713,23 @@ fn scene_visibility_blocked(origin: vec3<f32>, direction: vec3<f32>, maxDistance
   return meshCandidate.hit == 1u && meshCandidate.distance < nearest;
 }
 
-fn sample_emissive_triangle_light(hit: HitRecord, seed: u32) -> DirectLightSample {
+fn sample_emissive_triangle_light(
+  hit: HitRecord,
+  pixelId: u32,
+  sampleId: u32,
+  bounce: u32,
+  frameIndex: u32,
+  selectionDimension: u32,
+  surfaceDimension: u32
+) -> DirectLightSample {
   if (config.emissiveTriangleCount == 0u) {
     return DirectLightSample(vec4<f32>(0.0), vec4<f32>(0.0), 0.0, 0.0, 0u, 0u);
   }
   let lightSlot = min(
-    u32(random01(seed + 71u) * f32(config.emissiveTriangleCount)),
+    u32(
+      sample_dimension_1d(pixelId, sampleId, bounce, frameIndex, selectionDimension) *
+      f32(config.emissiveTriangleCount)
+    ),
     config.emissiveTriangleCount - 1u
   );
   let lightMetadata = bvhNodes[config.bvhNodeCapacity + lightSlot];
@@ -730,12 +741,18 @@ fn sample_emissive_triangle_light(hit: HitRecord, seed: u32) -> DirectLightSampl
   let lightTriangle = triangles[triangleIndex];
   let triangleArea = triangle_surface_area(lightTriangle);
   let lightNormal = triangle_surface_normal(lightTriangle);
-  let r1 = random01(seed + 101u);
-  let r2 = random01(seed + 193u);
-  let root = sqrt(r1);
+  let sampleUv = sample_dimension_2d(
+    pixelId,
+    sampleId,
+    bounce,
+    frameIndex,
+    surfaceDimension,
+    config.samplesPerPixel
+  );
+  let root = sqrt(sampleUv.x);
   let b0 = 1.0 - root;
-  let b1 = root * (1.0 - r2);
-  let b2 = root * r2;
+  let b1 = root * (1.0 - sampleUv.y);
+  let b2 = root * sampleUv.y;
   let lightPoint =
     lightTriangle.v0.xyz * b0 +
     lightTriangle.v1.xyz * b1 +
@@ -756,11 +773,25 @@ fn sample_emissive_triangle_light(hit: HitRecord, seed: u32) -> DirectLightSampl
 
 fn sample_direct_light(hit: HitRecord, ray: RayRecord, normal: vec3<f32>) -> DirectLightSample {
   let environmentSelectionProbability = select(1.0, 0.5, config.emissiveTriangleCount > 0u);
-  let selector = random01(mix_seed(ray.sourcePixelId, ray.sampleId, ray.bounce, config.frameIndex, 41u));
+  let selector = sample_dimension_1d(
+    ray.sourcePixelId,
+    ray.sampleId,
+    ray.bounce,
+    config.frameIndex,
+    SAMPLE_DIM_DIRECT_LIGHT_SELECTOR
+  );
   if (selector < environmentSelectionProbability) {
+    let environmentUv = sample_dimension_2d(
+      ray.sourcePixelId,
+      ray.sampleId,
+      ray.bounce,
+      config.frameIndex,
+      SAMPLE_DIM_DIRECT_ENVIRONMENT,
+      config.samplesPerPixel
+    );
     let environmentSample = sample_environment_importance(vec2<f32>(
       selector / max(environmentSelectionProbability, 0.000001),
-      random01(mix_seed(ray.sourcePixelId, ray.sampleId, ray.bounce, config.frameIndex, 43u))
+      environmentUv.y
     ));
     let lightDirection = safe_normalize(environmentSample.direction, normal);
     let radiance = direct_environment_radiance(
@@ -776,13 +807,15 @@ fn sample_direct_light(hit: HitRecord, ray: RayRecord, normal: vec3<f32>) -> Dir
       1u
     );
   }
-  let emissiveSample = sample_emissive_triangle_light(hit, mix_seed(
+  let emissiveSample = sample_emissive_triangle_light(
+    hit,
     ray.sourcePixelId,
     ray.sampleId,
     ray.bounce,
     config.frameIndex,
-    47u
-  ));
+    SAMPLE_DIM_EMISSIVE_LIGHT_SELECTION,
+    SAMPLE_DIM_EMISSIVE_LIGHT_SURFACE
+  );
   if (emissiveSample.valid == 0u) {
     return emissiveSample;
   }

--- a/tests/wavefront-compute.test.js
+++ b/tests/wavefront-compute.test.js
@@ -35,8 +35,17 @@ import {
   estimateWavefrontDirectionalHemisphericalReflectance,
   validateWavefrontBsdfSample,
 } from "../src/wavefront-compute.js";
+import {
+  defaultHighSppDenoiseAcceptanceThresholds,
+  evaluateHighSppDenoiseAcceptance,
+} from "../src/wavefront-denoise-validation.js";
 import { dispatchWavefrontGpuAccelerationBuild } from "../src/wavefront-acceleration-builder.js";
 import { createGpuParallelismCounters } from "../src/wavefront-frame-runtime.js";
+import {
+  listWavefrontSampleDimensions,
+  sampleWavefrontDimension2D,
+  WAVEFRONT_SAMPLE_DIMENSIONS,
+} from "../src/wavefront-sampling-dimensions.js";
 
 const gpuConstants = Object.freeze({
   buffer: Object.freeze({
@@ -754,6 +763,40 @@ test("wavefront compute denoise adapts filter cost and strength to spp", () => {
   assert.doesNotMatch(source, /getImageData|putImageData/);
 });
 
+test("wavefront sample dimensions stay unique and expose low-discrepancy helpers", () => {
+  const dimensions = listWavefrontSampleDimensions();
+  const uniqueDimensions = new Set(dimensions.map(({ dimension }) => dimension));
+  const source = readRendererSource();
+  const shaderSource = createWavefrontPathTracingComputeShaderSource();
+  const jitterA = sampleWavefrontDimension2D(
+    17,
+    0,
+    0,
+    777,
+    WAVEFRONT_SAMPLE_DIMENSIONS.cameraJitter,
+    32
+  );
+  const jitterB = sampleWavefrontDimension2D(
+    17,
+    1,
+    0,
+    777,
+    WAVEFRONT_SAMPLE_DIMENSIONS.cameraJitter,
+    32
+  );
+
+  assert.equal(uniqueDimensions.size, dimensions.length);
+  assert.ok(
+    dimensions.every(({ wgslName }) => shaderSource.includes(`const ${wgslName}: u32 =`))
+  );
+  assert.match(source, /fn radical_inverse_vdc\(bits: u32\) -> f32/);
+  assert.match(source, /fn sample_dimension_1d\(/);
+  assert.match(source, /fn sample_dimension_2d\(/);
+  assert.notDeepEqual(jitterA, jitterB);
+  assert.ok(jitterA.every((value) => value >= 0 && value < 1));
+  assert.ok(jitterB.every((value) => value >= 0 && value < 1));
+});
+
 test("wavefront compute guides active continuation rays toward emissive triangles", () => {
   const source = readRendererSource();
 
@@ -763,11 +806,19 @@ test("wavefront compute guides active continuation rays toward emissive triangle
   assert.match(source, /RAY_FLAG_GUIDED_EMISSIVE/);
   assert.match(source, /guidedLightWeight/);
   assert.match(source, /guidedEmissiveAvailable/);
-  assert.match(source, /sample_emissive_triangle_direction\(hit, seed \+ 101u, normal\)/);
+  assert.match(source, /SAMPLE_DIM_GUIDED_EMISSIVE_SELECTION/);
+  assert.match(source, /SAMPLE_DIM_GUIDED_EMISSIVE_SURFACE/);
+  assert.match(source, /sample_emissive_triangle_direction\(\s+hit,\s+ray\.sourcePixelId,/);
   assert.match(source, /RAY_FLAG_GUIDED_EMISSIVE/);
   assert.match(source, /\(pixelId \* 747796405u\) \^/);
-  assert.match(source, /mix_seed\(sourcePixelId, sampleId, 0u, config\.frameIndex, 1u\)/);
-  assert.match(source, /mix_seed\(ray\.sourcePixelId, ray\.sampleId, ray\.bounce, config\.frameIndex, 11u\)/);
+  assert.match(
+    source,
+    /sample_dimension_2d\(\s*sourcePixelId,\s*sampleId,\s*0u,\s*config\.frameIndex,\s*SAMPLE_DIM_CAMERA_JITTER,\s*config\.samplesPerPixel\s*\)/
+  );
+  assert.match(
+    source,
+    /sample_dimension_1d\(\s*ray\.sourcePixelId,\s*ray\.sampleId,\s*ray\.bounce,\s*config\.frameIndex,\s*SAMPLE_DIM_TRANSMISSION_SELECTOR/
+  );
   assert.match(source, /bvhNodes\[config\.bvhNodeCapacity \+ lightSlot\]/);
   assert.match(source, /nextIndex >= config\.tilePixelCount/);
   assert.doesNotMatch(source, /direct_key_lighting/);
@@ -788,8 +839,59 @@ test("wavefront compute guides and gates environment lighting through portals", 
   assert.match(source, /fn gated_environment_radiance/);
   assert.match(source, /fn sample_environment_portal_direction/);
   assert.match(source, /guidedPortalAvailable/);
-  assert.match(source, /sample_environment_portal_direction\(hit, seed \+ 131u, normal\)/);
+  assert.match(source, /SAMPLE_DIM_GUIDED_PORTAL_SELECTION/);
+  assert.match(source, /SAMPLE_DIM_GUIDED_PORTAL_SURFACE/);
+  assert.match(source, /sample_environment_portal_direction\(\s*hit,\s*ray\.sourcePixelId,/);
   assert.match(source, /gated_environment_radiance\(ray\.origin\.xyz, ray\.direction\.xyz\)/);
+});
+
+test("high-spp denoise acceptance keeps denoise-off structural and detail gates explicit", () => {
+  const passing = evaluateHighSppDenoiseAcceptance({
+    baselineDenoiseOff: { luminanceStdDev: 0.12 },
+    denoiseOff: {
+      structuralArtifactShare: 0,
+      invalidSampleShare: 0,
+      luminanceStdDev: 0.11,
+      detailContrast: { sheen: 0.96, chrome: 0.93, wood: 0.91 },
+    },
+    denoiseOn: {
+      structuralArtifactShare: 0,
+      detailContrast: { sheen: 0.9, chrome: 0.88, wood: 0.85 },
+    },
+  });
+  const masked = evaluateHighSppDenoiseAcceptance({
+    baselineDenoiseOff: { luminanceStdDev: 0.12 },
+    denoiseOff: {
+      structuralArtifactShare: 0.01,
+      invalidSampleShare: 0,
+      luminanceStdDev: 0.11,
+      detailContrast: { sheen: 0.96, chrome: 0.93, wood: 0.91 },
+    },
+    denoiseOn: {
+      structuralArtifactShare: 0,
+      detailContrast: { sheen: 0.9, chrome: 0.88, wood: 0.85 },
+    },
+  });
+  const blurred = evaluateHighSppDenoiseAcceptance({
+    baselineDenoiseOff: { luminanceStdDev: 0.12 },
+    denoiseOff: {
+      structuralArtifactShare: 0,
+      invalidSampleShare: 0,
+      luminanceStdDev: 0.11,
+      detailContrast: { sheen: 1, chrome: 1, wood: 1 },
+    },
+    denoiseOn: {
+      structuralArtifactShare: 0,
+      detailContrast: { sheen: 0.7, chrome: 0.68, wood: 0.66 },
+    },
+  });
+
+  assert.equal(defaultHighSppDenoiseAcceptanceThresholds.minDetailRetentionRatio, 0.92);
+  assert.equal(passing.pass, true);
+  assert.equal(masked.pass, false);
+  assert.ok(masked.failures.some((failure) => failure.includes("cannot mask")));
+  assert.equal(blurred.pass, false);
+  assert.ok(blurred.failures.some((failure) => failure.includes("detail retention")));
 });
 
 test("wavefront compute uses physical continuation throughput and bounded terminal residuals", () => {


### PR DESCRIPTION
## What changed
- adds a canonical wavefront sample-dimension registry shared by JS and WGSL
- replaces ad hoc camera/light/BSDF sampling offsets with explicit low-discrepancy helpers
- adds machine-checkable denoise-independence thresholds plus tests, docs, changelog, and ADR coverage

## Why
Story `Plasius-LTD/plasius-ltd-site#1100` depends on `gpu-renderer#66` and `gpu-renderer#67` to make high-SPP convergence less dependent on denoise while keeping the rollback path explicit through `renderer.denoise.highSppIndependence`.

## Impact
- reviewers can see every sampling dimension by name instead of inferring intent from raw integers
- camera jitter and light/BSDF sample pairs use a shader-cheap low-discrepancy sequence where convergence matters
- denoise-on output can no longer mask a failing denoise-off validation report in the renderer acceptance logic

## Validation
- `npm run test:unit -- tests/wavefront-compute.test.js`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm run test:coverage`
- `npm run pack:check`
