### PR TITLE
fix: remove duplicate wavefront radical inverse helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@ All notable changes to this project will be documented in this file.
   - (placeholder)
 
 - **Fixed**
-  - (placeholder)
+  - Removed a duplicate `radical_inverse_vdc` WGSL helper definition from the
+    assembled wavefront compute shader so stricter live-browser compilers do not
+    reject validation-scene startup before first frame.
 
 - **Security**
   - (placeholder)

--- a/src/wavefront-shader-lighting.js
+++ b/src/wavefront-shader-lighting.js
@@ -97,16 +97,6 @@ fn direct_environment_radiance(origin: vec3<f32>, direction: vec3<f32>) -> vec3<
     select(vec3<f32>(1.0), portalScale, portalHit);
 }
 
-fn radical_inverse_vdc(bitsValue: u32) -> f32 {
-  var bits = bitsValue;
-  bits = (bits << 16u) | (bits >> 16u);
-  bits = ((bits & 0x55555555u) << 1u) | ((bits & 0xaaaaaaaau) >> 1u);
-  bits = ((bits & 0x33333333u) << 2u) | ((bits & 0xccccccccu) >> 2u);
-  bits = ((bits & 0x0f0f0f0fu) << 4u) | ((bits & 0xf0f0f0f0u) >> 4u);
-  bits = ((bits & 0x00ff00ffu) << 8u) | ((bits & 0xff00ff00u) >> 8u);
-  return f32(bits) * 2.3283064365386963e-10;
-}
-
 fn hammersley_2d(index: u32, count: u32) -> vec2<f32> {
   return vec2<f32>(f32(index) / max(f32(count), 1.0), radical_inverse_vdc(index));
 }

--- a/tests/wavefront-compute.test.js
+++ b/tests/wavefront-compute.test.js
@@ -797,6 +797,13 @@ test("wavefront sample dimensions stay unique and expose low-discrepancy helpers
   assert.ok(jitterB.every((value) => value >= 0 && value < 1));
 });
 
+test("wavefront shader source keeps shared low-discrepancy helpers single-defined", () => {
+  const shaderSource = createWavefrontPathTracingComputeShaderSource();
+  const radicalInverseMatches = shaderSource.match(/fn radical_inverse_vdc\(/g) ?? [];
+
+  assert.equal(radicalInverseMatches.length, 1);
+});
+
 test("wavefront compute guides active continuation rays toward emissive triangles", () => {
   const source = readRendererSource();
 


### PR DESCRIPTION
## Summary
- remove the duplicate WGSL `radical_inverse_vdc` helper from `wavefront-shader-lighting` so the assembled compute shader defines it only once
- add a regression test that inspects the assembled compute shader source for a single shared helper definition
- document the live-browser compilation fix in the changelog

## Validation
- `npm run test:coverage`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm run pack:check`
- verified assembled shader helper counts: broken `HEAD` baseline had `2`, patched branch has `1`

## Remaining verification
- live WebGPU browser capture still needs re-check in a session where `navigator.gpu` is available so `gpu-lighting#58` can attach a successful manifest/summary.