### PR TITLE
feat: add strict physical low-SPP transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,21 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 - **Added**
-  - (placeholder)
+  - Added the boolean `renderer.transport.strictPhysicalLowSppLighting` rollout
+    path, including direct/nested feature-flag input support and frame stats for
+    strict physical low-SPP lighting validation.
+  - Added strict physical termination diagnostics for absorption/null
+    throughput, Russian roulette, and strict max-depth termination.
 
 - **Changed**
-  - (placeholder)
+  - Changed strict low-SPP wavefront lighting to sample procedural sunlight as a
+    shadow-tested directional source, procedural sky over the visible
+    hemisphere, and emissive triangles by area-weighted emission power with
+    matching MIS PDFs.
 
 - **Fixed**
-  - (placeholder)
+  - Prevented strict physical low-SPP renders from using terminal ambient rescue
+    for max-depth, null-throughput, or queue-overflow termination.
 
 - **Security**
   - (placeholder)

--- a/README.md
+++ b/README.md
@@ -145,6 +145,15 @@ The production transport rollout remains gated by
 continuation vertices carry sanitized physical throughput segments instead of a
 heuristic material-response tint, while the older fallback path remains the
 rollback route during validation.
+Low-SPP physical lighting hardening is separately controlled by the boolean
+`renderer.transport.strictPhysicalLowSppLighting` flag, passed either as
+`strictPhysicalLowSppLighting: true` or through `featureFlags`. When enabled,
+the renderer disables terminal ambient rescue for max-depth/null-throughput
+termination, samples procedural sunlight as an explicit shadow-tested
+directional source, samples procedural sky over the visible hemisphere, and
+selects emissive triangles by area-weighted emission power with matching MIS
+PDFs. Use `denoise: false` when validating this strict path so remaining
+variance is measured in the transport rather than hidden by filtering.
 
 ```js
 import {
@@ -303,6 +312,9 @@ The same stats also expose `radianceDiagnostics.invalidSamples` and
 `radianceDiagnostics.legacyClampEquivalentSamples`, so hardening scenes can
 measure NaN/Inf cleanup and legacy-4.0-equivalent fireflies without
 re-introducing a hidden estimator clamp.
+When `strictPhysicalLowSppLighting` is enabled, termination stats also separate
+`absorptionNull`, `russianRoulette`, and `strictMaxDepth` so validation can
+distinguish physically explainable dark samples from legacy ambient fallback.
 For static mesh scenes, the GPU acceleration build is submitted once and then
 reused by subsequent frames. Per-frame tracing writes one dynamic uniform slot
 per tile/sample or post-process pass and batches tile tracing, tile output,

--- a/docs/adrs/adr-0021-strict-physical-low-spp-lighting.md
+++ b/docs/adrs/adr-0021-strict-physical-low-spp-lighting.md
@@ -1,0 +1,52 @@
+# ADR 0021: Strict Physical Low-SPP Lighting
+
+## Status
+
+Accepted
+
+## Context
+
+Low-SPP wavefront renders were too dependent on heuristic terminal residuals and
+uniform light selection. Those mechanisms made some frames brighter, but they
+also made dark pixels difficult to classify because max-depth expiry, null
+throughput, queue overflow, and genuine occlusion could all look like unstable
+lighting failures.
+
+The renderer needs a remotely switchable path that favours physically
+explainable transport over preview stabilization.
+
+## Decision
+
+`@plasius/gpu-renderer` will support the boolean rollout flag
+`renderer.transport.strictPhysicalLowSppLighting`.
+
+When enabled, the wavefront path tracer:
+
+- stops using terminal ambient rescue for max-depth, null-throughput, and queue
+  overflow termination;
+- records strict physical termination reasons for absorption/null throughput,
+  Russian roulette, strict max-depth loss, and queue overflow;
+- samples procedural sunlight as an explicit shadow-tested directional light;
+- samples procedural sky from the surface hemisphere instead of a uniform
+  sphere fallback; and
+- selects emissive triangles by area-weighted emission power, with PDFs that
+  match the sampled distribution before MIS.
+
+When disabled, existing stabilized behavior remains the rollback path.
+
+## Consequences
+
+- Strict mode can retain honest Monte Carlo variance at very low SPP, but dark
+  pixels should now be explainable by diagnostics rather than hidden terminal
+  fill.
+- Procedural sun and finite emissive lights no longer depend on raw collision
+  luck or uniform triangle selection.
+- The counter buffer grows to expose additional termination categories.
+
+## Validation
+
+- Unit coverage must assert boolean flag packing, strict termination reasons,
+  procedural sun/sky sampling, power-weighted emissive selection, and corrected
+  emissive PDFs.
+- Existing Eames/Product Studio benchmark scenes should be validated with
+  `denoise: false` at SPP 1, 4, 8, and 20 before enabling strict mode broadly.

--- a/docs/adrs/index.md
+++ b/docs/adrs/index.md
@@ -18,4 +18,6 @@
 - [ADR 0016: Mixed Direct-Light MIS For Wavefront Materials](./adr-0016-mixed-direct-light-mis-for-wavefront-materials.md)
 - [ADR 0017: Physical Throughput For Wavefront Continuations](./adr-0017-physical-throughput-for-wavefront-continuations.md)
 - [ADR 0018: Purpose-Specific Renderer Module Boundaries](./adr-0018-purpose-specific-renderer-module-boundaries.md)
+- [ADR 0019: Wavefront Sample Dimensions and Denoise-Independence Gates](./adr-0019-wavefront-sample-dimensions-and-denoise-independence.md)
 - [ADR 0020: Animated Camera Rig Integration](./adr-0020-animated-camera-rig-integration.md)
+- [ADR 0021: Strict Physical Low-SPP Lighting](./adr-0021-strict-physical-low-spp-lighting.md)

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -698,6 +698,7 @@ export interface WavefrontPathTracingComputeConfig {
   readonly environmentPortalMode: 0 | 1 | 2;
   readonly environmentMap: WavefrontEnvironmentMapInput;
   readonly deferredPathResolve: boolean;
+  readonly strictPhysicalLowSppLighting: boolean;
   readonly triangleCount: number;
   readonly triangleCapacity: number;
   readonly bvhNodeCount: number;
@@ -722,6 +723,15 @@ export interface WavefrontPathTracingComputeConfig {
   readonly denoise: boolean;
   readonly frameIndex: number;
   readonly memory: WavefrontPathTracingMemoryEstimate;
+}
+
+export interface WavefrontRendererFeatureFlags {
+  readonly "renderer.transport.strictPhysicalLowSppLighting"?: boolean;
+  readonly renderer?: {
+    readonly transport?: {
+      readonly strictPhysicalLowSppLighting?: boolean;
+    };
+  };
 }
 
 export interface WavefrontEnvironmentLightingInput {
@@ -852,6 +862,8 @@ export interface CreateWavefrontPathTracingComputeRendererOptions {
   readonly environmentLighting?: WavefrontEnvironmentLightingInput;
   readonly displayQuality?: boolean;
   readonly denoise?: boolean;
+  readonly strictPhysicalLowSppLighting?: boolean;
+  readonly featureFlags?: WavefrontRendererFeatureFlags;
   readonly frameIndex?: number;
 }
 
@@ -899,6 +911,7 @@ export interface WavefrontPathTracingComputeRenderer {
     mediumCount: number;
     environmentMap: WavefrontEnvironmentMapSnapshot;
     deferredPathResolve: boolean;
+    strictPhysicalLowSppLighting: boolean;
     bvhNodeCount: number;
     displayQuality: boolean;
     accelerationBuildMode: WavefrontAccelerationBuildMode;
@@ -934,6 +947,7 @@ export interface WavefrontPathTracingComputeFrameStats {
   readonly mediumCount: number;
   readonly environmentMap: WavefrontEnvironmentMapSnapshot;
   readonly deferredPathResolve: boolean;
+  readonly strictPhysicalLowSppLighting: boolean;
   readonly bvhNodeCount: number;
   readonly displayQuality: boolean;
   readonly accelerationBuildMode: WavefrontAccelerationBuildMode;
@@ -1000,6 +1014,9 @@ export interface WavefrontPathTracingComputeFrameStats {
     environment: number;
     ambientFallback: number;
     maxDepth: number;
+    absorptionNull: number;
+    russianRoulette: number;
+    strictMaxDepth: number;
   }>;
   readonly terminalRadiance?: Readonly<{
     totalLuminance: number;
@@ -1161,7 +1178,7 @@ export const wavefrontPathTracingComputeLimits: Readonly<{
   environmentPortalRecordBytes: 96;
   accumulationRecordBytes: 16;
   pathVertexRecordBytes: 16;
-  counterRecordBytes: 32;
+  counterRecordBytes: 80;
   indirectDispatchRecordBytes: 12;
 }>;
 export const wavefrontSceneObjectKinds: Readonly<{

--- a/src/wavefront-compute.js
+++ b/src/wavefront-compute.js
@@ -150,6 +150,23 @@ import {
   wavefrontPathTracingComputeLimits,
   wavefrontSceneObjectKinds,
 } from "./wavefront-core.js";
+
+function triangleAreaForLightSampling(triangle) {
+  if (!triangle) {
+    return 1;
+  }
+  const edge1 = subtract(triangle.v1, triangle.v0);
+  const edge2 = subtract(triangle.v2, triangle.v0);
+  return Math.max(Math.hypot(...cross(edge1, edge2)) * 0.5, 0.000001);
+}
+
+function emissiveTriangleWeight(triangle) {
+  if (!triangle) {
+    return 1;
+  }
+  return triangleAreaForLightSampling(triangle) * Math.max(emissionPower(triangle.emission), 0.000001);
+}
+
 export async function createWavefrontPathTracingComputeRenderer(options = {}) {
   assertAnalyticDisplayQualityPolicy(options);
   const constants = getGpuUsageConstants();
@@ -321,8 +338,18 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
     Math.max(1, config.bvhNodeCapacity + config.emissiveTriangleCapacity)
   );
   const packedBvhNodeUints = new Uint32Array(packedBvhNodes.buffer);
+  const packedBvhNodeFloats = new Float32Array(packedBvhNodes.buffer);
+  const emissiveWeights = config.emissiveTriangleIndices.indices.map((triangleIndex) =>
+    emissiveTriangleWeight(config.meshAcceleration.triangles[triangleIndex])
+  );
+  const totalEmissiveWeight = emissiveWeights.reduce((total, weight) => total + weight, 0);
+  let cumulativeEmissiveWeight = 0;
   config.emissiveTriangleIndices.indices.forEach((triangleIndex, index) => {
     const nodeOffset = (config.bvhNodeCapacity + index) * (BVH_NODE_RECORD_BYTES / 4);
+    cumulativeEmissiveWeight += emissiveWeights[index] ?? 0;
+    packedBvhNodeFloats[nodeOffset] = cumulativeEmissiveWeight;
+    packedBvhNodeFloats[nodeOffset + 1] = emissiveWeights[index] ?? 0;
+    packedBvhNodeFloats[nodeOffset + 2] = totalEmissiveWeight;
     packedBvhNodeUints[nodeOffset + 8] = triangleIndex;
   });
   device.queue.writeBuffer(triangleBuffer, 0, packedTriangles.buffer);
@@ -857,6 +884,7 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
       environmentMap: {
         ...config.environmentMap,
       },
+      strictPhysicalLowSppLighting: config.strictPhysicalLowSppLighting,
       frameIndex: config.frameIndex,
       ...overrides,
     });

--- a/src/wavefront-config.js
+++ b/src/wavefront-config.js
@@ -46,6 +46,7 @@ import {
   rendererWavefrontComputeMode,
   resolveDeferredPathResolve,
   resolveEnvironmentMap,
+  resolveStrictPhysicalLowSppLighting,
   scale,
   subtract,
 } from "./wavefront-core.js";
@@ -455,6 +456,7 @@ export function createWavefrontPathTracingComputeConfig(options = {}) {
       options.environmentLighting?.environmentMap
   );
   const deferredPathResolve = resolveDeferredPathResolve(options);
+  const strictPhysicalLowSppLighting = resolveStrictPhysicalLowSppLighting(options);
 
   return Object.freeze({
     mode: rendererWavefrontComputeMode,
@@ -495,6 +497,7 @@ export function createWavefrontPathTracingComputeConfig(options = {}) {
     environmentPortalMode,
     environmentMap,
     deferredPathResolve,
+    strictPhysicalLowSppLighting,
     displayQuality: options.displayQuality === true,
     requiresMeshBvhForDisplayQuality: true,
     denoise: options.denoise !== false,

--- a/src/wavefront-core.js
+++ b/src/wavefront-core.js
@@ -38,7 +38,7 @@ export const GPU_MAX_SUBMITTED_WORK_DEADLINE_MS = 180_000;
 export const CONFIG_BUFFER_BYTES = 320;
 export const COUNTER_DISPATCH_ARGS_OFFSET = 16;
 export const INDIRECT_DISPATCH_ARGS_BYTES = 12;
-export const COUNTER_BUFFER_BYTES = 64;
+export const COUNTER_BUFFER_BYTES = 80;
 export const TERMINATION_LUMINANCE_SCALE = 1_000_000;
 export const COUNTER_TERMINATION_EMISSIVE_OFFSET = 8;
 export const COUNTER_TERMINATION_ENVIRONMENT_OFFSET = 9;
@@ -48,6 +48,9 @@ export const COUNTER_TERMINATION_AMBIENT_LUMINANCE_OFFSET = 12;
 export const COUNTER_TERMINATION_TOTAL_LUMINANCE_OFFSET = 13;
 export const COUNTER_TERMINATION_INVALID_SAMPLE_OFFSET = 14;
 export const COUNTER_TERMINATION_LEGACY_CLAMP_EQUIVALENT_OFFSET = 15;
+export const COUNTER_TERMINATION_ABSORPTION_NULL_OFFSET = 16;
+export const COUNTER_TERMINATION_RUSSIAN_ROULETTE_OFFSET = 17;
+export const COUNTER_TERMINATION_MAX_DEPTH_STRICT_OFFSET = 18;
 export const TRACE_STORAGE_BUFFER_BINDINGS = 10;
 export const BRDF_LUT_UPLOAD_CACHE = new Map();
 export const HIT_TYPE_SURFACE = 0;
@@ -56,6 +59,9 @@ export const TERMINAL_SOURCE_KIND_EMISSIVE = 1;
 export const TERMINAL_SOURCE_KIND_ENVIRONMENT = 2;
 export const TERMINAL_SOURCE_KIND_AMBIENT_MAX_DEPTH = 3;
 export const TERMINAL_SOURCE_KIND_AMBIENT_QUEUE_OVERFLOW = 4;
+export const TERMINAL_SOURCE_KIND_ABSORPTION_NULL = 5;
+export const TERMINAL_SOURCE_KIND_RUSSIAN_ROULETTE = 6;
+export const TERMINAL_SOURCE_KIND_MAX_DEPTH_STRICT = 7;
 export const MATERIAL_DIFFUSE = 0;
 export const MATERIAL_METAL = 1;
 export const MATERIAL_DIELECTRIC = 2;
@@ -90,6 +96,9 @@ export const EMPTY_TERMINATION_METRICS = Object.freeze({
     environment: 0,
     ambientFallback: 0,
     maxDepth: 0,
+    absorptionNull: 0,
+    russianRoulette: 0,
+    strictMaxDepth: 0,
   }),
   queueOverflow: 0,
   terminalRadiance: Object.freeze({
@@ -280,6 +289,15 @@ export function resolveDeferredPathResolve(options = {}) {
     options.pathResolve?.deferred ??
     true;
   return value !== false;
+}
+
+export function resolveStrictPhysicalLowSppLighting(options = {}) {
+  const value =
+    options.strictPhysicalLowSppLighting ??
+    options.featureFlags?.["renderer.transport.strictPhysicalLowSppLighting"] ??
+    options.featureFlags?.renderer?.transport?.strictPhysicalLowSppLighting ??
+    false;
+  return value === true;
 }
 
 export function emissionPower(emission) {

--- a/src/wavefront-frame-stats.js
+++ b/src/wavefront-frame-stats.js
@@ -115,6 +115,7 @@ export function createWavefrontFrameStats({
       mediumCount: config.mediumCount,
       environmentMap: createEnvironmentMapSnapshot(config.environmentMap),
       deferredPathResolve: config.deferredPathResolve,
+      strictPhysicalLowSppLighting: config.strictPhysicalLowSppLighting,
       bvhNodeCount: config.bvhNodeCount,
       displayQuality: config.displayQuality,
       accelerationBuildMode: config.accelerationBuildMode,

--- a/src/wavefront-packers.js
+++ b/src/wavefront-packers.js
@@ -211,7 +211,7 @@ export function createConfigPayload(config, tile, frameIndex, buildRange = {}) {
   writeVec4(floatView, 288, [
     config.deferredPathResolve ? 1 : 0,
     config.environmentLighting.sunlitBaseline,
-    0,
+    config.strictPhysicalLowSppLighting ? 1 : 0,
     0,
   ]);
   writeVec4(floatView, 304, [

--- a/src/wavefront-readbacks.js
+++ b/src/wavefront-readbacks.js
@@ -1,12 +1,15 @@
 import {
   COUNTER_BUFFER_BYTES,
+  COUNTER_TERMINATION_ABSORPTION_NULL_OFFSET,
   COUNTER_TERMINATION_AMBIENT_LUMINANCE_OFFSET,
   COUNTER_TERMINATION_AMBIENT_MAX_DEPTH_OFFSET,
   COUNTER_TERMINATION_EMISSIVE_OFFSET,
   COUNTER_TERMINATION_ENVIRONMENT_OFFSET,
   COUNTER_TERMINATION_INVALID_SAMPLE_OFFSET,
   COUNTER_TERMINATION_LEGACY_CLAMP_EQUIVALENT_OFFSET,
+  COUNTER_TERMINATION_MAX_DEPTH_STRICT_OFFSET,
   COUNTER_TERMINATION_QUEUE_OVERFLOW_OFFSET,
+  COUNTER_TERMINATION_RUSSIAN_ROULETTE_OFFSET,
   COUNTER_TERMINATION_TOTAL_LUMINANCE_OFFSET,
   EMPTY_TERMINATION_METRICS,
   GPU_READBACK_COMPLETION_TIMEOUT_MS,
@@ -54,6 +57,9 @@ export async function readWavefrontTerminationMetrics({
   const invalidSamples = countersView[COUNTER_TERMINATION_INVALID_SAMPLE_OFFSET] ?? 0;
   const legacyClampEquivalentSamples =
     countersView[COUNTER_TERMINATION_LEGACY_CLAMP_EQUIVALENT_OFFSET] ?? 0;
+  const absorptionNull = countersView[COUNTER_TERMINATION_ABSORPTION_NULL_OFFSET] ?? 0;
+  const russianRoulette = countersView[COUNTER_TERMINATION_RUSSIAN_ROULETTE_OFFSET] ?? 0;
+  const strictMaxDepth = countersView[COUNTER_TERMINATION_MAX_DEPTH_STRICT_OFFSET] ?? 0;
   const ambientResidualLuminance =
     (countersView[COUNTER_TERMINATION_AMBIENT_LUMINANCE_OFFSET] ?? 0) /
     TERMINATION_LUMINANCE_SCALE;
@@ -68,6 +74,9 @@ export async function readWavefrontTerminationMetrics({
       environment,
       ambientFallback: maxDepth + queueOverflow,
       maxDepth,
+      absorptionNull,
+      russianRoulette,
+      strictMaxDepth,
     }),
     queueOverflow,
     terminalRadiance: Object.freeze({

--- a/src/wavefront-sampling-dimensions.js
+++ b/src/wavefront-sampling-dimensions.js
@@ -13,6 +13,7 @@ const sampleDimensionEntries = Object.freeze([
   ["specularHalfVector", 23],
   ["clearcoatHalfVector", 24],
   ["fallbackHemisphere", 25],
+  ["russianRoulette", 26],
   ["emissiveLightSelection", 31],
   ["emissiveLightSurface", 32],
   ["directLightSelector", 41],

--- a/src/wavefront-shader-kernels.js
+++ b/src/wavefront-shader-kernels.js
@@ -70,6 +70,18 @@ fn record_termination_metrics(kind: u32, radiance: vec3<f32>) {
   if (kind == TERMINAL_SOURCE_KIND_AMBIENT_QUEUE_OVERFLOW) {
     atomicAdd(&counters.termination.ambientQueueOverflowCount, 1u);
     atomicAdd(&counters.termination.ambientResidualLuminanceScaled, scaledLuminance);
+    return;
+  }
+  if (kind == TERMINAL_SOURCE_KIND_ABSORPTION_NULL) {
+    atomicAdd(&counters.termination.absorptionNullCount, 1u);
+    return;
+  }
+  if (kind == TERMINAL_SOURCE_KIND_RUSSIAN_ROULETTE) {
+    atomicAdd(&counters.termination.russianRouletteCount, 1u);
+    return;
+  }
+  if (kind == TERMINAL_SOURCE_KIND_MAX_DEPTH_STRICT) {
+    atomicAdd(&counters.termination.strictMaxDepthCount, 1u);
   }
 }
 
@@ -117,6 +129,10 @@ fn generatePrimaryRays(@builtin(global_invocation_id) globalId: vec3<u32>) {
     atomicStore(&counters.termination.totalTerminalLuminanceScaled, 0u);
     atomicStore(&counters.termination.invalidSampleCount, 0u);
     atomicStore(&counters.termination.legacyClampEquivalentCount, 0u);
+    atomicStore(&counters.termination.absorptionNullCount, 0u);
+    atomicStore(&counters.termination.russianRouletteCount, 0u);
+    atomicStore(&counters.termination.strictMaxDepthCount, 0u);
+    atomicStore(&counters.termination.strictPad0, 0u);
     write_active_dispatch_args(config.tilePixelCount);
   }
   if (index >= config.tilePixelCount) {
@@ -634,7 +650,23 @@ fn resolveSurfaceRecords(@builtin(global_invocation_id) globalId: vec3<u32>) {
       ),
       hit
     );
-    let rawDirectLight = directLight * sample_weight();
+    let sunLight = surface_procedural_sun_contribution(
+      RayRecord(
+        ray.rayId,
+        ray.parentRayId,
+        ray.sourcePixelId,
+        ray.sampleId,
+        ray.bounce,
+        ray.mediumRefId,
+        ray.flags,
+        0u,
+        ray.origin,
+        ray.direction,
+        vec4<f32>(arrivingThroughput, ray.throughput.w)
+      ),
+      hit
+    );
+    let rawDirectLight = (directLight + sunLight) * sample_weight();
     record_radiance_diagnostics(rawDirectLight);
     let weightedDirectLight = sanitize_linear_radiance(rawDirectLight);
     accumulation[ray.rayId] =
@@ -643,11 +675,19 @@ fn resolveSurfaceRecords(@builtin(global_invocation_id) globalId: vec3<u32>) {
 
   if (ray.bounce + 1u >= config.maxDepth) {
     if (deferred_path_resolve_enabled()) {
-      record_deferred_terminal_source(
-        ray,
-        terminal_surface_environment_source(ray, hit),
-        TERMINAL_SOURCE_KIND_AMBIENT_MAX_DEPTH
-      );
+      if (strict_physical_low_spp_lighting_enabled()) {
+        record_deferred_terminal_source(
+          ray,
+          vec3<f32>(0.0),
+          TERMINAL_SOURCE_KIND_MAX_DEPTH_STRICT
+        );
+      } else {
+        record_deferred_terminal_source(
+          ray,
+          terminal_surface_environment_source(ray, hit),
+          TERMINAL_SOURCE_KIND_AMBIENT_MAX_DEPTH
+        );
+      }
     } else {
       let terminalEnvironment = terminal_surface_environment_contribution(
         ray,
@@ -669,7 +709,7 @@ fn resolveSurfaceRecords(@builtin(global_invocation_id) globalId: vec3<u32>) {
   let continuationNormal = surface_shading_normal(hit);
   let continuationViewDirection = safe_normalize(-ray.direction.xyz, continuationNormal);
   let continuationLightDirection = safe_normalize(scatter.direction.xyz, continuationNormal);
-  let continuationThroughput = surface_continuation_throughput(
+  var continuationThroughput = surface_continuation_throughput(
     hit,
     continuationViewDirection,
     continuationLightDirection,
@@ -677,11 +717,19 @@ fn resolveSurfaceRecords(@builtin(global_invocation_id) globalId: vec3<u32>) {
   ) * segmentTransmittance;
   if (max_component(continuationThroughput) <= 0.000001) {
     if (deferred_path_resolve_enabled()) {
-      record_deferred_terminal_source(
-        ray,
-        terminal_surface_environment_source(ray, hit),
-        TERMINAL_SOURCE_KIND_AMBIENT_MAX_DEPTH
-      );
+      if (strict_physical_low_spp_lighting_enabled()) {
+        record_deferred_terminal_source(
+          ray,
+          vec3<f32>(0.0),
+          TERMINAL_SOURCE_KIND_ABSORPTION_NULL
+        );
+      } else {
+        record_deferred_terminal_source(
+          ray,
+          terminal_surface_environment_source(ray, hit),
+          TERMINAL_SOURCE_KIND_AMBIENT_MAX_DEPTH
+        );
+      }
     } else {
       let terminalEnvironment = terminal_surface_environment_contribution(
         ray,
@@ -698,14 +746,46 @@ fn resolveSurfaceRecords(@builtin(global_invocation_id) globalId: vec3<u32>) {
     atomicAdd(&counters.terminatedCount, 1u);
     return;
   }
+  if (strict_physical_low_spp_lighting_enabled() && ray.bounce >= 2u) {
+    let survivalProbability = clamp(max_component(continuationThroughput), 0.05, 0.95);
+    let roulette = sample_dimension_1d(
+      ray.sourcePixelId,
+      ray.sampleId,
+      ray.bounce,
+      config.frameIndex,
+      SAMPLE_DIM_RUSSIAN_ROULETTE
+    );
+    if (roulette > survivalProbability) {
+      if (deferred_path_resolve_enabled()) {
+        record_deferred_terminal_source(
+          ray,
+          vec3<f32>(0.0),
+          TERMINAL_SOURCE_KIND_RUSSIAN_ROULETTE
+        );
+      } else {
+        record_termination_metrics(TERMINAL_SOURCE_KIND_RUSSIAN_ROULETTE, vec3<f32>(0.0));
+      }
+      atomicAdd(&counters.terminatedCount, 1u);
+      return;
+    }
+    continuationThroughput = continuationThroughput / survivalProbability;
+  }
   let nextIndex = atomicAdd(&counters.nextCount, 1u);
   if (nextIndex >= config.tilePixelCount) {
     if (deferred_path_resolve_enabled()) {
-      record_deferred_terminal_source(
-        ray,
-        terminal_surface_environment_source(ray, hit),
-        TERMINAL_SOURCE_KIND_AMBIENT_QUEUE_OVERFLOW
-      );
+      if (strict_physical_low_spp_lighting_enabled()) {
+        record_deferred_terminal_source(
+          ray,
+          vec3<f32>(0.0),
+          TERMINAL_SOURCE_KIND_AMBIENT_QUEUE_OVERFLOW
+        );
+      } else {
+        record_deferred_terminal_source(
+          ray,
+          terminal_surface_environment_source(ray, hit),
+          TERMINAL_SOURCE_KIND_AMBIENT_QUEUE_OVERFLOW
+        );
+      }
     } else {
       let overflowEnvironment = terminal_surface_environment_contribution(
         ray,

--- a/src/wavefront-shader-layout.js
+++ b/src/wavefront-shader-layout.js
@@ -3,6 +3,8 @@ import { WAVEFRONT_SAMPLE_DIMENSIONS_WGSL } from "./wavefront-sampling-dimension
 export const WAVEFRONT_SHADER_LAYOUT_WGSL = `
 const RAY_FLAG_GUIDED_EMISSIVE: u32 = 1u;
 const RAY_FLAG_DELTA_SAMPLE: u32 = 2u;
+const DIRECT_LIGHT_FLAG_DELTA: u32 = 1u;
+const DIRECT_LIGHT_FLAG_PHYSICAL_SUN: u32 = 2u;
 const SCATTER_LOBE_DIFFUSE: u32 = 1u;
 const SCATTER_LOBE_SPECULAR: u32 = 2u;
 const SCATTER_LOBE_CLEARCOAT: u32 = 3u;
@@ -210,12 +212,19 @@ struct TerminationMetrics {
   totalTerminalLuminanceScaled: atomic<u32>,
   invalidSampleCount: atomic<u32>,
   legacyClampEquivalentCount: atomic<u32>,
+  absorptionNullCount: atomic<u32>,
+  russianRouletteCount: atomic<u32>,
+  strictMaxDepthCount: atomic<u32>,
+  strictPad0: atomic<u32>,
 };
 
 const TERMINAL_SOURCE_KIND_EMISSIVE = 1u;
 const TERMINAL_SOURCE_KIND_ENVIRONMENT = 2u;
 const TERMINAL_SOURCE_KIND_AMBIENT_MAX_DEPTH = 3u;
 const TERMINAL_SOURCE_KIND_AMBIENT_QUEUE_OVERFLOW = 4u;
+const TERMINAL_SOURCE_KIND_ABSORPTION_NULL = 5u;
+const TERMINAL_SOURCE_KIND_RUSSIAN_ROULETTE = 6u;
+const TERMINAL_SOURCE_KIND_MAX_DEPTH_STRICT = 7u;
 const TERMINATION_LUMINANCE_SCALE = 1000000.0;
 
 struct Counters {

--- a/src/wavefront-shader-lighting.js
+++ b/src/wavefront-shader-lighting.js
@@ -13,21 +13,26 @@ fn environment_map_radiance(direction: vec3<f32>) -> vec3<f32> {
   return texel * max(config.environmentMapSettings.y, 0.0);
 }
 
-fn procedural_environment_radiance(direction: vec3<f32>) -> vec3<f32> {
+fn procedural_sky_radiance(direction: vec3<f32>) -> vec3<f32> {
   let rayDirection = safe_normalize(direction, vec3<f32>(0.0, 1.0, 0.0));
   let upFactor = saturate(rayDirection.y * 0.5 + 0.5);
+  return (
+    config.environmentHorizonColor.xyz * (1.0 - upFactor) +
+    config.environmentZenithColor.xyz * upFactor
+  ) * max(config.environmentSunDirectionIntensity.w, 0.0001);
+}
+
+fn procedural_environment_radiance(direction: vec3<f32>) -> vec3<f32> {
+  let rayDirection = safe_normalize(direction, vec3<f32>(0.0, 1.0, 0.0));
   let sunDirection = safe_normalize(
     config.environmentSunDirectionIntensity.xyz,
     vec3<f32>(0.0, 1.0, 0.0)
   );
   let sunGlow = pow(saturate(dot(rayDirection, sunDirection)), 192.0);
-  let gradient =
-    config.environmentHorizonColor.xyz * (1.0 - upFactor) +
-    config.environmentZenithColor.xyz * upFactor;
   return (
-    gradient +
-    config.environmentSunColor.xyz * sunGlow
-  ) * max(config.environmentSunDirectionIntensity.w, 0.0001);
+    procedural_sky_radiance(rayDirection) +
+    config.environmentSunColor.xyz * sunGlow * max(config.environmentSunDirectionIntensity.w, 0.0001)
+  );
 }
 
 fn base_environment_radiance(direction: vec3<f32>) -> vec3<f32> {
@@ -181,11 +186,22 @@ fn uniform_sphere_pdf() -> f32 {
   return 1.0 / (4.0 * 3.14159265359);
 }
 
+fn uniform_hemisphere_pdf() -> f32 {
+  return 1.0 / (2.0 * 3.14159265359);
+}
+
 fn sample_uniform_sphere_direction(sample: vec2<f32>) -> vec3<f32> {
   let z = 1.0 - 2.0 * sample.y;
   let radial = sqrt(max(1.0 - z * z, 0.0));
   let phi = sample.x * 6.28318530718;
   return vec3<f32>(cos(phi) * radial, z, sin(phi) * radial);
+}
+
+fn sample_uniform_hemisphere_direction(sample: vec2<f32>, normal: vec3<f32>) -> vec3<f32> {
+  let z = sample.y;
+  let radial = sqrt(max(1.0 - z * z, 0.0));
+  let phi = sample.x * 6.28318530718;
+  return local_to_world(vec3<f32>(cos(phi) * radial, sin(phi) * radial, z), normal);
 }
 
 fn environment_sampling_texel(x: u32, y: u32) -> vec4<f32> {
@@ -715,13 +731,26 @@ fn sample_emissive_triangle_light(
   if (config.emissiveTriangleCount == 0u) {
     return DirectLightSample(vec4<f32>(0.0), vec4<f32>(0.0), 0.0, 0.0, 0u, 0u);
   }
-  let lightSlot = min(
-    u32(
-      sample_dimension_1d(pixelId, sampleId, bounce, frameIndex, selectionDimension) *
-      f32(config.emissiveTriangleCount)
-    ),
+  let selector =
+    sample_dimension_1d(pixelId, sampleId, bounce, frameIndex, selectionDimension);
+  var lightSlot = min(
+    u32(selector * f32(config.emissiveTriangleCount)),
     config.emissiveTriangleCount - 1u
   );
+  if (strict_physical_low_spp_lighting_enabled()) {
+    let firstMetadata = bvhNodes[config.bvhNodeCapacity];
+    let totalWeight = max(firstMetadata.boundsMin.z, 0.0);
+    if (totalWeight > 0.000001) {
+      let targetWeight = selector * totalWeight;
+      for (var candidateSlot = 0u; candidateSlot < config.emissiveTriangleCount; candidateSlot = candidateSlot + 1u) {
+        let candidateMetadata = bvhNodes[config.bvhNodeCapacity + candidateSlot];
+        if (targetWeight <= candidateMetadata.boundsMin.x) {
+          lightSlot = candidateSlot;
+          break;
+        }
+      }
+    }
+  }
   let lightMetadata = bvhNodes[config.bvhNodeCapacity + lightSlot];
   let triangleIndex = lightMetadata.childOrFirst;
   if (triangleIndex >= config.triangleCount) {
@@ -749,7 +778,15 @@ fn sample_emissive_triangle_light(
     lightTriangle.v2.xyz * b2;
   let lightDirection = safe_normalize(lightPoint - hit.position.xyz, lightNormal);
   let traceDistance = max(distance(lightPoint, hit.position.xyz) - 0.01, 0.01);
-  let areaPdf = 1.0 / max(triangleArea * f32(config.emissiveTriangleCount), 0.000001);
+  var selectionProbability = 1.0 / max(f32(config.emissiveTriangleCount), 1.0);
+  if (strict_physical_low_spp_lighting_enabled()) {
+    let totalWeight = max(lightMetadata.boundsMin.z, 0.0);
+    let triangleWeight = max(lightMetadata.boundsMin.y, 0.0);
+    if (totalWeight > 0.000001 && triangleWeight > 0.000001) {
+      selectionProbability = triangleWeight / totalWeight;
+    }
+  }
+  let areaPdf = selectionProbability / max(triangleArea, 0.000001);
   let lightPdf = solid_angle_pdf_from_area_pdf(areaPdf, hit.position.xyz, lightPoint, lightNormal);
   if (lightPdf <= 0.000001) {
     return DirectLightSample(vec4<f32>(0.0), vec4<f32>(0.0), 0.0, 0.0, 0u, 0u);
@@ -779,19 +816,29 @@ fn sample_direct_light(hit: HitRecord, ray: RayRecord, normal: vec3<f32>) -> Dir
       SAMPLE_DIM_DIRECT_ENVIRONMENT,
       config.samplesPerPixel
     );
-    let environmentSample = sample_environment_importance(vec2<f32>(
-      selector / max(environmentSelectionProbability, 0.000001),
-      environmentUv.y
-    ));
-    let lightDirection = safe_normalize(environmentSample.direction, normal);
-    let radiance = direct_environment_radiance(
-      offset_origin(hit.position.xyz, hit.geometricNormal.xyz, hit.shadingNormal.xyz, lightDirection),
-      lightDirection
-    );
+    var lightDirection = normal;
+    var radiance = vec3<f32>(0.0);
+    var pdf = 0.0;
+    if (strict_physical_low_spp_lighting_enabled() && !environment_importance_sampling_enabled()) {
+      lightDirection = sample_uniform_hemisphere_direction(environmentUv, normal);
+      radiance = procedural_sky_radiance(lightDirection);
+      pdf = uniform_hemisphere_pdf();
+    } else {
+      let environmentSample = sample_environment_importance(vec2<f32>(
+        selector / max(environmentSelectionProbability, 0.000001),
+        environmentUv.y
+      ));
+      lightDirection = safe_normalize(environmentSample.direction, normal);
+      radiance = direct_environment_radiance(
+        offset_origin(hit.position.xyz, hit.geometricNormal.xyz, hit.shadingNormal.xyz, lightDirection),
+        lightDirection
+      );
+      pdf = environmentSample.pdf;
+    }
     return DirectLightSample(
       vec4<f32>(lightDirection, 0.0),
       vec4<f32>(radiance, 0.0),
-      environmentSample.pdf * environmentSelectionProbability,
+      pdf * environmentSelectionProbability,
       1000000.0,
       0u,
       1u
@@ -848,12 +895,40 @@ fn surface_direct_light_contribution(ray: RayRecord, hit: HitRecord) -> vec3<f32
   }
   let bsdfPdf = evaluate_surface_bsdf_pdf(hit, viewDirection, lightDirection);
   let misWeight = power_heuristic(lightSample.pdf, bsdfPdf);
-  let contribution =
+  let contribution = select(
     ray.throughput.xyz *
-    bsdf *
-    incidentRadiance *
-    (nDotL * misWeight / max(lightSample.pdf, 0.000001));
+      bsdf *
+      incidentRadiance *
+      (nDotL * misWeight / max(lightSample.pdf, 0.000001)),
+    ray.throughput.xyz * bsdf * incidentRadiance * nDotL,
+    (lightSample.flags & DIRECT_LIGHT_FLAG_DELTA) != 0u
+  );
   return sanitize_linear_radiance(contribution);
+}
+
+fn surface_procedural_sun_contribution(ray: RayRecord, hit: HitRecord) -> vec3<f32> {
+  if (!strict_physical_low_spp_lighting_enabled() || environment_map_enabled()) {
+    return vec3<f32>(0.0);
+  }
+  let normal = surface_shading_normal(hit);
+  let viewDirection = safe_normalize(-ray.direction.xyz, normal);
+  let lightDirection = safe_normalize(
+    config.environmentSunDirectionIntensity.xyz,
+    vec3<f32>(0.0, 1.0, 0.0)
+  );
+  let nDotL = saturate(dot(normal, lightDirection));
+  if (nDotL <= 0.000001) {
+    return vec3<f32>(0.0);
+  }
+  let origin = offset_origin(hit.position.xyz, hit.geometricNormal.xyz, hit.shadingNormal.xyz, lightDirection);
+  if (scene_visibility_blocked(origin, lightDirection, 1000000.0)) {
+    return vec3<f32>(0.0);
+  }
+  let incidentRadiance =
+    max(config.environmentSunColor.xyz, vec3<f32>(0.0)) *
+    max(config.environmentSunDirectionIntensity.w, 0.0001);
+  let bsdf = evaluate_surface_bsdf(hit, viewDirection, lightDirection);
+  return sanitize_linear_radiance(ray.throughput.xyz * bsdf * incidentRadiance * nDotL);
 }
 
 `;

--- a/src/wavefront-shader-materials.js
+++ b/src/wavefront-shader-materials.js
@@ -143,6 +143,10 @@ fn deferred_path_resolve_enabled() -> bool {
   return config.pathResolveSettings.x > 0.5;
 }
 
+fn strict_physical_low_spp_lighting_enabled() -> bool {
+  return config.pathResolveSettings.z > 0.5;
+}
+
 fn path_vertex_count_per_ray() -> u32 {
   return config.maxDepth + 1u;
 }

--- a/tests/wavefront-compute.test.js
+++ b/tests/wavefront-compute.test.js
@@ -528,6 +528,44 @@ test("wavefront frame config exposes samples per pixel to WGSL", () => {
   assert.equal(payloadView.getUint32(264, true), 8);
 });
 
+test("wavefront config packs the strict physical low-spp lighting flag", () => {
+  const directConfig = createWavefrontPathTracingComputeConfig({
+    width: 640,
+    height: 360,
+    strictPhysicalLowSppLighting: true,
+  });
+  const dottedConfig = createWavefrontPathTracingComputeConfig({
+    width: 640,
+    height: 360,
+    featureFlags: {
+      "renderer.transport.strictPhysicalLowSppLighting": true,
+    },
+  });
+  const nestedConfig = createWavefrontPathTracingComputeConfig({
+    width: 640,
+    height: 360,
+    featureFlags: {
+      renderer: {
+        transport: {
+          strictPhysicalLowSppLighting: true,
+        },
+      },
+    },
+  });
+  const payload = createConfigPayload(
+    directConfig,
+    { x: 0, y: 0, width: 64, height: 64 },
+    17
+  );
+  const payloadView = new DataView(payload);
+
+  assert.equal(createWavefrontPathTracingComputeConfig({ width: 640, height: 360 }).strictPhysicalLowSppLighting, false);
+  assert.equal(directConfig.strictPhysicalLowSppLighting, true);
+  assert.equal(dottedConfig.strictPhysicalLowSppLighting, true);
+  assert.equal(nestedConfig.strictPhysicalLowSppLighting, true);
+  assert.equal(payloadView.getFloat32(296, true), 1);
+});
+
 test("wavefront reference helper generates deterministic primary rays from the camera contract", () => {
   const config = createWavefrontPathTracingComputeConfig({
     width: 1,
@@ -750,7 +788,7 @@ test("wavefront compute offsets continuation and visibility rays with geometric-
   );
   assert.match(
     source,
-    /let radiance = direct_environment_radiance\(\s*offset_origin\(hit\.position\.xyz, hit\.geometricNormal\.xyz, hit\.shadingNormal\.xyz, lightDirection\),\s*lightDirection\s*\);/
+    /radiance = direct_environment_radiance\(\s*offset_origin\(hit\.position\.xyz, hit\.geometricNormal\.xyz, hit\.shadingNormal\.xyz, lightDirection\),\s*lightDirection\s*\);/
   );
   assert.match(
     source,
@@ -921,7 +959,7 @@ test("high-spp denoise acceptance keeps denoise-off structural and detail gates 
   assert.ok(blurred.failures.some((failure) => failure.includes("detail retention")));
 });
 
-test("wavefront compute uses physical continuation throughput and bounded terminal residuals", () => {
+test("wavefront compute uses physical continuation throughput with strict physical termination", () => {
   const source = readRendererSource();
 
   assert.match(source, /struct TerminationMetrics {/);
@@ -931,6 +969,9 @@ test("wavefront compute uses physical continuation throughput and bounded termin
   assert.match(source, /const TERMINAL_SOURCE_KIND_ENVIRONMENT = 2u;/);
   assert.match(source, /const TERMINAL_SOURCE_KIND_AMBIENT_MAX_DEPTH = 3u;/);
   assert.match(source, /const TERMINAL_SOURCE_KIND_AMBIENT_QUEUE_OVERFLOW = 4u;/);
+  assert.match(source, /const TERMINAL_SOURCE_KIND_ABSORPTION_NULL = 5u;/);
+  assert.match(source, /const TERMINAL_SOURCE_KIND_RUSSIAN_ROULETTE = 6u;/);
+  assert.match(source, /const TERMINAL_SOURCE_KIND_MAX_DEPTH_STRICT = 7u;/);
   assert.match(source, /const SCATTER_LOBE_DIFFUSE: u32 = 1u;/);
   assert.match(source, /const SCATTER_LOBE_SPECULAR: u32 = 2u;/);
   assert.match(source, /const SCATTER_LOBE_CLEARCOAT: u32 = 3u;/);
@@ -938,6 +979,8 @@ test("wavefront compute uses physical continuation throughput and bounded termin
   assert.match(source, /const SCATTER_LOBE_DELTA_TRANSMISSION: u32 = 5u;/);
   assert.match(source, /fn terminal_surface_environment_source/);
   assert.match(source, /fn terminal_surface_environment_contribution/);
+  assert.match(source, /fn strict_physical_low_spp_lighting_enabled\(\) -> bool/);
+  assert.match(source, /return config\.pathResolveSettings\.z > 0\.5;/);
   assert.match(source, /fn sanitize_path_throughput_component/);
   assert.match(source, /fn sanitize_path_throughput/);
   assert.match(source, /fn record_deferred_path_throughput/);
@@ -966,9 +1009,25 @@ test("wavefront compute uses physical continuation throughput and bounded termin
   assert.match(source, /let specularEnvironment = reflectionEnvironment \* \(f0 \* brdfTerm\.x \+ vec3<f32>\(brdfTerm\.y\)\);/);
   assert.match(source, /let glossyEnvironment = max\(/);
   assert.match(source, /let environmentFloor = max\(ambientFloor, max\(sunlitFloor, glossyEnvironment \* environmentInfluence\)\);/);
-  assert.match(source, /let continuationThroughput = surface_continuation_throughput\(\s+hit,\s+continuationViewDirection,\s+continuationLightDirection,\s+scatter\s+\) \* segmentTransmittance;/);
+  assert.match(source, /var continuationThroughput = surface_continuation_throughput\(\s+hit,\s+continuationViewDirection,\s+continuationLightDirection,\s+scatter\s+\) \* segmentTransmittance;/);
   assert.match(source, /if \(max_component\(continuationThroughput\) <= 0\.000001\) \{/);
   assert.match(source, /record_deferred_path_throughput\(ray, continuationThroughput\);/);
+  assert.match(source, /strict_physical_low_spp_lighting_enabled\(\) && ray\.bounce >= 2u/);
+  assert.match(source, /let survivalProbability = clamp\(max_component\(continuationThroughput\), 0\.05, 0\.95\);/);
+  assert.match(source, /SAMPLE_DIM_RUSSIAN_ROULETTE/);
+  assert.match(source, /continuationThroughput = continuationThroughput \/ survivalProbability;/);
+  assert.match(
+    source,
+    /record_deferred_terminal_source\(\s*ray,\s*vec3<f32>\(0\.0\),\s*TERMINAL_SOURCE_KIND_MAX_DEPTH_STRICT\s*\);/
+  );
+  assert.match(
+    source,
+    /record_deferred_terminal_source\(\s*ray,\s*vec3<f32>\(0\.0\),\s*TERMINAL_SOURCE_KIND_ABSORPTION_NULL\s*\);/
+  );
+  assert.match(
+    source,
+    /record_deferred_terminal_source\(\s*ray,\s*vec3<f32>\(0\.0\),\s*TERMINAL_SOURCE_KIND_RUSSIAN_ROULETTE\s*\);/
+  );
   assert.match(
     source,
     /record_deferred_terminal_source\(\s*ray,\s*terminal_surface_environment_source\(ray, hit\),\s*TERMINAL_SOURCE_KIND_AMBIENT_MAX_DEPTH\s*\);/
@@ -996,10 +1055,17 @@ test("wavefront compute samples all-material direct light with MIS before random
   const source = readRendererSource();
 
   assert.match(source, /fn direct_environment_radiance/);
+  assert.match(source, /fn procedural_sky_radiance/);
+  assert.match(source, /fn uniform_hemisphere_pdf\(\) -> f32/);
+  assert.match(source, /fn sample_uniform_hemisphere_direction\(sample: vec2<f32>, normal: vec3<f32>\) -> vec3<f32>/);
   assert.match(source, /fn sample_environment_importance/);
   assert.match(source, /struct DirectLightSample/);
   assert.match(source, /fn sample_emissive_triangle_light/);
   assert.match(source, /fn sample_direct_light/);
+  assert.match(source, /fn surface_procedural_sun_contribution/);
+  assert.match(source, /strict_physical_low_spp_lighting_enabled\(\) && !environment_importance_sampling_enabled\(\)/);
+  assert.match(source, /radiance = procedural_sky_radiance\(lightDirection\);/);
+  assert.match(source, /pdf = uniform_hemisphere_pdf\(\);/);
   assert.match(source, /fn surface_supports_direct_lighting/);
   assert.match(source, /u32\(config\.environmentMapMeta\.x\)/);
   assert.match(source, /u32\(config\.environmentMapMeta\.y\)/);
@@ -1032,7 +1098,11 @@ test("wavefront compute samples all-material direct light with MIS before random
   );
   assert.match(
     source,
-    /let rawDirectLight = directLight \* sample_weight\(\);/
+    /let sunLight = surface_procedural_sun_contribution\(\s+RayRecord\(/
+  );
+  assert.match(
+    source,
+    /let rawDirectLight = \(directLight \+ sunLight\) \* sample_weight\(\);/
   );
   assert.match(
     source,
@@ -1051,11 +1121,20 @@ test("wavefront compute samples all-material direct light with MIS before random
 test("wavefront compute converts emissive area PDFs to solid-angle MIS measures", () => {
   const source = readRendererSource();
 
+  assert.match(source, /function emissiveTriangleWeight\(triangle\)/);
+  assert.match(source, /triangleAreaForLightSampling\(triangle\) \* Math\.max\(emissionPower\(triangle\.emission\), 0\.000001\)/);
+  assert.match(source, /const emissiveWeights = config\.emissiveTriangleIndices\.indices\.map/);
+  assert.match(source, /packedBvhNodeFloats\[nodeOffset\] = cumulativeEmissiveWeight;/);
+  assert.match(source, /packedBvhNodeFloats\[nodeOffset \+ 1\] = emissiveWeights\[index\] \?\? 0;/);
+  assert.match(source, /packedBvhNodeFloats\[nodeOffset \+ 2\] = totalEmissiveWeight;/);
   assert.match(source, /fn triangle_surface_area\(triangle: TriangleRecord\) -> f32/);
   assert.match(source, /fn solid_angle_pdf_from_area_pdf\(/);
   assert.match(source, /let geometry = max\(dot\(lightNormal, -lightDirection\), 0\.0\);/);
   assert.match(source, /return areaPdf \* distanceSquared \/ max\(geometry, 0\.000001\);/);
-  assert.match(source, /let areaPdf = 1\.0 \/ max\(triangleArea \* f32\(config\.emissiveTriangleCount\), 0\.000001\);/);
+  assert.match(source, /let targetWeight = selector \* totalWeight;/);
+  assert.match(source, /targetWeight <= candidateMetadata\.boundsMin\.x/);
+  assert.match(source, /selectionProbability = triangleWeight \/ totalWeight;/);
+  assert.match(source, /let areaPdf = selectionProbability \/ max\(triangleArea, 0\.000001\);/);
   assert.match(
     source,
     /let lightPdf = solid_angle_pdf_from_area_pdf\(areaPdf, hit\.position\.xyz, lightPoint, lightNormal\);/
@@ -1259,7 +1338,7 @@ test("wavefront compute defers visible colour until terminal path resolve", () =
   assert.match(source, /let resolved = resolve_deferred_path_radiance\(index\) \* sample_weight\(\);/);
   assert.match(
     source,
-    /let rawDirectLight = directLight \* sample_weight\(\);/
+    /let rawDirectLight = \(directLight \+ sunLight\) \* sample_weight\(\);/
   );
   assert.match(source, /if \(config\.deferredPathResolve\) \{/);
   assert.match(source, /createGpuSubmissionBatcher\(\{/);
@@ -2399,6 +2478,9 @@ serialWebGpuTest("wavefront compute renderer drives GPU-only mesh BVH passes", a
       environment: 0,
       ambientFallback: 0,
       maxDepth: 0,
+      absorptionNull: 0,
+      russianRoulette: 0,
+      strictMaxDepth: 0,
     });
     assert.deepEqual(compatibilityFrame.terminalRadiance, {
       totalLuminance: 0,
@@ -2445,7 +2527,9 @@ serialWebGpuTest("wavefront compute renderer drives GPU-only mesh BVH passes", a
       device.copyBufferToBufferCalls.every(
         (call) =>
           (call.sourceOffset === 16 && call.destinationOffset === 0 && call.size === 12) ||
-          (call.sourceOffset === 0 && call.destinationOffset === 0 && call.size === 64)
+          (call.sourceOffset === 0 &&
+            call.destinationOffset === 0 &&
+            call.size === wavefrontPathTracingComputeLimits.counterRecordBytes)
       ),
       true
     );


### PR DESCRIPTION
## Summary
- add boolean remote feature flag `renderer.transport.strictPhysicalLowSppLighting` for strict physical low-SPP transport
- remove strict-mode heuristic terminal rescue and add physical termination diagnostics
- add procedural sun/sky, emissive selection, PDF/MIS-oriented coverage, docs, changelog, and ADR

## Tracking
- Feature: Plasius-LTD/plasius-ltd-site#1374
- Story: Plasius-LTD/plasius-ltd-site#1375
- Task: Closes #124

## Validation
- npm run lint
- npm run typecheck
- npm run audit:npm
- npm run build
- npm run test:coverage
- npm run pack:check

## Notes
- Existing Eames/Product Studio visual benchmark matrix was not run locally because no package script or harness was found. Strict validation remains documented with `denoise: false`.