### PR TITLE
feat: add animation adventure renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 - **Added**
-  - (placeholder)
+  - Added a renderer-owned animated scene surface for adventure playback with scripted beats, route motion, blend snapshots, and bezier-lag camera follow.
+  - Added a renderer-owned model-tree leaf material lab with procedural branches, close-up leaf rendering controls, quality tiers, and offscreen renderer telemetry for GPU Demo model iteration.
 
 - **Changed**
   - (placeholder)

--- a/README.md
+++ b/README.md
@@ -118,6 +118,46 @@ in dedicated runtime helpers so performance-facing integrations can consume
 stable frame stats without inheriting the renderer's shader and pipeline
 assembly internals.
 
+## Animated Scene Renderer
+
+`createAnimatedSceneRenderer` provides the renderer-owned v1 surface for the
+GPU animation adventure demo. It accepts scripted beats, route points, props,
+and a lagged-follow camera rig, then exposes `start`, `resize`, `getSnapshot`,
+and `destroy` for host packages. It is implemented inside `gpu-renderer` and
+does not route animation playback through Three.js.
+
+## Model Tree Leaf Renderer
+
+`createModelTreeRenderer` provides a local model-tree demo harness for fast
+GPU Demo asset iteration. It renders a procedural branch hierarchy with dense
+close-up leaves, tunable density, wind, translucency, wetness/sheen, and
+quality tiers so model and material decisions can be reviewed before they are
+promoted into the public site catalog.
+
+```js
+import { createModelTreeRenderer } from "@plasius/gpu-renderer";
+
+const treeRenderer = createModelTreeRenderer({
+  canvas: document.querySelector("#tree-scene"),
+  quality: "closeup",
+  leafMaterial: {
+    density: 0.92,
+    wind: 0.22,
+    translucency: 0.7,
+    wetness: 0.28,
+    veinContrast: 0.62,
+  },
+});
+
+treeRenderer.resize(1280, 720, devicePixelRatio);
+treeRenderer.start();
+```
+
+The package demo at `demo/index.html` mounts this renderer and also starts an
+offscreen `createGpuRenderer` instance when WebGPU is available, giving the
+model-tree lab live renderer lifecycle telemetry while keeping the visible
+surface focused on the leaf material output.
+
 The production transport rollout remains gated by
 `renderer.transport.physicalEstimator`. With the flag enabled, deferred
 continuation vertices carry sanitized physical throughput segments instead of a

--- a/README.md
+++ b/README.md
@@ -126,38 +126,6 @@ and a lagged-follow camera rig, then exposes `start`, `resize`, `getSnapshot`,
 and `destroy` for host packages. It is implemented inside `gpu-renderer` and
 does not route animation playback through Three.js.
 
-## Model Tree Leaf Renderer
-
-`createModelTreeRenderer` provides a local model-tree demo harness for fast
-GPU Demo asset iteration. It renders a procedural branch hierarchy with dense
-close-up leaves, tunable density, wind, translucency, wetness/sheen, and
-quality tiers so model and material decisions can be reviewed before they are
-promoted into the public site catalog.
-
-```js
-import { createModelTreeRenderer } from "@plasius/gpu-renderer";
-
-const treeRenderer = createModelTreeRenderer({
-  canvas: document.querySelector("#tree-scene"),
-  quality: "closeup",
-  leafMaterial: {
-    density: 0.92,
-    wind: 0.22,
-    translucency: 0.7,
-    wetness: 0.28,
-    veinContrast: 0.62,
-  },
-});
-
-treeRenderer.resize(1280, 720, devicePixelRatio);
-treeRenderer.start();
-```
-
-The package demo at `demo/index.html` mounts this renderer and also starts an
-offscreen `createGpuRenderer` instance when WebGPU is available, giving the
-model-tree lab live renderer lifecycle telemetry while keeping the visible
-surface focused on the leaf material output.
-
 The production transport rollout remains gated by
 `renderer.transport.physicalEstimator`. With the flag enabled, deferred
 continuation vertices carry sanitized physical throughput segments instead of a

--- a/src/animated-scene-renderer.js
+++ b/src/animated-scene-renderer.js
@@ -1,0 +1,328 @@
+const DEFAULT_CAMERA = Object.freeze({
+  mode: "lagged-follow",
+  cubicBezier: [0.22, 0.61, 0.36, 1],
+  lagMs: 240,
+  lookAheadMs: 320,
+  offset: [0, 2.4, 5.5],
+});
+
+function nowMs() {
+  return typeof performance !== "undefined" && typeof performance.now === "function"
+    ? performance.now()
+    : Date.now();
+}
+
+function clamp01(value) {
+  return Math.min(1, Math.max(0, value));
+}
+
+function lerp(a, b, t) {
+  return a + (b - a) * t;
+}
+
+function lerp3(a, b, t) {
+  return [
+    lerp(a[0] ?? 0, b[0] ?? 0, t),
+    lerp(a[1] ?? 0, b[1] ?? 0, t),
+    lerp(a[2] ?? 0, b[2] ?? 0, t),
+  ];
+}
+
+function bezierY([, y1, , y2], t) {
+  const u = 1 - t;
+  return 3 * u * u * t * y1 + 3 * u * t * t * y2 + t * t * t;
+}
+
+function durationFromBeats(beats) {
+  return beats.reduce((total, beat) => total + Math.max(0, beat.durationMs ?? 0), 0);
+}
+
+function resolveBeat(beats, loopTimeMs) {
+  let cursor = 0;
+  for (const beat of beats) {
+    const durationMs = Math.max(1, beat.durationMs ?? 1);
+    if (loopTimeMs < cursor + durationMs) {
+      return { beat, beatTimeMs: loopTimeMs - cursor, durationMs };
+    }
+    cursor += durationMs;
+  }
+  const fallback = beats.at(-1);
+  return { beat: fallback, beatTimeMs: fallback?.durationMs ?? 0, durationMs: fallback?.durationMs ?? 1 };
+}
+
+function resolveRoutePosition(route, timeMs) {
+  if (!route.length) {
+    return [0, 0, 0];
+  }
+  if (route.length === 1 || timeMs <= (route[0].arriveMs ?? 0)) {
+    return [...route[0].position];
+  }
+
+  for (let index = 1; index < route.length; index += 1) {
+    const previous = route[index - 1];
+    const next = route[index];
+    const start = previous.arriveMs ?? 0;
+    const end = next.arriveMs ?? start + 1;
+    if (timeMs <= end) {
+      return lerp3(previous.position, next.position, clamp01((timeMs - start) / Math.max(1, end - start)));
+    }
+  }
+
+  return [...route.at(-1).position];
+}
+
+function resolveCanvas(canvas) {
+  if (typeof canvas === "string") {
+    const found = globalThis.document?.querySelector?.(canvas);
+    if (!found) {
+      throw new Error(`Animated scene canvas '${canvas}' was not found.`);
+    }
+    return found;
+  }
+  if (!canvas) {
+    throw new Error("Animated scene renderer requires a canvas.");
+  }
+  return canvas;
+}
+
+function project(position, cameraPosition, width, height) {
+  const x = position[0] - cameraPosition[0];
+  const z = position[2] - cameraPosition[2];
+  const scale = Math.max(24, 90 / Math.max(1, Math.abs(z) * 0.25 + 1));
+  return [
+    width * 0.5 + x * scale,
+    height * 0.62 + z * scale * 0.45 - position[1] * scale,
+    scale,
+  ];
+}
+
+function drawProp(ctx, prop, cameraPosition, width, height) {
+  const [x, y, scale] = project(prop.position, cameraPosition, width, height);
+  ctx.save();
+  ctx.translate(x, y);
+  ctx.lineWidth = Math.max(1, scale * 0.04);
+
+  if (prop.kind === "crop-row") {
+    ctx.strokeStyle = "#4f6f32";
+    ctx.beginPath();
+    ctx.moveTo(-scale * 0.8, 0);
+    ctx.lineTo(scale * 0.8, 0);
+    ctx.stroke();
+    ctx.fillStyle = "#6f9f43";
+    for (let i = -3; i <= 3; i += 1) {
+      ctx.fillRect(i * scale * 0.22, -scale * 0.18, scale * 0.06, scale * 0.2);
+    }
+  } else if (prop.kind === "fence-segment") {
+    ctx.strokeStyle = "#896b4d";
+    ctx.beginPath();
+    ctx.moveTo(-scale * 0.5, 0);
+    ctx.lineTo(scale * 0.5, 0);
+    ctx.moveTo(-scale * 0.35, -scale * 0.25);
+    ctx.lineTo(-scale * 0.35, scale * 0.1);
+    ctx.moveTo(scale * 0.35, -scale * 0.25);
+    ctx.lineTo(scale * 0.35, scale * 0.1);
+    ctx.stroke();
+  } else if (prop.kind === "cart") {
+    ctx.fillStyle = "#7b5238";
+    ctx.fillRect(-scale * 0.45, -scale * 0.28, scale * 0.9, scale * 0.32);
+    ctx.fillStyle = "#25201c";
+    ctx.beginPath();
+    ctx.arc(-scale * 0.27, scale * 0.1, scale * 0.1, 0, Math.PI * 2);
+    ctx.arc(scale * 0.27, scale * 0.1, scale * 0.1, 0, Math.PI * 2);
+    ctx.fill();
+  } else if (prop.kind === "small-tree") {
+    ctx.fillStyle = "#5b3b24";
+    ctx.fillRect(-scale * 0.05, -scale * 0.45, scale * 0.1, scale * 0.45);
+    ctx.fillStyle = "#3f7a3d";
+    ctx.beginPath();
+    ctx.arc(0, -scale * 0.58, scale * 0.24, 0, Math.PI * 2);
+    ctx.fill();
+  } else {
+    ctx.fillStyle = prop.kind === "crate" ? "#9a6a3d" : "#d0c39f";
+    ctx.fillRect(-scale * 0.18, -scale * 0.18, scale * 0.36, scale * 0.36);
+  }
+
+  ctx.restore();
+}
+
+function drawCharacter(ctx, characterPosition, cameraPosition, width, height, gaitPhase) {
+  const [x, y, scale] = project(characterPosition, cameraPosition, width, height);
+  const stride = Math.sin(gaitPhase * Math.PI * 2);
+  ctx.save();
+  ctx.translate(x, y);
+  ctx.lineWidth = Math.max(2, scale * 0.05);
+  ctx.lineCap = "round";
+  ctx.strokeStyle = "#34251f";
+  ctx.fillStyle = "#9b5f48";
+
+  ctx.beginPath();
+  ctx.arc(0, -scale * 1.15, scale * 0.18, 0, Math.PI * 2);
+  ctx.fill();
+
+  ctx.strokeStyle = "#57413a";
+  ctx.beginPath();
+  ctx.moveTo(0, -scale * 0.95);
+  ctx.lineTo(0, -scale * 0.45);
+  ctx.moveTo(0, -scale * 0.82);
+  ctx.lineTo(-scale * 0.25, -scale * (0.58 + stride * 0.08));
+  ctx.moveTo(0, -scale * 0.82);
+  ctx.lineTo(scale * 0.25, -scale * (0.58 - stride * 0.08));
+  ctx.moveTo(0, -scale * 0.45);
+  ctx.lineTo(-scale * 0.18, -scale * (0.05 - stride * 0.12));
+  ctx.moveTo(0, -scale * 0.45);
+  ctx.lineTo(scale * 0.18, -scale * (0.05 + stride * 0.12));
+  ctx.stroke();
+
+  ctx.fillStyle = "#496b8f";
+  ctx.fillRect(-scale * 0.17, -scale * 0.9, scale * 0.34, scale * 0.42);
+  ctx.restore();
+}
+
+function renderScene(canvas, ctx, snapshot, props) {
+  const width = canvas.width || 1;
+  const height = canvas.height || 1;
+  ctx.clearRect(0, 0, width, height);
+  ctx.fillStyle = "#d8e8d0";
+  ctx.fillRect(0, 0, width, height);
+  ctx.fillStyle = "#9fc47a";
+  ctx.fillRect(0, height * 0.52, width, height * 0.48);
+  ctx.strokeStyle = "#caa66d";
+  ctx.lineWidth = Math.max(2, width * 0.006);
+  ctx.beginPath();
+  ctx.moveTo(width * 0.35, height);
+  ctx.quadraticCurveTo(width * 0.53, height * 0.58, width * 0.62, 0);
+  ctx.stroke();
+
+  for (const prop of props) {
+    drawProp(ctx, prop, snapshot.cameraPosition, width, height);
+  }
+  drawCharacter(ctx, snapshot.characterPosition, snapshot.cameraPosition, width, height, snapshot.clipTimeMs / 900);
+}
+
+export function createAnimatedSceneRenderer(options = {}) {
+  const canvas = resolveCanvas(options.canvas);
+  const ctx = canvas.getContext?.("2d");
+  if (!ctx) {
+    throw new Error("Animated scene renderer requires a 2D canvas context.");
+  }
+
+  const route = [...(options.route ?? options.animationAdventure?.route ?? [])];
+  const beats = [...(options.beats ?? options.animationAdventure?.beats ?? [])].sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+  const props = [...(options.props ?? options.animationAdventure?.props ?? [])];
+  const camera = Object.freeze({ ...DEFAULT_CAMERA, ...(options.camera ?? options.animationAdventure?.camera ?? {}) });
+  const loopDurationMs = Math.max(durationFromBeats(beats), route.at(-1)?.arriveMs ?? 1, 1);
+  const requestFrame = options.requestAnimationFrame ?? globalThis.requestAnimationFrame?.bind(globalThis);
+  const cancelFrame = options.cancelAnimationFrame ?? globalThis.cancelAnimationFrame?.bind(globalThis);
+  let frameHandle;
+  let running = false;
+  let frame = 0;
+  let startedAtMs;
+  let lastTimestamp;
+  let cameraPosition = route[0]
+    ? [
+        route[0].position[0] + (camera.offset?.[0] ?? 0),
+        route[0].position[1] + (camera.offset?.[1] ?? 0),
+        route[0].position[2] + (camera.offset?.[2] ?? 0),
+      ]
+    : [0, 2.4, 5.5];
+  let snapshot = {
+    frame,
+    running,
+    activeClipId: beats[0]?.clipId ?? "",
+    activeBeatId: beats[0]?.id ?? "",
+    blendProgress: 0,
+    clipTimeMs: 0,
+    characterPosition: route[0]?.position ? [...route[0].position] : [0, 0, 0],
+    cameraPosition: [...cameraPosition],
+    frameState: "initialized",
+  };
+
+  function renderOnce(timestamp = nowMs()) {
+    if (startedAtMs === undefined) {
+      startedAtMs = timestamp;
+    }
+    const elapsedMs = Math.max(0, timestamp - startedAtMs);
+    const loopTimeMs = elapsedMs % loopDurationMs;
+    const frameTimeMs = lastTimestamp === undefined ? 16.67 : Math.max(0, timestamp - lastTimestamp);
+    lastTimestamp = timestamp;
+    frame += 1;
+
+    const { beat, beatTimeMs, durationMs } = resolveBeat(beats, loopTimeMs);
+    const blend = beat?.blend ?? { inMs: 0, outMs: 0 };
+    const blendIn = blend.inMs > 0 ? clamp01(beatTimeMs / blend.inMs) : 1;
+    const blendOut = blend.outMs > 0 ? clamp01((durationMs - beatTimeMs) / blend.outMs) : 1;
+    const blendProgress = clamp01(Math.min(blendIn, blendOut));
+    const characterPosition = resolveRoutePosition(route, loopTimeMs);
+    const lookAheadPosition = resolveRoutePosition(route, loopTimeMs + camera.lookAheadMs);
+    const desiredCamera = [
+      lookAheadPosition[0] + (camera.offset?.[0] ?? 0),
+      lookAheadPosition[1] + (camera.offset?.[1] ?? 0),
+      lookAheadPosition[2] + (camera.offset?.[2] ?? 0),
+    ];
+    const smoothing = bezierY(camera.cubicBezier, clamp01(frameTimeMs / Math.max(1, camera.lagMs)));
+    cameraPosition = lerp3(cameraPosition, desiredCamera, smoothing);
+
+    snapshot = {
+      frame,
+      running,
+      activeClipId: beat?.clipId ?? "",
+      activeBeatId: beat?.id ?? "",
+      blendProgress,
+      clipTimeMs: beatTimeMs,
+      characterPosition,
+      cameraPosition: [...cameraPosition],
+      frameState: running ? "running" : "rendered-once",
+    };
+
+    renderScene(canvas, ctx, snapshot, props);
+    return snapshot;
+  }
+
+  function tick(timestamp) {
+    renderOnce(timestamp);
+    if (running && requestFrame) {
+      frameHandle = requestFrame(tick);
+    }
+  }
+
+  return {
+    start() {
+      if (running) {
+        return;
+      }
+      running = true;
+      snapshot = { ...snapshot, running: true, frameState: "running" };
+      if (requestFrame) {
+        frameHandle = requestFrame(tick);
+      } else {
+        renderOnce();
+      }
+    },
+    resize(width, height, devicePixelRatio = 1) {
+      const ratio = Number.isFinite(devicePixelRatio) && devicePixelRatio > 0 ? devicePixelRatio : 1;
+      canvas.width = Math.max(1, Math.floor(width * ratio));
+      canvas.height = Math.max(1, Math.floor(height * ratio));
+      if (canvas.style) {
+        canvas.style.width = `${width}px`;
+        canvas.style.height = `${height}px`;
+      }
+      renderScene(canvas, ctx, snapshot, props);
+    },
+    renderOnce,
+    getSnapshot() {
+      return {
+        ...snapshot,
+        characterPosition: [...snapshot.characterPosition],
+        cameraPosition: [...snapshot.cameraPosition],
+      };
+    },
+    destroy() {
+      running = false;
+      if (frameHandle !== undefined && cancelFrame) {
+        cancelFrame(frameHandle);
+      }
+      frameHandle = undefined;
+      snapshot = { ...snapshot, running: false, frameState: "destroyed" };
+    },
+  };
+}

--- a/src/animated-scene-renderer.js
+++ b/src/animated-scene-renderer.js
@@ -289,6 +289,9 @@ export function createAnimatedSceneRenderer(options = {}) {
   }
 
   function tick(timestamp) {
+    if (!running) {
+      return;
+    }
     renderOnce(timestamp);
     if (running && requestFrame) {
       frameHandle = requestFrame(tick);

--- a/src/animated-scene-renderer.js
+++ b/src/animated-scene-renderer.js
@@ -37,6 +37,13 @@ function durationFromBeats(beats) {
   return beats.reduce((total, beat) => total + Math.max(0, beat.durationMs ?? 0), 0);
 }
 
+function definedCameraOverrides(camera) {
+  if (!camera || typeof camera !== "object") {
+    return {};
+  }
+  return Object.fromEntries(Object.entries(camera).filter(([, value]) => value !== undefined));
+}
+
 function resolveBeat(beats, loopTimeMs) {
   let cursor = 0;
   for (const beat of beats) {
@@ -209,7 +216,10 @@ export function createAnimatedSceneRenderer(options = {}) {
   const route = [...(options.route ?? options.animationAdventure?.route ?? [])];
   const beats = [...(options.beats ?? options.animationAdventure?.beats ?? [])].sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
   const props = [...(options.props ?? options.animationAdventure?.props ?? [])];
-  const camera = Object.freeze({ ...DEFAULT_CAMERA, ...(options.camera ?? options.animationAdventure?.camera ?? {}) });
+  const camera = Object.freeze({
+    ...DEFAULT_CAMERA,
+    ...definedCameraOverrides(options.camera ?? options.animationAdventure?.camera),
+  });
   const loopDurationMs = Math.max(durationFromBeats(beats), route.at(-1)?.arriveMs ?? 1, 1);
   const requestFrame = options.requestAnimationFrame ?? globalThis.requestAnimationFrame?.bind(globalThis);
   const cancelFrame = options.cancelAnimationFrame ?? globalThis.cancelAnimationFrame?.bind(globalThis);

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,4 +1,87 @@
 export type RendererColor = string | [number, number, number, number?];
+export type AnimatedSceneVector3 = readonly [number, number, number] | readonly number[];
+export type AnimatedScenePropKind =
+  | "crop-row"
+  | "fence-segment"
+  | "crate"
+  | "cart"
+  | "small-tree"
+  | "path-marker";
+
+export interface AnimatedScenePathPoint {
+  readonly id: string;
+  readonly position: AnimatedSceneVector3;
+  readonly arriveMs: number;
+}
+
+export interface AnimatedSceneBeat {
+  readonly id: string;
+  readonly order: number;
+  readonly clipId: string;
+  readonly durationMs: number;
+  readonly blend?: {
+    readonly inMs?: number;
+    readonly outMs?: number;
+  };
+}
+
+export interface AnimatedSceneCameraFollowRig {
+  readonly mode?: "lagged-follow";
+  readonly cubicBezier?: readonly [number, number, number, number] | readonly number[];
+  readonly lagMs?: number;
+  readonly lookAheadMs?: number;
+  readonly offset?: AnimatedSceneVector3;
+}
+
+export interface AnimatedSceneProp {
+  readonly id?: string;
+  readonly kind: AnimatedScenePropKind | string;
+  readonly position: AnimatedSceneVector3;
+}
+
+export interface CreateAnimatedSceneRendererOptions {
+  readonly canvas: string | HTMLCanvasElement | {
+    width: number;
+    height: number;
+    style?: Record<string, string>;
+    getContext(type: "2d"): CanvasRenderingContext2D | null;
+  };
+  readonly route?: readonly AnimatedScenePathPoint[];
+  readonly beats?: readonly AnimatedSceneBeat[];
+  readonly props?: readonly AnimatedSceneProp[];
+  readonly camera?: AnimatedSceneCameraFollowRig;
+  readonly animationAdventure?: {
+    readonly route?: readonly AnimatedScenePathPoint[];
+    readonly beats?: readonly AnimatedSceneBeat[];
+    readonly props?: readonly AnimatedSceneProp[];
+    readonly camera?: AnimatedSceneCameraFollowRig;
+  };
+  readonly requestAnimationFrame?: (callback: FrameRequestCallback) => number;
+  readonly cancelAnimationFrame?: (handle: number) => void;
+}
+
+export interface AnimatedSceneSnapshot {
+  readonly frame: number;
+  readonly running: boolean;
+  readonly activeClipId: string;
+  readonly activeBeatId: string;
+  readonly blendProgress: number;
+  readonly clipTimeMs: number;
+  readonly characterPosition: readonly [number, number, number];
+  readonly cameraPosition: readonly [number, number, number];
+  readonly frameState: "initialized" | "running" | "rendered-once" | "destroyed";
+}
+
+export interface AnimatedSceneRenderer {
+  start(): void;
+  resize(width: number, height: number, devicePixelRatio?: number): void;
+  renderOnce(timestamp?: number): AnimatedSceneSnapshot;
+  getSnapshot(): AnimatedSceneSnapshot;
+  destroy(): void;
+}
+
+export function createAnimatedSceneRenderer(options: CreateAnimatedSceneRendererOptions): AnimatedSceneRenderer;
+
 export type WavefrontSceneObjectKind = "sphere" | "box" | "aabb" | "bounds" | number;
 export type WavefrontMaterialKind =
   | "diffuse"

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,7 @@
 export {
+  createAnimatedSceneRenderer,
+} from "./animated-scene-renderer.js";
+export {
   createDefaultWavefrontSceneObjects,
   createWavefrontBvhBuildLevels,
   createWavefrontBvhSortStages,

--- a/tests/package.test.js
+++ b/tests/package.test.js
@@ -2,6 +2,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
   bindRendererToXrManager,
+  createAnimatedSceneRenderer,
   createGpuRenderer,
   createRendererDebugHooks,
   createWavefrontAdaptiveSamplingLevels,
@@ -124,6 +125,43 @@ function createFakeCanvas() {
   };
 }
 
+function createFakeCanvas2d() {
+  const calls = [];
+  const context = {
+    calls,
+    fillStyle: "",
+    strokeStyle: "",
+    lineWidth: 1,
+    lineCap: "butt",
+    clearRect: (...args) => calls.push(["clearRect", ...args]),
+    fillRect: (...args) => calls.push(["fillRect", ...args]),
+    beginPath: () => calls.push(["beginPath"]),
+    moveTo: (...args) => calls.push(["moveTo", ...args]),
+    lineTo: (...args) => calls.push(["lineTo", ...args]),
+    quadraticCurveTo: (...args) => calls.push(["quadraticCurveTo", ...args]),
+    arc: (...args) => calls.push(["arc", ...args]),
+    fill: () => calls.push(["fill"]),
+    stroke: () => calls.push(["stroke"]),
+    save: () => calls.push(["save"]),
+    restore: () => calls.push(["restore"]),
+    translate: (...args) => calls.push(["translate", ...args]),
+    rotate: (...args) => calls.push(["rotate", ...args]),
+  };
+
+  return {
+    width: 0,
+    height: 0,
+    style: {},
+    getContext(type) {
+      if (type !== "2d") {
+        return null;
+      }
+      return context;
+    },
+    context,
+  };
+}
+
 function createFakeDocument(canvasMap = {}) {
   return {
     querySelector(selector) {
@@ -166,6 +204,71 @@ test("createGpuRenderer renders and updates snapshot", async () => {
   assert.equal(snapshot.xrActive, false);
 
   renderer.destroy();
+});
+
+test("createAnimatedSceneRenderer advances route, blend, camera, and lifecycle", () => {
+  const canvas = createFakeCanvas2d();
+  let scheduled = null;
+  let canceled = null;
+  const renderer = createAnimatedSceneRenderer({
+    canvas,
+    requestAnimationFrame(callback) {
+      scheduled = callback;
+      return 44;
+    },
+    cancelAnimationFrame(handle) {
+      canceled = handle;
+    },
+    route: [
+      { id: "gate", position: [0, 0, 0], arriveMs: 0 },
+      { id: "crop-row", position: [4, 0, 0], arriveMs: 4000 },
+    ],
+    beats: [
+      {
+        id: "idle-at-gate",
+        order: 0,
+        clipId: "female-basic-locomotion-idle",
+        durationMs: 1000,
+        blend: { inMs: 0, outMs: 200 },
+      },
+      {
+        id: "walk-to-crops",
+        order: 1,
+        clipId: "female-basic-locomotion-walking",
+        durationMs: 3000,
+        blend: { inMs: 200, outMs: 240 },
+      },
+    ],
+    camera: {
+      mode: "lagged-follow",
+      cubicBezier: [0.22, 0.61, 0.36, 1],
+      lagMs: 240,
+      lookAheadMs: 320,
+      offset: [-1, 2.4, 5.5],
+    },
+    props: [
+      { kind: "crop-row", position: [2, 0, 1] },
+      { kind: "cart", position: [4, 0, 0] },
+    ],
+  });
+
+  renderer.resize(320, 180, 2);
+  renderer.start();
+  assert.equal(typeof scheduled, "function");
+
+  const first = renderer.renderOnce(0);
+  const second = renderer.renderOnce(1600);
+
+  assert.equal(first.activeClipId, "female-basic-locomotion-idle");
+  assert.equal(second.activeClipId, "female-basic-locomotion-walking");
+  assert.equal(second.characterPosition[0] > first.characterPosition[0], true);
+  assert.equal(second.cameraPosition[0] < second.characterPosition[0], true);
+  assert.equal(second.blendProgress > 0, true);
+  assert.equal(canvas.context.calls.some((call) => call[0] === "fillRect"), true);
+
+  renderer.destroy();
+  assert.equal(canceled, 44);
+  assert.equal(renderer.getSnapshot().frameState, "destroyed");
 });
 
 test("createGpuRenderer emits frame lifecycle hooks with frame ids", async () => {

--- a/tests/package.test.js
+++ b/tests/package.test.js
@@ -271,6 +271,38 @@ test("createAnimatedSceneRenderer advances route, blend, camera, and lifecycle",
   assert.equal(renderer.getSnapshot().frameState, "destroyed");
 });
 
+test("createAnimatedSceneRenderer preserves camera defaults for undefined overrides", () => {
+  const renderer = createAnimatedSceneRenderer({
+    canvas: createFakeCanvas2d(),
+    route: [
+      { id: "gate", position: [0, 0, 0], arriveMs: 0 },
+      { id: "crop-row", position: [4, 0, 0], arriveMs: 4000 },
+    ],
+    beats: [
+      {
+        id: "walk-to-crops",
+        order: 0,
+        clipId: "female-basic-locomotion-walking",
+        durationMs: 4000,
+        blend: { inMs: 0, outMs: 240 },
+      },
+    ],
+    camera: {
+      cubicBezier: undefined,
+      lagMs: undefined,
+      lookAheadMs: undefined,
+      offset: [-1, 2.4, 5.5],
+    },
+  });
+
+  const snapshot = renderer.renderOnce(1200);
+
+  assert.equal(Number.isFinite(snapshot.cameraPosition[0]), true);
+  assert.equal(snapshot.cameraPosition[1], 2.4);
+  assert.equal(snapshot.cameraPosition[2], 5.5);
+  renderer.destroy();
+});
+
 test("createGpuRenderer emits frame lifecycle hooks with frame ids", async () => {
   const device = new FakeDevice();
   const gpu = new FakeGpu(new FakeAdapter(device));

--- a/tests/package.test.js
+++ b/tests/package.test.js
@@ -303,6 +303,39 @@ test("createAnimatedSceneRenderer preserves camera defaults for undefined overri
   renderer.destroy();
 });
 
+test("createAnimatedSceneRenderer ignores stale animation ticks after destroy", () => {
+  let scheduledTick = null;
+  const renderer = createAnimatedSceneRenderer({
+    canvas: createFakeCanvas2d(),
+    route: [
+      { id: "gate", position: [0, 0, 0], arriveMs: 0 },
+      { id: "crop-row", position: [4, 0, 0], arriveMs: 4000 },
+    ],
+    beats: [
+      {
+        id: "walk-to-crops",
+        order: 0,
+        clipId: "female-basic-locomotion-walking",
+        durationMs: 4000,
+        blend: { inMs: 0, outMs: 240 },
+      },
+    ],
+    requestAnimationFrame(callback) {
+      scheduledTick = callback;
+      return 91;
+    },
+  });
+
+  renderer.start();
+  assert.equal(typeof scheduledTick, "function");
+  renderer.destroy();
+  const destroyed = renderer.getSnapshot();
+
+  assert.equal(destroyed.frameState, "destroyed");
+  scheduledTick(1000);
+  assert.equal(renderer.getSnapshot().frameState, "destroyed");
+});
+
 test("createGpuRenderer emits frame lifecycle hooks with frame ids", async () => {
   const device = new FakeDevice();
   const gpu = new FakeGpu(new FakeAdapter(device));


### PR DESCRIPTION
## Summary
- add renderer-owned animation adventure scene surface without Three.js
- support scripted beats, route movement, blend progress, deterministic props, cubic-bezier lagged camera follow, and runtime snapshots
- expose start, resize, renderOnce, getSnapshot, and destroy APIs

## Validation
- npm test
- npm run typecheck

Parent task: Plasius-LTD/gpu-renderer#105
Story: Plasius-LTD/plasius-ltd-site#1298