### PR TITLE
chore: align gpu runtime dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ All notable changes to this project will be documented in this file.
   - (placeholder)
 
 - **Changed**
+  - Updated runtime GPU dependencies to `@plasius/gpu-shared` `^1.0.2` and
+    `@plasius/gpu-xr` `^0.1.16` so downstream GPU Demo consumers do not pull
+    stale shared runtime packages transitively.
   - (placeholder)
 
 - **Fixed**

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,8 +19,8 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "@plasius/gpu-shared": "^0.1.11",
-        "@plasius/gpu-xr": "^0.1.11"
+        "@plasius/gpu-shared": "^1.0.2",
+        "@plasius/gpu-xr": "^0.1.16"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -730,9 +730,9 @@
       }
     },
     "node_modules/@plasius/gpu-shared": {
-      "version": "0.1.20",
-      "resolved": "https://registry.npmjs.org/@plasius/gpu-shared/-/gpu-shared-0.1.20.tgz",
-      "integrity": "sha512-YsZo1Id+UnVxr1YshrfI/N0DuVfkq7De+W9RZA5daM0STwgelh71G6Kk24Pv893g76nrBuyH0SyTgmhjMvAvTA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@plasius/gpu-shared/-/gpu-shared-1.0.2.tgz",
+      "integrity": "sha512-3WyB97wGqM7+mVIqkT408aLUarkwv531TNGs1hRFFK3Xo0mj93O1hnL3lUL+gML0NqAkRIZvtKw489hBESdeRA==",
       "funding": [
         {
           "type": "patreon",
@@ -748,7 +748,7 @@
         "node": ">=24"
       },
       "peerDependencies": {
-        "@plasius/gpu-renderer": "^0.2.3",
+        "@plasius/gpu-renderer": "^0.2.22",
         "@plasius/translations": "^1.0.17"
       },
       "peerDependenciesMeta": {
@@ -761,9 +761,9 @@
       }
     },
     "node_modules/@plasius/gpu-xr": {
-      "version": "0.1.15",
-      "resolved": "https://registry.npmjs.org/@plasius/gpu-xr/-/gpu-xr-0.1.15.tgz",
-      "integrity": "sha512-wiAWVYBSIYxT/8uHtQJ1TvYGILpYlbFCnrub8Rj+bDL0bx2hmu3citDUIIaFCEPw+dvM3pafjJmQdgCt+r1XAA==",
+      "version": "0.1.16",
+      "resolved": "https://registry.npmjs.org/@plasius/gpu-xr/-/gpu-xr-0.1.16.tgz",
+      "integrity": "sha512-R5KRAXJtP+qkn5VJNpQtEBAJAXuMNkzK+Z+JgxXPgKXxc3E3wwPVTY/6RYY0PBqnLz1UqpgScxy/zHEl+bwNFQ==",
       "funding": [
         {
           "type": "patreon",
@@ -776,7 +776,7 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "@plasius/gpu-shared": "^0.1.9"
+        "@plasius/gpu-shared": "^1.0.2"
       },
       "engines": {
         "node": ">=24"

--- a/package.json
+++ b/package.json
@@ -49,8 +49,8 @@
   "author": "Plasius LTD <development@plasius.co.uk>",
   "license": "Apache-2.0",
   "dependencies": {
-    "@plasius/gpu-shared": "^0.1.11",
-    "@plasius/gpu-xr": "^0.1.11"
+    "@plasius/gpu-shared": "^1.0.2",
+    "@plasius/gpu-xr": "^0.1.16"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",


### PR DESCRIPTION
Closes #109

## Summary
- Update @plasius/gpu-shared to ^1.0.2.
- Update @plasius/gpu-xr to ^0.1.16 so renderer installs no longer pull stale shared 0.x transitively.
- Refresh package-lock and changelog.

## Validation
- npm test
- npm run typecheck
- npm run lint
- npm run build
- npm run pack:check
- npm run audit:npm
- npm ls @plasius/gpu-shared --all --omit=dev