### PR TITLE
feat: add animated renderer camera modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,15 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 - **Added**
-  - (placeholder)
+  - Added a renderer-owned animated scene surface for adventure playback with scripted beats, route motion, blend snapshots, and bezier-lag camera follow.
+  - Added animated camera mode integration with `@plasius/gpu-camera`,
+    including editor, spectator, third-person, and first-person view snapshots
+    plus head-look intent state.
+  - Added a renderer-owned model-tree leaf material lab with procedural branches, close-up leaf rendering controls, quality tiers, and offscreen renderer telemetry for GPU Demo model iteration.
 
 - **Changed**
-  - (placeholder)
+  - Updated renderer dependencies to consume the `@plasius/gpu-shared` v1 line
+    and the next `@plasius/gpu-camera` camera-rig release.
 
 - **Fixed**
   - (placeholder)
@@ -26,10 +31,13 @@ All notable changes to this project will be documented in this file.
 ## [0.2.26] - 2026-07-02
 
 - **Added**
-  - (placeholder)
+  - Added animated camera mode integration with `@plasius/gpu-camera`,
+    including editor, spectator, third-person, and first-person view snapshots
+    plus head-look intent state.
 
 - **Changed**
-  - (placeholder)
+  - Added `@plasius/gpu-camera` as a runtime dependency for shared animated
+    character camera rig resolution.
 
 - **Fixed**
   - Fixed Animation Adventure skinned GLB canvas drawing so Peasant Girl renders

--- a/README.md
+++ b/README.md
@@ -122,16 +122,23 @@ assembly internals.
 
 `createAnimatedSceneRenderer` provides the renderer-owned v1 surface for the
 GPU animation adventure demo. It accepts scripted beats, route points, props,
-and a lagged-follow camera rig, then exposes `start`, `resize`, `getSnapshot`,
-and `destroy` for host packages. It is implemented inside `gpu-renderer` and
-does not route animation playback through Three.js. When hosts provide
+and a backward-compatible `lagged-follow` camera rig that now resolves through
+the shared `@plasius/gpu-camera` editor, spectator, third-person, and
+first-person rig primitives. The renderer exposes `start`, `resize`,
+`getSnapshot`, `setCamera`, `setCameraViewMode`, `applyCameraControl`, and
+`destroy` for host packages. Third-person distance is clamped by camera
+constraints, first-person resolves from the head anchor, and head-look is
+reported as transient post-animation intent instead of mutating clip data. It
+is implemented inside `gpu-renderer` and does not route animation playback
+through Three.js. When hosts provide
 `modelAsset` and `clipAssets`, the v1 canvas renderer parses the Peasant Girl
 GLB mesh, skin, inverse-bind matrices, and Mixamo-compatible clip channels,
 then CPU-skins the active clip and draws model-derived geometry into the
 adventure canvas. Snapshots expose `modelRenderable`, `fallbackProxyActive`,
 `skinnedVertexCount`, `skinnedJointCount`, `activeClipRenderable`,
+`cameraViewMode`, `cameraTransform`, `targetDistance`, `headLook`,
 `characterVisible`, `characterGroundY`, and `propGroundAnchors` so hosts can
-catch scene grounding and model-renderability regressions.
+catch camera, scene grounding, and model-renderability regressions.
 
 The production transport rollout remains gated by
 `renderer.transport.physicalEstimator`. With the flag enabled, deferred

--- a/docs/adrs/adr-0020-animated-camera-rig-integration.md
+++ b/docs/adrs/adr-0020-animated-camera-rig-integration.md
@@ -1,0 +1,41 @@
+# ADR 0020: Animated Camera Rig Integration
+
+- Status: Accepted
+- Date: 2026-07-02
+
+## Context
+
+The GPU Demo animated character scene needs editor, spectator, third-person,
+and first-person camera modes. The camera math belongs in
+`@plasius/gpu-camera`, but the renderer owns scene anchors, animation
+snapshots, and the eventual point where camera-derived head-look intent can be
+blended into animated bones.
+
+## Decision
+
+`createAnimatedSceneRenderer(...)` consumes `@plasius/gpu-camera` rig frames for
+animated scene cameras. Legacy `camera.mode: "lagged-follow"` remains accepted
+and maps to spectator behavior. Renderer snapshots now include the resolved
+view mode, camera transform, target distance, and head-look state.
+
+Head-look intent is treated as a post-animation input. The renderer exposes the
+intent and applies only fallback visualization in the current canvas renderer;
+future skeletal renderers must blend the same intent after clip evaluation and
+must not mutate source clip data.
+
+## Consequences
+
+- Positive: Animated scene consumers get a stable camera snapshot contract.
+- Positive: The camera package owns reusable rig constraints while the renderer
+  owns animation/anchor integration.
+- Positive: Missing head anchors fail soft with `headLook.status:
+  "unavailable"`.
+- Tradeoff: The current canvas renderer can only visualize head-look intent;
+  full bone application requires the skeletal renderer path.
+
+## Alternatives Considered
+
+- Keep camera modes in the site page: Rejected because package consumers would
+  duplicate camera constraints and head-look semantics.
+- Apply head-look inside `@plasius/gpu-camera`: Rejected because bone blending
+  belongs with renderer/animation state, not generic camera math.

--- a/docs/adrs/index.md
+++ b/docs/adrs/index.md
@@ -18,3 +18,4 @@
 - [ADR 0016: Mixed Direct-Light MIS For Wavefront Materials](./adr-0016-mixed-direct-light-mis-for-wavefront-materials.md)
 - [ADR 0017: Physical Throughput For Wavefront Continuations](./adr-0017-physical-throughput-for-wavefront-continuations.md)
 - [ADR 0018: Purpose-Specific Renderer Module Boundaries](./adr-0018-purpose-specific-renderer-module-boundaries.md)
+- [ADR 0020: Animated Camera Rig Integration](./adr-0020-animated-camera-rig-integration.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
+        "@plasius/gpu-camera": "^0.1.17",
         "@plasius/gpu-shared": "^1.0.2",
         "@plasius/gpu-xr": "^0.1.16"
       },
@@ -727,6 +728,28 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@plasius/gpu-camera": {
+      "version": "0.1.17",
+      "resolved": "https://registry.npmjs.org/@plasius/gpu-camera/-/gpu-camera-0.1.17.tgz",
+      "integrity": "sha512-BX54wM1brOi0o+/1Qfx5xmkujOSgn2Qtu5/aK3RFV1BE7Rb2j+jnI5clxXOrgQX+htfo4CCtFGOwlF/VRSPS0Q==",
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/c/plasiusltd/membership"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/Plasius-LTD"
+        }
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@plasius/gpu-shared": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=24"
       }
     },
     "node_modules/@plasius/gpu-shared": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   "author": "Plasius LTD <development@plasius.co.uk>",
   "license": "Apache-2.0",
   "dependencies": {
+    "@plasius/gpu-camera": "^0.1.17",
     "@plasius/gpu-shared": "^1.0.2",
     "@plasius/gpu-xr": "^0.1.16"
   },

--- a/src/animated-scene-renderer.js
+++ b/src/animated-scene-renderer.js
@@ -1,11 +1,21 @@
+import { resolveCameraRigFrame } from "@plasius/gpu-camera";
 import { createAnimatedGltfModel } from "./animated-gltf-model.js";
 
 const DEFAULT_CAMERA = Object.freeze({
   mode: "lagged-follow",
+  viewMode: "spectator",
   cubicBezier: [0.22, 0.61, 0.36, 1],
   lagMs: 240,
   lookAheadMs: 320,
   offset: [0, 2.4, 5.5],
+  constraints: Object.freeze({
+    maxDistance: 10,
+    firstPersonHeadOffset: 0.05,
+  }),
+  headLook: Object.freeze({
+    enabled: true,
+    returnMs: 240,
+  }),
 });
 
 function nowMs() {
@@ -28,6 +38,22 @@ function lerp3(a, b, t) {
     lerp(a[1] ?? 0, b[1] ?? 0, t),
     lerp(a[2] ?? 0, b[2] ?? 0, t),
   ];
+}
+
+function normalize3(value, fallback = [0, 0, -1]) {
+  if (!Array.isArray(value) || value.length < 3) {
+    return [...fallback];
+  }
+  const vector = [
+    Number.isFinite(Number(value[0])) ? Number(value[0]) : fallback[0],
+    Number.isFinite(Number(value[1])) ? Number(value[1]) : fallback[1],
+    Number.isFinite(Number(value[2])) ? Number(value[2]) : fallback[2],
+  ];
+  const length = Math.hypot(vector[0], vector[1], vector[2]);
+  if (length <= 1e-6) {
+    return [...fallback];
+  }
+  return [vector[0] / length, vector[1] / length, vector[2] / length];
 }
 
 function clamp(value, min, max) {
@@ -82,6 +108,33 @@ function resolveRoutePosition(route, timeMs) {
   }
 
   return [...route.at(-1).position];
+}
+
+function resolveRouteForward(route, timeMs) {
+  if (route.length < 2) {
+    return [0, 0, -1];
+  }
+  let previous = route[0];
+  let next = route[1];
+  for (let index = 1; index < route.length; index += 1) {
+    next = route[index];
+    if (timeMs <= (next.arriveMs ?? 0)) {
+      previous = route[index - 1];
+      break;
+    }
+  }
+  return normalize3([
+    (next.position?.[0] ?? 0) - (previous.position?.[0] ?? 0),
+    (next.position?.[1] ?? 0) - (previous.position?.[1] ?? 0),
+    (next.position?.[2] ?? 0) - (previous.position?.[2] ?? 0),
+  ]);
+}
+
+function resolveCameraViewMode(camera) {
+  if (camera?.mode === "lagged-follow") {
+    return camera.viewMode ?? "spectator";
+  }
+  return camera?.viewMode ?? camera?.mode ?? "spectator";
 }
 
 function resolveCanvas(canvas) {
@@ -199,10 +252,11 @@ function drawProp(ctx, prop, cameraPosition, width, height) {
   return projected;
 }
 
-function drawCharacter(ctx, characterPosition, cameraPosition, width, height, gaitPhase) {
+function drawCharacter(ctx, characterPosition, cameraPosition, width, height, gaitPhase, headLook) {
   const projected = project(characterPosition, cameraPosition, width, height);
   const { x, y, scale } = projected;
   const stride = Math.sin(gaitPhase * Math.PI * 2);
+  const headYaw = (headLook?.yaw ?? 0) * (headLook?.weight ?? 0);
   ctx.save();
   ctx.translate(x, y);
   ctx.lineWidth = Math.max(2, scale * 0.05);
@@ -236,6 +290,14 @@ function drawCharacter(ctx, characterPosition, cameraPosition, width, height, ga
   ctx.fillRect(-scale * 0.2, -scale * 1.28, scale * 0.4, scale * 0.16);
   ctx.fillRect(-scale * 0.23, -scale * 1.14, scale * 0.1, scale * 0.28);
   ctx.fillRect(scale * 0.13, -scale * 1.14, scale * 0.1, scale * 0.28);
+  if (headLook?.status === "active" || headLook?.status === "returning") {
+    ctx.strokeStyle = "rgba(255, 246, 210, 0.74)";
+    ctx.lineWidth = Math.max(1, scale * 0.025);
+    ctx.beginPath();
+    ctx.moveTo(0, -scale * 1.16);
+    ctx.lineTo(Math.sin(headYaw) * scale * 0.32, -scale * 1.16 - scale * 0.08);
+    ctx.stroke();
+  }
 
   ctx.strokeStyle = "#6b4935";
   ctx.beginPath();
@@ -381,7 +443,15 @@ function renderScene(canvas, ctx, snapshot, props, characterModel) {
     skinnedClipCount = characterModel.clipCount;
     activeClipRenderable = drawn.sample.activeClipRenderable;
   } else {
-    characterProjection = drawCharacter(ctx, snapshot.characterPosition, snapshot.cameraPosition, width, height, snapshot.clipTimeMs / 900);
+    characterProjection = drawCharacter(
+      ctx,
+      snapshot.characterPosition,
+      snapshot.cameraPosition,
+      width,
+      height,
+      snapshot.clipTimeMs / 900,
+      snapshot.headLook,
+    );
   }
 
   return {
@@ -422,10 +492,10 @@ export function createAnimatedSceneRenderer(options = {}) {
   const beats = [...(options.beats ?? options.animationAdventure?.beats ?? [])].sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
   const props = [...(options.props ?? options.animationAdventure?.props ?? [])];
   const characterModel = resolveCharacterModel(options);
-  const camera = Object.freeze({
+  let camera = {
     ...DEFAULT_CAMERA,
     ...definedCameraOverrides(options.camera ?? options.animationAdventure?.camera),
-  });
+  };
   const loopDurationMs = Math.max(durationFromBeats(beats), route.at(-1)?.arriveMs ?? 1, 1);
   const requestFrame = options.requestAnimationFrame ?? globalThis.requestAnimationFrame?.bind(globalThis);
   const cancelFrame = options.cancelAnimationFrame ?? globalThis.cancelAnimationFrame?.bind(globalThis);
@@ -434,6 +504,9 @@ export function createAnimatedSceneRenderer(options = {}) {
   let frame = 0;
   let startedAtMs;
   let lastTimestamp;
+  let pendingCameraControl = null;
+  let activeCameraControl = false;
+  let headLookWeight = 0;
   let cameraPosition = route[0]
     ? [
         route[0].position[0] + (camera.offset?.[0] ?? 0),
@@ -441,6 +514,22 @@ export function createAnimatedSceneRenderer(options = {}) {
         route[0].position[2] + (camera.offset?.[2] ?? 0),
       ]
     : [0, 2.4, 5.5];
+  let cameraRigFrame = resolveCameraRigFrame({
+    viewMode: "editor",
+    anchors: {
+      target: route[0]?.position ? [...route[0].position] : [0, 0, 0],
+      head: route[0]?.position ? [route[0].position[0], route[0].position[1] + 1.65, route[0].position[2]] : [0, 1.65, 0],
+      forward: [0, 0, -1],
+    },
+    camera: {
+      id: "animation-adventure",
+      transform: {
+        position: [...cameraPosition],
+        target: route[0]?.position ? [...route[0].position] : [0, 0, 0],
+      },
+    },
+    constraints: camera.constraints,
+  });
   let snapshot = {
     frame,
     running,
@@ -450,6 +539,10 @@ export function createAnimatedSceneRenderer(options = {}) {
     clipTimeMs: 0,
     characterPosition: route[0]?.position ? [...route[0].position] : [0, 0, 0],
     cameraPosition: [...cameraPosition],
+    cameraViewMode: resolveCameraViewMode(camera),
+    cameraTransform: cameraRigFrame.transform,
+    targetDistance: cameraRigFrame.targetDistance,
+    headLook: cameraRigFrame.headLook,
     characterGroundY: 0,
     characterVisible: false,
     modelLoaded: Boolean(characterModel),
@@ -481,6 +574,15 @@ export function createAnimatedSceneRenderer(options = {}) {
     const blendOut = blend.outMs > 0 ? clamp01((durationMs - beatTimeMs) / blend.outMs) : 1;
     const blendProgress = clamp01(Math.min(blendIn, blendOut));
     const characterPosition = resolveRoutePosition(route, loopTimeMs);
+    const characterForward = resolveRouteForward(route, loopTimeMs);
+    const headAnchor =
+      camera.headBoneAvailable === false
+        ? undefined
+        : [
+            characterPosition[0],
+            characterPosition[1] + (camera.headHeight ?? 1.65),
+            characterPosition[2],
+          ];
     const lookAheadPosition = resolveRoutePosition(route, loopTimeMs + camera.lookAheadMs);
     const desiredCamera = [
       lookAheadPosition[0] + (camera.offset?.[0] ?? 0),
@@ -489,6 +591,46 @@ export function createAnimatedSceneRenderer(options = {}) {
     ];
     const smoothing = bezierY(camera.cubicBezier, clamp01(frameTimeMs / Math.max(1, camera.lagMs)));
     cameraPosition = lerp3(cameraPosition, desiredCamera, smoothing);
+    const cameraViewMode = resolveCameraViewMode(camera);
+    const rigViewMode = cameraViewMode === "spectator" ? "editor" : cameraViewMode;
+    cameraRigFrame = resolveCameraRigFrame({
+      viewMode: rigViewMode,
+      anchors: {
+        target: characterPosition,
+        ...(headAnchor ? { head: headAnchor } : {}),
+        forward: characterForward,
+      },
+      camera: {
+        id: "animation-adventure",
+        transform: {
+          position: [...cameraPosition],
+          target: lookAheadPosition,
+        },
+      },
+      constraints: camera.constraints,
+      control: pendingCameraControl,
+      activeControl: activeCameraControl,
+    });
+
+    if (activeCameraControl && cameraRigFrame.headLook.status === "active") {
+      headLookWeight = cameraRigFrame.headLook.weight;
+    } else {
+      const returnMs = Math.max(1, camera.headLook?.returnMs ?? DEFAULT_CAMERA.headLook.returnMs);
+      headLookWeight = lerp(headLookWeight, 0, clamp01(frameTimeMs / returnMs));
+    }
+    const headLook = {
+      ...cameraRigFrame.headLook,
+      status:
+        cameraRigFrame.headLook.status === "unavailable"
+          ? "unavailable"
+          : headLookWeight > 0.001 && !activeCameraControl
+            ? "returning"
+            : cameraRigFrame.headLook.status,
+      weight: headLookWeight,
+    };
+    cameraPosition = [...cameraRigFrame.transform.position];
+    pendingCameraControl = null;
+    activeCameraControl = false;
 
     snapshot = {
       frame,
@@ -499,6 +641,10 @@ export function createAnimatedSceneRenderer(options = {}) {
       clipTimeMs: beatTimeMs,
       characterPosition,
       cameraPosition: [...cameraPosition],
+      cameraViewMode,
+      cameraTransform: cameraRigFrame.transform,
+      targetDistance: cameraRigFrame.targetDistance,
+      headLook,
       characterGroundY: 0,
       characterVisible: false,
       modelLoaded: Boolean(characterModel),
@@ -565,8 +711,35 @@ export function createAnimatedSceneRenderer(options = {}) {
         ...snapshot,
         characterPosition: [...snapshot.characterPosition],
         cameraPosition: [...snapshot.cameraPosition],
+        cameraTransform: {
+          position: [...snapshot.cameraTransform.position],
+          target: [...snapshot.cameraTransform.target],
+          up: [...snapshot.cameraTransform.up],
+        },
+        headLook: {
+          ...snapshot.headLook,
+          target: [...snapshot.headLook.target],
+        },
         propGroundAnchors: snapshot.propGroundAnchors.map((anchor) => ({ ...anchor })),
       };
+    },
+    setCamera(nextCamera = {}) {
+      camera = { ...camera, ...nextCamera };
+      snapshot = {
+        ...snapshot,
+        cameraViewMode: resolveCameraViewMode(camera),
+      };
+    },
+    setCameraViewMode(viewMode) {
+      camera = { ...camera, viewMode };
+      snapshot = {
+        ...snapshot,
+        cameraViewMode: resolveCameraViewMode(camera),
+      };
+    },
+    applyCameraControl(control, options = {}) {
+      pendingCameraControl = control;
+      activeCameraControl = options.activeControl !== false;
     },
     destroy() {
       running = false;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -26,11 +26,29 @@ export interface AnimatedSceneBeat {
 }
 
 export interface AnimatedSceneCameraFollowRig {
-  readonly mode?: "lagged-follow";
+  readonly mode?: "lagged-follow" | "editor" | "spectator" | "third-person" | "first-person";
+  readonly viewMode?: "editor" | "spectator" | "third-person" | "first-person";
   readonly cubicBezier?: readonly [number, number, number, number] | readonly number[];
   readonly lagMs?: number;
   readonly lookAheadMs?: number;
   readonly offset?: AnimatedSceneVector3;
+  readonly constraints?: {
+    readonly minDistance?: number;
+    readonly maxDistance?: number;
+    readonly minPolarAngle?: number;
+    readonly maxPolarAngle?: number;
+    readonly firstPersonHeadOffset?: number;
+    readonly headLookMaxYaw?: number;
+    readonly headLookMaxPitch?: number;
+    readonly headLookWeight?: number;
+  };
+  readonly headLook?: {
+    readonly enabled?: boolean;
+    readonly activeOnly?: boolean;
+    readonly returnMs?: number;
+  };
+  readonly headBoneAvailable?: boolean;
+  readonly headHeight?: number;
 }
 
 export interface AnimatedSceneProp {
@@ -78,6 +96,20 @@ export interface AnimatedSceneSnapshot {
   readonly clipTimeMs: number;
   readonly characterPosition: readonly [number, number, number];
   readonly cameraPosition: readonly [number, number, number];
+  readonly cameraViewMode: "editor" | "spectator" | "third-person" | "first-person";
+  readonly cameraTransform: {
+    readonly position: readonly [number, number, number];
+    readonly target: readonly [number, number, number];
+    readonly up: readonly [number, number, number];
+  };
+  readonly targetDistance: number;
+  readonly headLook: {
+    readonly status: "inactive" | "active" | "returning" | "unavailable";
+    readonly yaw: number;
+    readonly pitch: number;
+    readonly weight: number;
+    readonly target: readonly [number, number, number];
+  };
   readonly characterGroundY: number;
   readonly characterVisible: boolean;
   readonly modelLoaded: boolean;
@@ -104,6 +136,21 @@ export interface AnimatedSceneRenderer {
   resize(width: number, height: number, devicePixelRatio?: number): void;
   renderOnce(timestamp?: number): AnimatedSceneSnapshot;
   getSnapshot(): AnimatedSceneSnapshot;
+  setCamera(nextCamera?: Partial<AnimatedSceneCameraFollowRig>): void;
+  setCameraViewMode(viewMode: "editor" | "spectator" | "third-person" | "first-person"): void;
+  applyCameraControl(
+    control: {
+      readonly type?: "orbit" | "truck" | "pan" | "dolly" | "look";
+      readonly deltaAzimuth?: number;
+      readonly deltaPolar?: number;
+      readonly deltaX?: number;
+      readonly deltaY?: number;
+      readonly deltaYaw?: number;
+      readonly deltaPitch?: number;
+      readonly distance?: number;
+    },
+    options?: { readonly activeControl?: boolean },
+  ): void;
   destroy(): void;
 }
 

--- a/tests/package.test.js
+++ b/tests/package.test.js
@@ -463,6 +463,9 @@ test("createAnimatedSceneRenderer advances route, blend, camera, and lifecycle",
   assert.equal(second.activeClipId, "female-basic-locomotion-walking");
   assert.equal(second.characterPosition[0] > first.characterPosition[0], true);
   assert.equal(second.cameraPosition[0] < second.characterPosition[0], true);
+  assert.equal(second.cameraViewMode, "spectator");
+  assert.equal(Array.isArray(second.cameraTransform.position), true);
+  assert.equal(second.headLook.status, "inactive");
   assert.equal(second.blendProgress > 0, true);
   assert.equal(second.characterVisible, true);
   assert.equal(second.characterGroundY > 0, true);
@@ -473,6 +476,86 @@ test("createAnimatedSceneRenderer advances route, blend, camera, and lifecycle",
   renderer.destroy();
   assert.equal(canceled, 44);
   assert.equal(renderer.getSnapshot().frameState, "destroyed");
+});
+
+test("createAnimatedSceneRenderer resolves third-person camera constraints and head look", () => {
+  const canvas = createFakeCanvas2d();
+  const renderer = createAnimatedSceneRenderer({
+    canvas,
+    route: [
+      { id: "gate", position: [0, 0, 0], arriveMs: 0 },
+      { id: "crop-row", position: [4, 0, 0], arriveMs: 4000 },
+    ],
+    beats: [
+      {
+        id: "walk",
+        order: 0,
+        clipId: "female-basic-locomotion-walking",
+        durationMs: 1000,
+      },
+    ],
+    camera: {
+      viewMode: "third-person",
+      offset: [0, 3, 30],
+      constraints: {
+        maxDistance: 10,
+      },
+    },
+  });
+
+  renderer.applyCameraControl({ type: "orbit", deltaAzimuth: 0.25 }, { activeControl: true });
+  const frame = renderer.renderOnce(100);
+
+  assert.equal(frame.cameraViewMode, "third-person");
+  assert.equal(Math.round(frame.targetDistance), 10);
+  assert.equal(frame.headLook.status, "active");
+  assert.equal(frame.headLook.weight > 0, true);
+});
+
+test("createAnimatedSceneRenderer resolves first-person from the head anchor", () => {
+  const canvas = createFakeCanvas2d();
+  const renderer = createAnimatedSceneRenderer({
+    canvas,
+    route: [{ id: "gate", position: [2, 0, 3], arriveMs: 0 }],
+    beats: [
+      {
+        id: "idle",
+        order: 0,
+        clipId: "female-basic-locomotion-idle",
+        durationMs: 1000,
+      },
+    ],
+    camera: {
+      viewMode: "first-person",
+      constraints: {
+        firstPersonHeadOffset: 0.05,
+      },
+    },
+  });
+
+  const frame = renderer.renderOnce(100);
+
+  assert.equal(frame.cameraViewMode, "first-person");
+  assert.deepEqual(frame.cameraTransform.position.map((value) => Number(value.toFixed(2))), [2, 1.65, 2.95]);
+});
+
+test("createAnimatedSceneRenderer fails soft when a head bone is unavailable", () => {
+  const canvas = createFakeCanvas2d();
+  const renderer = createAnimatedSceneRenderer({
+    canvas,
+    route: [{ id: "gate", position: [0, 0, 0], arriveMs: 0 }],
+    beats: [],
+    camera: {
+      viewMode: "third-person",
+      headBoneAvailable: false,
+    },
+  });
+
+  renderer.applyCameraControl({ type: "look", deltaYaw: 0.4 }, { activeControl: true });
+  const frame = renderer.renderOnce(100);
+
+  assert.equal(frame.headLook.status, "unavailable");
+  assert.equal(frame.headLook.weight, 0);
 });
 
 test("createAnimatedSceneRenderer preserves camera defaults for undefined overrides", () => {


### PR DESCRIPTION
## Summary
- wire `createAnimatedSceneRenderer` to `@plasius/gpu-camera` rig resolution
- preserve legacy `lagged-follow` as spectator-compatible behavior while adding editor, spectator, third-person, and first-person snapshot state
- expose non-breaking camera control methods and head-look intent state for animated scene hosts

## Validation
- npm test
- npm run typecheck
- npm run lint

## Release note
This PR intentionally leaves package.json at the current published version. The approved CD workflow should be run from main with a patch bump after merge so it publishes @plasius/gpu-renderer@0.2.27.
