### PR TITLE
fix: expose wavefront samples per pixel to WGSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@ All notable changes to this project will be documented in this file.
   - (placeholder)
 
 - **Fixed**
-  - (placeholder)
+  - Added the missing `samplesPerPixel` field to the WGSL frame config and
+    matching CPU uniform payload so live Product Studio wavefront shaders compile
+    in browser runtimes that validate the assembled shader strictly.
 
 - **Security**
   - (placeholder)

--- a/src/wavefront-packers.js
+++ b/src/wavefront-packers.js
@@ -200,7 +200,7 @@ export function createConfigPayload(config, tile, frameIndex, buildRange = {}) {
   data.setUint32(252, config.emissiveTriangleCount ?? 0, true);
   data.setUint32(256, config.environmentPortalCount ?? 0, true);
   data.setUint32(260, config.environmentPortalMode ?? 0, true);
-  data.setUint32(264, 0, true);
+  data.setUint32(264, config.samplesPerPixel, true);
   data.setUint32(268, 0, true);
   writeVec4(floatView, 272, [
     config.environmentMap.enabled ? 1 : 0,

--- a/src/wavefront-shader-layout.js
+++ b/src/wavefront-shader-layout.js
@@ -194,7 +194,7 @@ struct FrameConfig {
   emissiveTriangleCount: u32,
   environmentPortalCount: u32,
   environmentPortalMode: u32,
-  _portalPad0: u32,
+  samplesPerPixel: u32,
   _portalPad1: u32,
   environmentMapSettings: vec4<f32>,
   pathResolveSettings: vec4<f32>,

--- a/tests/wavefront-compute.test.js
+++ b/tests/wavefront-compute.test.js
@@ -41,6 +41,7 @@ import {
 } from "../src/wavefront-denoise-validation.js";
 import { dispatchWavefrontGpuAccelerationBuild } from "../src/wavefront-acceleration-builder.js";
 import { createGpuParallelismCounters } from "../src/wavefront-frame-runtime.js";
+import { createConfigPayload } from "../src/wavefront-packers.js";
 import {
   listWavefrontSampleDimensions,
   sampleWavefrontDimension2D,
@@ -506,6 +507,25 @@ test("wavefront compute config exposes bounded samples per pixel", () => {
       }),
     /maxFramePassesPerSubmission must be a positive integer/
   );
+});
+
+test("wavefront frame config exposes samples per pixel to WGSL", () => {
+  const shaderSource = createWavefrontPathTracingComputeShaderSource();
+  const config = createWavefrontPathTracingComputeConfig({
+    width: 640,
+    height: 360,
+    samplesPerPixel: 8,
+  });
+  const payload = createConfigPayload(
+    config,
+    { x: 0, y: 0, width: 64, height: 64 },
+    17
+  );
+  const payloadView = new DataView(payload);
+
+  assert.match(shaderSource, /samplesPerPixel: u32/);
+  assert.match(shaderSource, /config\.samplesPerPixel/);
+  assert.equal(payloadView.getUint32(264, true), 8);
 });
 
 test("wavefront reference helper generates deterministic primary rays from the camera contract", () => {


### PR DESCRIPTION
## Summary
- Adds `samplesPerPixel` to the WGSL `FrameConfig` using the existing padding slot at byte 264.
- Writes the normalized CPU config samples-per-pixel value into the matching uniform payload slot.
- Adds a regression test covering the assembled WGSL and packed payload.

## Production Incident Context
Product Studio on the site failed in live browser validation with: `struct member samplesPerPixel not found`. A localhost WebGPU validation-scope diagnostic against this branch returns `pipelineError: null` and `scopeError: null` for `prepareMeshTrianglesAndLeaves`.

## Validation
- `npm test`
- `npm run typecheck`
- `npm run lint`
- Local browser WGSL pipeline diagnostic on `127.0.0.1:4190`: no pipeline error, no validation error
