### PR TITLE
feat: render animation adventure skinned GLB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,10 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 - **Added**
-  - (placeholder)
+  - Added renderer-owned skinned GLB ingestion for Animation Adventure,
+    including mesh/skin/clip parsing, Mixamo node-name retargeting, CPU
+    skinning for the active clip, model-derived canvas drawing, and snapshot
+    renderability diagnostics under task `#114`.
 
 - **Changed**
   - (placeholder)

--- a/README.md
+++ b/README.md
@@ -124,11 +124,14 @@ assembly internals.
 GPU animation adventure demo. It accepts scripted beats, route points, props,
 and a lagged-follow camera rig, then exposes `start`, `resize`, `getSnapshot`,
 and `destroy` for host packages. It is implemented inside `gpu-renderer` and
-does not route animation playback through Three.js. The v1 canvas renderer
-draws a grounded Peasant Girl proxy plus deterministic farm props while the
-skinned GLB renderer path is built out; snapshots expose `characterVisible`,
-`characterGroundY`, and `propGroundAnchors` so hosts can catch scene grounding
-regressions.
+does not route animation playback through Three.js. When hosts provide
+`modelAsset` and `clipAssets`, the v1 canvas renderer parses the Peasant Girl
+GLB mesh, skin, inverse-bind matrices, and Mixamo-compatible clip channels,
+then CPU-skins the active clip and draws model-derived geometry into the
+adventure canvas. Snapshots expose `modelRenderable`, `fallbackProxyActive`,
+`skinnedVertexCount`, `skinnedJointCount`, `activeClipRenderable`,
+`characterVisible`, `characterGroundY`, and `propGroundAnchors` so hosts can
+catch scene grounding and model-renderability regressions.
 
 The production transport rollout remains gated by
 `renderer.transport.physicalEstimator`. With the flag enabled, deferred

--- a/docs/tdrs/index.md
+++ b/docs/tdrs/index.md
@@ -3,3 +3,4 @@
 - [TDR 0001: Renderer Debug Hook Contract](./tdr-0001-renderer-debug-hook-contract.md)
 - [TDR 0002: Renderer Worker Manifest Profiles](./tdr-0002-renderer-worker-manifest-profiles.md)
 - [TDR 0003: Ray-Tracing-First Render Graph Contract](./tdr-0003-ray-tracing-first-render-graph-contract.md)
+- [TDR 0004: Animation Adventure Skinned GLB Canvas Path](./tdr-0004-animation-adventure-skinned-glb-canvas.md)

--- a/docs/tdrs/tdr-0004-animation-adventure-skinned-glb-canvas.md
+++ b/docs/tdrs/tdr-0004-animation-adventure-skinned-glb-canvas.md
@@ -1,0 +1,38 @@
+# TDR 0004: Animation Adventure Skinned GLB Canvas Path
+
+## Status
+
+Accepted
+
+## Context
+
+The GPU Demo Animation Adventure must show the Peasant Girl as the actual
+loaded skinned GLB asset. The previous v1 adventure canvas used a procedural
+character proxy, which kept the route and camera demo alive but did not satisfy
+the model-rendering requirement.
+
+## Decision
+
+`@plasius/gpu-renderer` owns a lightweight GLB ingestion path for the Animation
+Adventure canvas renderer:
+
+- parse binary GLB JSON and BIN chunks directly in the renderer package
+- read mesh positions, indices, skin joints, weights, inverse-bind matrices,
+  and Mixamo-compatible animation channels
+- retarget animation clip channels to model skeleton nodes by node name
+- compute CPU skinning matrices for the current active clip and route time
+- project the skinned mesh into the v1 adventure canvas without Three.js
+
+`@plasius/gpu-shared` is responsible for loading model and clip bytes and
+passing those buffers to the renderer. It does not parse or render the GLB.
+
+## Consequences
+
+- The current demo renders a model-derived Peasant Girl mesh instead of a
+  procedural proxy when compatible GLB payloads are available.
+- The renderer snapshot distinguishes loaded payloads from renderability through
+  `modelLoaded`, `modelRenderable`, `fallbackProxyActive`, and skinned mesh
+  diagnostics.
+- The implementation remains canvas-based for v1. A later WebGPU-native
+  skinned mesh path can replace the projection layer while preserving the
+  renderer-owned parsing and snapshot contract.

--- a/src/animated-gltf-model.js
+++ b/src/animated-gltf-model.js
@@ -1,0 +1,415 @@
+const GLB_MAGIC = 0x46546c67;
+const GLB_VERSION = 2;
+const GLB_JSON_CHUNK = 0x4e4f534a;
+const GLB_BIN_CHUNK = 0x004e4942;
+
+const COMPONENT_READERS = Object.freeze({
+  5120: { size: 1, read: (view, offset) => view.getInt8(offset), normalizedDivisor: 127 },
+  5121: { size: 1, read: (view, offset) => view.getUint8(offset), normalizedDivisor: 255 },
+  5122: { size: 2, read: (view, offset) => view.getInt16(offset, true), normalizedDivisor: 32767 },
+  5123: { size: 2, read: (view, offset) => view.getUint16(offset, true), normalizedDivisor: 65535 },
+  5125: { size: 4, read: (view, offset) => view.getUint32(offset, true), normalizedDivisor: 4294967295 },
+  5126: { size: 4, read: (view, offset) => view.getFloat32(offset, true), normalizedDivisor: 1 },
+});
+
+const ACCESSOR_COMPONENTS = Object.freeze({
+  SCALAR: 1,
+  VEC2: 2,
+  VEC3: 3,
+  VEC4: 4,
+  MAT4: 16,
+});
+
+function identityMatrix() {
+  return [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+}
+
+function multiplyMatrix(a, b) {
+  const out = new Array(16).fill(0);
+  for (let column = 0; column < 4; column += 1) {
+    for (let row = 0; row < 4; row += 1) {
+      out[column * 4 + row] =
+        a[0 * 4 + row] * b[column * 4 + 0]
+        + a[1 * 4 + row] * b[column * 4 + 1]
+        + a[2 * 4 + row] * b[column * 4 + 2]
+        + a[3 * 4 + row] * b[column * 4 + 3];
+    }
+  }
+  return out;
+}
+
+function transformPoint(matrix, point) {
+  const [x, y, z] = point;
+  return [
+    matrix[0] * x + matrix[4] * y + matrix[8] * z + matrix[12],
+    matrix[1] * x + matrix[5] * y + matrix[9] * z + matrix[13],
+    matrix[2] * x + matrix[6] * y + matrix[10] * z + matrix[14],
+  ];
+}
+
+function composeMatrix(translation = [0, 0, 0], rotation = [0, 0, 0, 1], scale = [1, 1, 1]) {
+  const [x, y, z, w] = normalizeQuaternion(rotation);
+  const [sx, sy, sz] = scale;
+  const x2 = x + x;
+  const y2 = y + y;
+  const z2 = z + z;
+  const xx = x * x2;
+  const xy = x * y2;
+  const xz = x * z2;
+  const yy = y * y2;
+  const yz = y * z2;
+  const zz = z * z2;
+  const wx = w * x2;
+  const wy = w * y2;
+  const wz = w * z2;
+
+  return [
+    (1 - (yy + zz)) * sx,
+    (xy + wz) * sx,
+    (xz - wy) * sx,
+    0,
+    (xy - wz) * sy,
+    (1 - (xx + zz)) * sy,
+    (yz + wx) * sy,
+    0,
+    (xz + wy) * sz,
+    (yz - wx) * sz,
+    (1 - (xx + yy)) * sz,
+    0,
+    translation[0] ?? 0,
+    translation[1] ?? 0,
+    translation[2] ?? 0,
+    1,
+  ];
+}
+
+function normalizeQuaternion(quaternion = [0, 0, 0, 1]) {
+  const length = Math.hypot(quaternion[0] ?? 0, quaternion[1] ?? 0, quaternion[2] ?? 0, quaternion[3] ?? 1) || 1;
+  return [
+    (quaternion[0] ?? 0) / length,
+    (quaternion[1] ?? 0) / length,
+    (quaternion[2] ?? 0) / length,
+    (quaternion[3] ?? 1) / length,
+  ];
+}
+
+function lerp(a, b, t) {
+  return a + (b - a) * t;
+}
+
+function lerpArray(a, b, t) {
+  return a.map((value, index) => lerp(value, b[index] ?? value, t));
+}
+
+function nlerpQuaternion(a, b, t) {
+  let end = b;
+  const dot = a.reduce((total, value, index) => total + value * (b[index] ?? 0), 0);
+  if (dot < 0) {
+    end = b.map((value) => -value);
+  }
+  return normalizeQuaternion(lerpArray(a, end, t));
+}
+
+function parseGlb(buffer) {
+  if (!(buffer instanceof ArrayBuffer)) {
+    return null;
+  }
+  const view = new DataView(buffer);
+  if (view.byteLength < 20 || view.getUint32(0, true) !== GLB_MAGIC || view.getUint32(4, true) !== GLB_VERSION) {
+    return null;
+  }
+
+  let offset = 12;
+  let json = null;
+  let binary = null;
+  while (offset + 8 <= view.byteLength) {
+    const length = view.getUint32(offset, true);
+    const type = view.getUint32(offset + 4, true);
+    const start = offset + 8;
+    const end = start + length;
+    if (end > view.byteLength) {
+      return null;
+    }
+    if (type === GLB_JSON_CHUNK) {
+      const text = new TextDecoder().decode(new Uint8Array(buffer, start, length)).trim();
+      json = JSON.parse(text);
+    } else if (type === GLB_BIN_CHUNK) {
+      binary = new Uint8Array(buffer, start, length);
+    }
+    offset = end;
+  }
+
+  if (!json || !binary) {
+    return null;
+  }
+  return { json, binary };
+}
+
+function readAccessor(document, accessorIndex) {
+  const accessor = document.json.accessors?.[accessorIndex];
+  if (!accessor) {
+    return [];
+  }
+  const bufferView = document.json.bufferViews?.[accessor.bufferView];
+  const component = COMPONENT_READERS[accessor.componentType];
+  const componentCount = ACCESSOR_COMPONENTS[accessor.type] ?? 1;
+  if (!bufferView || !component) {
+    return [];
+  }
+
+  const view = new DataView(
+    document.binary.buffer,
+    document.binary.byteOffset + (bufferView.byteOffset ?? 0) + (accessor.byteOffset ?? 0),
+    bufferView.byteLength ?? 0,
+  );
+  const stride = bufferView.byteStride ?? component.size * componentCount;
+  const values = [];
+  for (let index = 0; index < accessor.count; index += 1) {
+    const item = [];
+    const baseOffset = index * stride;
+    for (let componentIndex = 0; componentIndex < componentCount; componentIndex += 1) {
+      const raw = component.read(view, baseOffset + componentIndex * component.size);
+      item.push(accessor.normalized && accessor.componentType !== 5126 ? raw / component.normalizedDivisor : raw);
+    }
+    values.push(componentCount === 1 ? item[0] : item);
+  }
+  return values;
+}
+
+function readMatrices(document, accessorIndex) {
+  return readAccessor(document, accessorIndex).map((matrix) => Array.from(matrix));
+}
+
+function nodeLocalMatrix(node, override = {}) {
+  if (node.matrix && !override.translation && !override.rotation && !override.scale) {
+    return [...node.matrix];
+  }
+  return composeMatrix(
+    override.translation ?? node.translation ?? [0, 0, 0],
+    override.rotation ?? node.rotation ?? [0, 0, 0, 1],
+    override.scale ?? node.scale ?? [1, 1, 1],
+  );
+}
+
+function computeWorldMatrices(nodes, overridesByName = new Map()) {
+  const parents = new Set();
+  for (const node of nodes) {
+    for (const child of node.children ?? []) {
+      parents.add(child);
+    }
+  }
+  const roots = nodes
+    .map((_, index) => index)
+    .filter((index) => !parents.has(index));
+  const worldMatrices = nodes.map(() => identityMatrix());
+
+  function visit(nodeIndex, parentMatrix) {
+    const node = nodes[nodeIndex];
+    if (!node) {
+      return;
+    }
+    const worldMatrix = multiplyMatrix(parentMatrix, nodeLocalMatrix(node, overridesByName.get(node.name) ?? {}));
+    worldMatrices[nodeIndex] = worldMatrix;
+    for (const child of node.children ?? []) {
+      visit(child, worldMatrix);
+    }
+  }
+
+  for (const root of roots) {
+    visit(root, identityMatrix());
+  }
+  return worldMatrices;
+}
+
+function normalizeWeights(weights) {
+  const total = weights.reduce((sum, value) => sum + Math.max(0, value), 0);
+  if (total <= 0) {
+    return [1, 0, 0, 0];
+  }
+  return weights.map((value) => Math.max(0, value) / total);
+}
+
+function deriveBounds(vertices) {
+  const min = [Infinity, Infinity, Infinity];
+  const max = [-Infinity, -Infinity, -Infinity];
+  for (const vertex of vertices) {
+    for (let axis = 0; axis < 3; axis += 1) {
+      min[axis] = Math.min(min[axis], vertex[axis]);
+      max[axis] = Math.max(max[axis], vertex[axis]);
+    }
+  }
+  if (!Number.isFinite(min[0])) {
+    return { min: [0, 0, 0], max: [0, 1, 0], size: [1, 1, 1] };
+  }
+  return {
+    min,
+    max,
+    size: [max[0] - min[0], max[1] - min[1], max[2] - min[2]],
+  };
+}
+
+function sampleChannel(channel, sampler, document, timeSeconds) {
+  const input = readAccessor(document, sampler.input);
+  const output = readAccessor(document, sampler.output);
+  if (!input.length || !output.length) {
+    return null;
+  }
+  const duration = input.at(-1) || 0;
+  const sampleTime = duration > 0 ? timeSeconds % duration : 0;
+  let frame = 0;
+  while (frame < input.length - 2 && sampleTime > input[frame + 1]) {
+    frame += 1;
+  }
+  const start = input[frame] ?? 0;
+  const end = input[frame + 1] ?? start;
+  const t = end > start ? (sampleTime - start) / (end - start) : 0;
+  const startValue = Array.isArray(output[frame]) ? output[frame] : [output[frame] ?? 0];
+  const endValue = Array.isArray(output[frame + 1]) ? output[frame + 1] : startValue;
+  return channel.target.path === "rotation"
+    ? nlerpQuaternion(startValue, endValue, t)
+    : lerpArray(startValue, endValue, t);
+}
+
+function createClipPayload(clipRef) {
+  const document = parseGlb(clipRef?.asset);
+  const animation = document?.json.animations?.[0];
+  if (!document || !animation) {
+    return null;
+  }
+  const nodeNames = new Set();
+  let durationSeconds = 0;
+  for (const channel of animation.channels ?? []) {
+    const nodeName = document.json.nodes?.[channel.target?.node]?.name;
+    if (nodeName) {
+      nodeNames.add(nodeName);
+    }
+    const sampler = animation.samplers?.[channel.sampler];
+    const input = sampler ? readAccessor(document, sampler.input) : [];
+    durationSeconds = Math.max(durationSeconds, input.at(-1) ?? 0);
+  }
+  return {
+    id: clipRef.id,
+    document,
+    animation,
+    durationSeconds,
+    nodeNames,
+  };
+}
+
+function sampleClipOverrides(clipPayload, timeSeconds) {
+  const overrides = new Map();
+  if (!clipPayload) {
+    return overrides;
+  }
+  for (const channel of clipPayload.animation.channels ?? []) {
+    const targetNode = clipPayload.document.json.nodes?.[channel.target?.node];
+    const sampler = clipPayload.animation.samplers?.[channel.sampler];
+    if (!targetNode?.name || !sampler) {
+      continue;
+    }
+    const value = sampleChannel(channel, sampler, clipPayload.document, timeSeconds);
+    if (!value) {
+      continue;
+    }
+    const existing = overrides.get(targetNode.name) ?? {};
+    overrides.set(targetNode.name, {
+      ...existing,
+      [channel.target.path]: value,
+    });
+  }
+  return overrides;
+}
+
+export function createAnimatedGltfModel(modelAsset, clipRefs = []) {
+  const document = parseGlb(modelAsset);
+  if (!document) {
+    return null;
+  }
+
+  const nodes = document.json.nodes ?? [];
+  const meshNodeIndex = nodes.findIndex((node) => node.mesh !== undefined && node.skin !== undefined);
+  const meshNode = nodes[meshNodeIndex];
+  const mesh = document.json.meshes?.[meshNode?.mesh];
+  const primitive = mesh?.primitives?.find((candidate) => candidate.attributes?.POSITION !== undefined);
+  const skin = document.json.skins?.[meshNode?.skin];
+  if (!meshNode || !primitive || !skin) {
+    return null;
+  }
+
+  const positions = readAccessor(document, primitive.attributes.POSITION);
+  const joints = primitive.attributes.JOINTS_0 === undefined
+    ? positions.map(() => [0, 0, 0, 0])
+    : readAccessor(document, primitive.attributes.JOINTS_0);
+  const weights = primitive.attributes.WEIGHTS_0 === undefined
+    ? positions.map(() => [1, 0, 0, 0])
+    : readAccessor(document, primitive.attributes.WEIGHTS_0).map(normalizeWeights);
+  const indices = primitive.indices === undefined
+    ? positions.map((_, index) => index)
+    : readAccessor(document, primitive.indices);
+  const inverseBindMatrices = skin.inverseBindMatrices === undefined
+    ? skin.joints.map(() => identityMatrix())
+    : readMatrices(document, skin.inverseBindMatrices);
+  const clips = clipRefs.map(createClipPayload).filter(Boolean);
+  const bindWorldMatrices = computeWorldMatrices(nodes);
+  const bindVertices = skinVertices({
+    positions,
+    joints,
+    weights,
+    skin,
+    inverseBindMatrices,
+    worldMatrices: bindWorldMatrices,
+  });
+  const bounds = deriveBounds(bindVertices);
+
+  return {
+    name: mesh.name ?? meshNode.name ?? "skinned-gltf-model",
+    vertexCount: positions.length,
+    triangleCount: Math.floor(indices.length / 3),
+    jointCount: skin.joints.length,
+    animatedNodeCount: new Set(clips.flatMap((clip) => [...clip.nodeNames])).size,
+    clipCount: clips.length,
+    clips,
+    sample(activeClipId, clipTimeMs) {
+      const clip = clips.find((candidate) => candidate.id === activeClipId) ?? clips[0] ?? null;
+      const overrides = sampleClipOverrides(clip, Math.max(0, clipTimeMs) / 1000);
+      const worldMatrices = computeWorldMatrices(nodes, overrides);
+      const vertices = skinVertices({
+        positions,
+        joints,
+        weights,
+        skin,
+        inverseBindMatrices,
+        worldMatrices,
+      });
+      return {
+        vertices,
+        indices,
+        bounds: deriveBounds(vertices),
+        bindBounds: bounds,
+        activeClipRenderable: Boolean(clip),
+        activeClipDurationSeconds: clip?.durationSeconds ?? 0,
+      };
+    },
+  };
+}
+
+function skinVertices({ positions, joints, weights, skin, inverseBindMatrices, worldMatrices }) {
+  return positions.map((position, vertexIndex) => {
+    const jointIndices = joints[vertexIndex] ?? [0, 0, 0, 0];
+    const jointWeights = weights[vertexIndex] ?? [1, 0, 0, 0];
+    const skinned = [0, 0, 0];
+    for (let influence = 0; influence < 4; influence += 1) {
+      const weight = jointWeights[influence] ?? 0;
+      if (weight <= 0) {
+        continue;
+      }
+      const jointNodeIndex = skin.joints[jointIndices[influence] ?? 0] ?? skin.joints[0];
+      const jointMatrix = multiplyMatrix(worldMatrices[jointNodeIndex] ?? identityMatrix(), inverseBindMatrices[jointIndices[influence] ?? 0] ?? identityMatrix());
+      const transformed = transformPoint(jointMatrix, position);
+      skinned[0] += transformed[0] * weight;
+      skinned[1] += transformed[1] * weight;
+      skinned[2] += transformed[2] * weight;
+    }
+    return skinned;
+  });
+}

--- a/src/animated-scene-renderer.js
+++ b/src/animated-scene-renderer.js
@@ -1,3 +1,5 @@
+import { createAnimatedGltfModel } from "./animated-gltf-model.js";
+
 const DEFAULT_CAMERA = Object.freeze({
   mode: "lagged-follow",
   cubicBezier: [0.22, 0.61, 0.36, 1],
@@ -249,7 +251,84 @@ function drawCharacter(ctx, characterPosition, cameraPosition, width, height, ga
   return projected;
 }
 
-function renderScene(canvas, ctx, snapshot, props) {
+function pointForModelVertex(vertex, projection, sample) {
+  const bounds = sample.bounds;
+  const height = Math.max(0.1, bounds.size[1] || sample.bindBounds.size[1] || 1);
+  const modelScale = projection.scale * 1.3 / height;
+  const centerX = (bounds.min[0] + bounds.max[0]) * 0.5;
+  const centerZ = (bounds.min[2] + bounds.max[2]) * 0.5;
+  return [
+    projection.x + (vertex[0] - centerX) * modelScale,
+    projection.groundY - (vertex[1] - bounds.min[1]) * modelScale + (vertex[2] - centerZ) * modelScale * 0.16,
+  ];
+}
+
+function modelFillForHeight(vertex, sample) {
+  const height = Math.max(0.1, sample.bounds.size[1] || 1);
+  const t = (vertex[1] - sample.bounds.min[1]) / height;
+  if (t > 0.82) {
+    return "#6d4a36";
+  }
+  if (t > 0.58) {
+    return "#d7b28f";
+  }
+  if (t > 0.25) {
+    return "#6f8f62";
+  }
+  return "#5e4636";
+}
+
+function drawSkinnedGltfCharacter(ctx, model, snapshot, width, height) {
+  const projection = project(snapshot.characterPosition, snapshot.cameraPosition, width, height);
+  const sample = model.sample(snapshot.activeClipId, snapshot.clipTimeMs);
+  const maxTriangles = 1500;
+  const triangleCount = Math.floor(sample.indices.length / 3);
+  const stride = Math.max(1, Math.ceil(triangleCount / maxTriangles));
+  const triangles = [];
+  for (let triangleIndex = 0; triangleIndex < triangleCount; triangleIndex += stride) {
+    const base = triangleIndex * 3;
+    const a = sample.vertices[sample.indices[base]];
+    const b = sample.vertices[sample.indices[base + 1]];
+    const c = sample.vertices[sample.indices[base + 2]];
+    if (!a || !b || !c) {
+      continue;
+    }
+    triangles.push({
+      a,
+      b,
+      c,
+      depth: (a[2] + b[2] + c[2]) / 3,
+      fill: modelFillForHeight(a, sample),
+    });
+  }
+  triangles.sort((left, right) => left.depth - right.depth);
+
+  ctx.save();
+  drawGroundShadow(ctx, projection.scale);
+  ctx.lineWidth = Math.max(0.7, projection.scale * 0.012);
+  ctx.strokeStyle = "rgba(58, 43, 34, 0.22)";
+  for (const triangle of triangles) {
+    const [ax, ay] = pointForModelVertex(triangle.a, projection, sample);
+    const [bx, by] = pointForModelVertex(triangle.b, projection, sample);
+    const [cx, cy] = pointForModelVertex(triangle.c, projection, sample);
+    ctx.fillStyle = triangle.fill;
+    ctx.beginPath();
+    ctx.moveTo(ax, ay);
+    ctx.lineTo(bx, by);
+    ctx.lineTo(cx, cy);
+    ctx.closePath?.();
+    ctx.fill();
+    ctx.stroke();
+  }
+  ctx.restore();
+
+  return {
+    projection,
+    sample,
+  };
+}
+
+function renderScene(canvas, ctx, snapshot, props, characterModel) {
   const width = canvas.width || 1;
   const height = canvas.height || 1;
   ctx.clearRect(0, 0, width, height);
@@ -283,12 +362,56 @@ function renderScene(canvas, ctx, snapshot, props) {
       visible: projected.visible,
     });
   }
-  const characterProjection = drawCharacter(ctx, snapshot.characterPosition, snapshot.cameraPosition, width, height, snapshot.clipTimeMs / 900);
+  let characterProjection;
+  let modelRenderable = false;
+  let fallbackProxyActive = true;
+  let skinnedVertexCount = 0;
+  let skinnedTriangleCount = 0;
+  let skinnedJointCount = 0;
+  let skinnedAnimatedNodeCount = 0;
+  let skinnedClipCount = 0;
+  let activeClipRenderable = false;
+
+  if (characterModel) {
+    const drawn = drawSkinnedGltfCharacter(ctx, characterModel, snapshot, width, height);
+    characterProjection = drawn.projection;
+    modelRenderable = true;
+    fallbackProxyActive = false;
+    skinnedVertexCount = characterModel.vertexCount;
+    skinnedTriangleCount = characterModel.triangleCount;
+    skinnedJointCount = characterModel.jointCount;
+    skinnedAnimatedNodeCount = characterModel.animatedNodeCount;
+    skinnedClipCount = characterModel.clipCount;
+    activeClipRenderable = drawn.sample.activeClipRenderable;
+  } else {
+    characterProjection = drawCharacter(ctx, snapshot.characterPosition, snapshot.cameraPosition, width, height, snapshot.clipTimeMs / 900);
+  }
+
   return {
     characterGroundY: characterProjection.groundY,
     characterVisible: characterProjection.visible,
+    modelLoaded: Boolean(characterModel),
+    modelRenderable,
+    fallbackProxyActive,
+    skinnedVertexCount,
+    skinnedTriangleCount,
+    skinnedJointCount,
+    skinnedAnimatedNodeCount,
+    skinnedClipCount,
+    activeClipRenderable,
     propGroundAnchors,
   };
+}
+
+function resolveCharacterModel(options) {
+  try {
+    return createAnimatedGltfModel(
+      options.modelAsset ?? options.animationAdventure?.modelAsset,
+      options.clipAssets ?? options.animationAdventure?.clipAssets ?? [],
+    );
+  } catch {
+    return null;
+  }
 }
 
 export function createAnimatedSceneRenderer(options = {}) {
@@ -301,6 +424,7 @@ export function createAnimatedSceneRenderer(options = {}) {
   const route = [...(options.route ?? options.animationAdventure?.route ?? [])];
   const beats = [...(options.beats ?? options.animationAdventure?.beats ?? [])].sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
   const props = [...(options.props ?? options.animationAdventure?.props ?? [])];
+  const characterModel = resolveCharacterModel(options);
   const camera = Object.freeze({
     ...DEFAULT_CAMERA,
     ...definedCameraOverrides(options.camera ?? options.animationAdventure?.camera),
@@ -331,6 +455,15 @@ export function createAnimatedSceneRenderer(options = {}) {
     cameraPosition: [...cameraPosition],
     characterGroundY: 0,
     characterVisible: false,
+    modelLoaded: Boolean(characterModel),
+    modelRenderable: false,
+    fallbackProxyActive: true,
+    skinnedVertexCount: characterModel?.vertexCount ?? 0,
+    skinnedTriangleCount: characterModel?.triangleCount ?? 0,
+    skinnedJointCount: characterModel?.jointCount ?? 0,
+    skinnedAnimatedNodeCount: characterModel?.animatedNodeCount ?? 0,
+    skinnedClipCount: characterModel?.clipCount ?? 0,
+    activeClipRenderable: false,
     propGroundAnchors: [],
     frameState: "initialized",
   };
@@ -371,11 +504,20 @@ export function createAnimatedSceneRenderer(options = {}) {
       cameraPosition: [...cameraPosition],
       characterGroundY: 0,
       characterVisible: false,
+      modelLoaded: Boolean(characterModel),
+      modelRenderable: false,
+      fallbackProxyActive: true,
+      skinnedVertexCount: characterModel?.vertexCount ?? 0,
+      skinnedTriangleCount: characterModel?.triangleCount ?? 0,
+      skinnedJointCount: characterModel?.jointCount ?? 0,
+      skinnedAnimatedNodeCount: characterModel?.animatedNodeCount ?? 0,
+      skinnedClipCount: characterModel?.clipCount ?? 0,
+      activeClipRenderable: false,
       propGroundAnchors: [],
       frameState: running ? "running" : "rendered-once",
     };
 
-    const visibility = renderScene(canvas, ctx, snapshot, props);
+    const visibility = renderScene(canvas, ctx, snapshot, props, characterModel);
     snapshot = {
       ...snapshot,
       ...visibility,
@@ -414,7 +556,7 @@ export function createAnimatedSceneRenderer(options = {}) {
         canvas.style.width = `${width}px`;
         canvas.style.height = `${height}px`;
       }
-      const visibility = renderScene(canvas, ctx, snapshot, props);
+      const visibility = renderScene(canvas, ctx, snapshot, props, characterModel);
       snapshot = {
         ...snapshot,
         ...visibility,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -39,6 +39,11 @@ export interface AnimatedSceneProp {
   readonly position: AnimatedSceneVector3;
 }
 
+export interface AnimatedSceneClipAsset {
+  readonly id: string;
+  readonly asset?: ArrayBuffer | null;
+}
+
 export interface CreateAnimatedSceneRendererOptions {
   readonly canvas: string | HTMLCanvasElement | {
     width: number;
@@ -50,11 +55,15 @@ export interface CreateAnimatedSceneRendererOptions {
   readonly beats?: readonly AnimatedSceneBeat[];
   readonly props?: readonly AnimatedSceneProp[];
   readonly camera?: AnimatedSceneCameraFollowRig;
+  readonly modelAsset?: ArrayBuffer | null;
+  readonly clipAssets?: readonly AnimatedSceneClipAsset[];
   readonly animationAdventure?: {
     readonly route?: readonly AnimatedScenePathPoint[];
     readonly beats?: readonly AnimatedSceneBeat[];
     readonly props?: readonly AnimatedSceneProp[];
     readonly camera?: AnimatedSceneCameraFollowRig;
+    readonly modelAsset?: ArrayBuffer | null;
+    readonly clipAssets?: readonly AnimatedSceneClipAsset[];
   };
   readonly requestAnimationFrame?: (callback: FrameRequestCallback) => number;
   readonly cancelAnimationFrame?: (handle: number) => void;
@@ -71,6 +80,15 @@ export interface AnimatedSceneSnapshot {
   readonly cameraPosition: readonly [number, number, number];
   readonly characterGroundY: number;
   readonly characterVisible: boolean;
+  readonly modelLoaded: boolean;
+  readonly modelRenderable: boolean;
+  readonly fallbackProxyActive: boolean;
+  readonly skinnedVertexCount: number;
+  readonly skinnedTriangleCount: number;
+  readonly skinnedJointCount: number;
+  readonly skinnedAnimatedNodeCount: number;
+  readonly skinnedClipCount: number;
+  readonly activeClipRenderable: boolean;
   readonly propGroundAnchors: readonly {
     readonly id: string;
     readonly kind: string;

--- a/tests/package.test.js
+++ b/tests/package.test.js
@@ -140,6 +140,7 @@ function createFakeCanvas2d() {
     lineTo: (...args) => calls.push(["lineTo", ...args]),
     quadraticCurveTo: (...args) => calls.push(["quadraticCurveTo", ...args]),
     arc: (...args) => calls.push(["arc", ...args]),
+    closePath: () => calls.push(["closePath"]),
     fill: () => calls.push(["fill"]),
     stroke: () => calls.push(["stroke"]),
     save: () => calls.push(["save"]),
@@ -160,6 +161,130 @@ function createFakeCanvas2d() {
     },
     context,
   };
+}
+
+function align4(value) {
+  return (value + 3) & ~3;
+}
+
+function asArrayBuffer(buffer) {
+  return buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength);
+}
+
+function makeChunk(byteLength, write) {
+  const buffer = Buffer.alloc(align4(byteLength));
+  write(buffer);
+  return buffer;
+}
+
+function createGlb(json, binary) {
+  const jsonText = JSON.stringify({
+    asset: { version: "2.0", generator: "gpu-renderer-test" },
+    buffers: [{ byteLength: binary.byteLength }],
+    ...json,
+  });
+  const jsonBuffer = Buffer.from(jsonText, "utf8");
+  const paddedJson = Buffer.concat([jsonBuffer, Buffer.alloc(align4(jsonBuffer.byteLength) - jsonBuffer.byteLength, 0x20)]);
+  const totalLength = 12 + 8 + paddedJson.byteLength + 8 + binary.byteLength;
+  const header = Buffer.alloc(12);
+  header.writeUInt32LE(0x46546c67, 0);
+  header.writeUInt32LE(2, 4);
+  header.writeUInt32LE(totalLength, 8);
+  const jsonHeader = Buffer.alloc(8);
+  jsonHeader.writeUInt32LE(paddedJson.byteLength, 0);
+  jsonHeader.writeUInt32LE(0x4e4f534a, 4);
+  const binHeader = Buffer.alloc(8);
+  binHeader.writeUInt32LE(binary.byteLength, 0);
+  binHeader.writeUInt32LE(0x004e4942, 4);
+  return asArrayBuffer(Buffer.concat([header, jsonHeader, paddedJson, binHeader, binary]));
+}
+
+function createSkinnedTriangleGlb() {
+  const chunks = [];
+  const push = (buffer) => {
+    const byteOffset = chunks.reduce((total, chunk) => total + chunk.byteLength, 0);
+    chunks.push(buffer);
+    return { byteOffset, byteLength: buffer.byteLength };
+  };
+
+  const indicesView = push(makeChunk(6, (buffer) => {
+    [0, 1, 2].forEach((value, index) => buffer.writeUInt16LE(value, index * 2));
+  }));
+  const positionsView = push(makeChunk(36, (buffer) => {
+    [-0.4, 0, 0, 0.4, 0, 0, 0, 1.6, 0].forEach((value, index) => buffer.writeFloatLE(value, index * 4));
+  }));
+  const jointsView = push(makeChunk(24, (buffer) => {
+    new Array(12).fill(0).forEach((value, index) => buffer.writeUInt16LE(value, index * 2));
+  }));
+  const weightsView = push(makeChunk(48, (buffer) => {
+    [1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0].forEach((value, index) => buffer.writeFloatLE(value, index * 4));
+  }));
+  const inverseBindView = push(makeChunk(64, (buffer) => {
+    [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1].forEach((value, index) => buffer.writeFloatLE(value, index * 4));
+  }));
+
+  const binary = Buffer.concat(chunks);
+  return createGlb({
+    scenes: [{ nodes: [0] }],
+    scene: 0,
+    nodes: [
+      { name: "RootNode", children: [1, 2] },
+      { name: "mixamorig:Hips", translation: [0, 0, 0] },
+      { name: "Peasant_girl", mesh: 0, skin: 0 },
+    ],
+    skins: [{ joints: [1], inverseBindMatrices: 4, skeleton: 1 }],
+    meshes: [{
+      name: "Peasant_girl",
+      primitives: [{
+        attributes: {
+          POSITION: 1,
+          JOINTS_0: 2,
+          WEIGHTS_0: 3,
+        },
+        indices: 0,
+        mode: 4,
+      }],
+    }],
+    bufferViews: [indicesView, positionsView, jointsView, weightsView, inverseBindView],
+    accessors: [
+      { bufferView: 0, componentType: 5123, count: 3, type: "SCALAR" },
+      { bufferView: 1, componentType: 5126, count: 3, type: "VEC3" },
+      { bufferView: 2, componentType: 5123, count: 3, type: "VEC4" },
+      { bufferView: 3, componentType: 5126, count: 3, type: "VEC4" },
+      { bufferView: 4, componentType: 5126, count: 1, type: "MAT4" },
+    ],
+  }, binary);
+}
+
+function createTranslationClipGlb() {
+  const chunks = [];
+  const push = (buffer) => {
+    const byteOffset = chunks.reduce((total, chunk) => total + chunk.byteLength, 0);
+    chunks.push(buffer);
+    return { byteOffset, byteLength: buffer.byteLength };
+  };
+  const timeView = push(makeChunk(8, (buffer) => {
+    [0, 1].forEach((value, index) => buffer.writeFloatLE(value, index * 4));
+  }));
+  const translationView = push(makeChunk(24, (buffer) => {
+    [0, 0, 0, 0.2, 0, 0].forEach((value, index) => buffer.writeFloatLE(value, index * 4));
+  }));
+  const binary = Buffer.concat(chunks);
+  return createGlb({
+    scenes: [{ nodes: [0] }],
+    scene: 0,
+    nodes: [{ name: "mixamorig:Hips" }],
+    animations: [{
+      name: "walk",
+      samplers: [{ input: 0, output: 1, interpolation: "LINEAR" }],
+      channels: [{ sampler: 0, target: { node: 0, path: "translation" } }],
+    }],
+    bufferViews: [timeView, translationView],
+    accessors: [
+      { bufferView: 0, componentType: 5126, count: 2, type: "SCALAR" },
+      { bufferView: 1, componentType: 5126, count: 2, type: "VEC3" },
+    ],
+  }, binary);
 }
 
 function createFakeDocument(canvasMap = {}) {
@@ -348,6 +473,56 @@ test("createAnimatedSceneRenderer grounds adventure props and visible character 
   assert.equal(Math.abs((anchors.get("soil")?.groundY ?? 0) - snapshot.characterGroundY) < 120, true);
   assert.equal(Math.abs((anchors.get("crate")?.groundY ?? 0) - snapshot.characterGroundY) < 120, true);
   assert.equal((anchors.get("tree")?.groundY ?? 0) > snapshot.characterGroundY, true);
+  renderer.destroy();
+});
+
+test("createAnimatedSceneRenderer renders a skinned GLB model when model and clip payloads are provided", () => {
+  const canvas = createFakeCanvas2d();
+  const renderer = createAnimatedSceneRenderer({
+    canvas,
+    route: [
+      { id: "gate", position: [0, 0, 0], arriveMs: 0 },
+      { id: "crop-row", position: [4, 0, 1], arriveMs: 4000 },
+    ],
+    beats: [
+      {
+        id: "walk-to-crops",
+        order: 0,
+        clipId: "female-basic-locomotion-walking",
+        durationMs: 4000,
+        blend: { inMs: 0, outMs: 240 },
+      },
+    ],
+    camera: {
+      mode: "lagged-follow",
+      cubicBezier: [0.22, 0.61, 0.36, 1],
+      lagMs: 240,
+      lookAheadMs: 320,
+      offset: [-1, 2.4, 5.5],
+    },
+    modelAsset: createSkinnedTriangleGlb(),
+    clipAssets: [
+      {
+        id: "female-basic-locomotion-walking",
+        asset: createTranslationClipGlb(),
+      },
+    ],
+  });
+
+  renderer.resize(640, 360, 1);
+  const snapshot = renderer.renderOnce(1800);
+
+  assert.equal(snapshot.modelLoaded, true);
+  assert.equal(snapshot.modelRenderable, true);
+  assert.equal(snapshot.fallbackProxyActive, false);
+  assert.equal(snapshot.skinnedVertexCount, 3);
+  assert.equal(snapshot.skinnedTriangleCount, 1);
+  assert.equal(snapshot.skinnedJointCount, 1);
+  assert.equal(snapshot.skinnedClipCount, 1);
+  assert.equal(snapshot.skinnedAnimatedNodeCount, 1);
+  assert.equal(snapshot.activeClipRenderable, true);
+  assert.equal(snapshot.characterVisible, true);
+  assert.equal(canvas.context.calls.some((call) => call[0] === "closePath"), true);
   renderer.destroy();
 });
 


### PR DESCRIPTION
## Summary
- add renderer-owned GLB parser for binary GLB model and animation clip payloads
- parse mesh positions, indices, skins, joint weights, inverse-bind matrices, and Mixamo animation channels
- retarget clip channels by node name, CPU-skin the active clip, and draw model-derived Peasant Girl geometry in the adventure canvas
- expose snapshot diagnostics for model renderability, fallback proxy state, joint/vertex/clip counts, and active clip renderability
- document the renderer-owned skinned GLB canvas path in TDR 0004

## Validation
- `npm test`
- `npm run typecheck`
- `npm run lint`
- `npm run test:coverage`
- `npm run build`
- `npm run pack:check`
- real Peasant Girl GLB + walking clip smoke: 3318 vertices, 5033 triangles, 69 joints, 52 animated nodes, active clip renderable
- `git diff --check`

Closes #114
Refs Plasius-LTD/gpu-shared#66
Refs Plasius-LTD/plasius-ltd-site#1208
Refs Plasius-LTD/plasius-ltd-site#1298