### PR TITLE
feat: add product transport experiment flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,14 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 - **Added**
-  - (placeholder)
+  - Added composable strict low-SPP transport experiment flags for stable
+    sample routing, strict zero overflow, deferred low-SPP Russian roulette,
+    deterministic direct lighting, Product Studio environment importance, and
+    product transport telemetry.
 
 - **Changed**
-  - (placeholder)
+  - Changed wavefront renderer config, frame stats, and snapshots to expose the
+    requested/effective transport experiment set and packed shader bitfield.
 
 - **Fixed**
   - (placeholder)

--- a/README.md
+++ b/README.md
@@ -160,6 +160,22 @@ directional source, samples procedural sky over the visible hemisphere, and
 selects emissive triangles by area-weighted emission power with matching MIS
 PDFs. Use `denoise: false` when validating this strict path so remaining
 variance is measured in the transport rather than hidden by filtering.
+Strict validation can also enable the Product Studio transport experiment
+matrix through independent boolean feature flags. The flags are composable:
+none, one, several, or all may be requested at once. Flags that depend on strict
+physical transport report as requested but no-op effectively when
+`renderer.transport.strictPhysicalLowSppLighting` is disabled.
+
+- `renderer.transport.stableSampleRouting.enabled`
+- `renderer.transport.strictZeroOverflow.enabled`
+- `renderer.transport.deferLowSppRussianRoulette.enabled`
+- `renderer.transport.deterministicDirectLighting.enabled`
+- `renderer.environment.productStudioImportance.enabled`
+- `renderer.diagnostics.productTransportTelemetry.enabled`
+
+Renderer config, frame stats, and snapshots expose both the structured
+`transportExperiments` state and the packed `transportExperimentFlags` bitfield
+so Product Studio diagnostics can record the exact active set for each render.
 
 ```js
 import {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -737,6 +737,8 @@ export interface WavefrontPathTracingComputeConfig {
   readonly environmentMap: WavefrontEnvironmentMapInput;
   readonly deferredPathResolve: boolean;
   readonly strictPhysicalLowSppLighting: boolean;
+  readonly transportExperiments: WavefrontTransportExperimentState;
+  readonly transportExperimentFlags: number;
   readonly triangleCount: number;
   readonly triangleCapacity: number;
   readonly bvhNodeCount: number;
@@ -765,11 +767,60 @@ export interface WavefrontPathTracingComputeConfig {
 
 export interface WavefrontRendererFeatureFlags {
   readonly "renderer.transport.strictPhysicalLowSppLighting"?: boolean;
+  readonly "renderer.transport.stableSampleRouting.enabled"?: boolean;
+  readonly "renderer.transport.strictZeroOverflow.enabled"?: boolean;
+  readonly "renderer.transport.deferLowSppRussianRoulette.enabled"?: boolean;
+  readonly "renderer.transport.deterministicDirectLighting.enabled"?: boolean;
+  readonly "renderer.environment.productStudioImportance.enabled"?: boolean;
+  readonly "renderer.diagnostics.productTransportTelemetry.enabled"?: boolean;
+  readonly enabled?: {
+    readonly "renderer.transport.strictPhysicalLowSppLighting"?: boolean;
+    readonly "renderer.transport.stableSampleRouting.enabled"?: boolean;
+    readonly "renderer.transport.strictZeroOverflow.enabled"?: boolean;
+    readonly "renderer.transport.deferLowSppRussianRoulette.enabled"?: boolean;
+    readonly "renderer.transport.deterministicDirectLighting.enabled"?: boolean;
+    readonly "renderer.environment.productStudioImportance.enabled"?: boolean;
+    readonly "renderer.diagnostics.productTransportTelemetry.enabled"?: boolean;
+  };
+  readonly flags?: {
+    readonly "renderer.transport.strictPhysicalLowSppLighting"?: boolean;
+    readonly "renderer.transport.stableSampleRouting.enabled"?: boolean;
+    readonly "renderer.transport.strictZeroOverflow.enabled"?: boolean;
+    readonly "renderer.transport.deferLowSppRussianRoulette.enabled"?: boolean;
+    readonly "renderer.transport.deterministicDirectLighting.enabled"?: boolean;
+    readonly "renderer.environment.productStudioImportance.enabled"?: boolean;
+    readonly "renderer.diagnostics.productTransportTelemetry.enabled"?: boolean;
+  };
   readonly renderer?: {
     readonly transport?: {
       readonly strictPhysicalLowSppLighting?: boolean;
+      readonly stableSampleRouting?: boolean;
+      readonly strictZeroOverflow?: boolean;
+      readonly deferLowSppRussianRoulette?: boolean;
+      readonly deterministicDirectLighting?: boolean;
+    };
+    readonly environment?: {
+      readonly productStudioImportance?: boolean;
+    };
+    readonly diagnostics?: {
+      readonly productTransportTelemetry?: boolean;
     };
   };
+}
+
+export interface WavefrontTransportExperimentFlags {
+  readonly stableSampleRouting: boolean;
+  readonly strictZeroOverflow: boolean;
+  readonly deferLowSppRussianRoulette: boolean;
+  readonly deterministicDirectLighting: boolean;
+  readonly productStudioImportance: boolean;
+  readonly productTransportTelemetry: boolean;
+}
+
+export interface WavefrontTransportExperimentState {
+  readonly requested: WavefrontTransportExperimentFlags;
+  readonly effective: WavefrontTransportExperimentFlags;
+  readonly bitmask: number;
 }
 
 export interface WavefrontEnvironmentLightingInput {
@@ -901,6 +952,12 @@ export interface CreateWavefrontPathTracingComputeRendererOptions {
   readonly displayQuality?: boolean;
   readonly denoise?: boolean;
   readonly strictPhysicalLowSppLighting?: boolean;
+  readonly "renderer.transport.stableSampleRouting.enabled"?: boolean;
+  readonly "renderer.transport.strictZeroOverflow.enabled"?: boolean;
+  readonly "renderer.transport.deferLowSppRussianRoulette.enabled"?: boolean;
+  readonly "renderer.transport.deterministicDirectLighting.enabled"?: boolean;
+  readonly "renderer.environment.productStudioImportance.enabled"?: boolean;
+  readonly "renderer.diagnostics.productTransportTelemetry.enabled"?: boolean;
   readonly featureFlags?: WavefrontRendererFeatureFlags;
   readonly frameIndex?: number;
 }
@@ -950,6 +1007,8 @@ export interface WavefrontPathTracingComputeRenderer {
     environmentMap: WavefrontEnvironmentMapSnapshot;
     deferredPathResolve: boolean;
     strictPhysicalLowSppLighting: boolean;
+    transportExperiments: WavefrontTransportExperimentState;
+    transportExperimentFlags: number;
     bvhNodeCount: number;
     displayQuality: boolean;
     accelerationBuildMode: WavefrontAccelerationBuildMode;
@@ -986,6 +1045,8 @@ export interface WavefrontPathTracingComputeFrameStats {
   readonly environmentMap: WavefrontEnvironmentMapSnapshot;
   readonly deferredPathResolve: boolean;
   readonly strictPhysicalLowSppLighting: boolean;
+  readonly transportExperiments: WavefrontTransportExperimentState;
+  readonly transportExperimentFlags: number;
   readonly bvhNodeCount: number;
   readonly displayQuality: boolean;
   readonly accelerationBuildMode: WavefrontAccelerationBuildMode;

--- a/src/wavefront-compute.js
+++ b/src/wavefront-compute.js
@@ -885,6 +885,7 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
         ...config.environmentMap,
       },
       strictPhysicalLowSppLighting: config.strictPhysicalLowSppLighting,
+      featureFlags: options.featureFlags,
       frameIndex: config.frameIndex,
       ...overrides,
     });
@@ -935,6 +936,9 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
       mediumCount: config.mediumCount,
       environmentMap: createEnvironmentMapSnapshot(config.environmentMap),
       deferredPathResolve: config.deferredPathResolve,
+      strictPhysicalLowSppLighting: config.strictPhysicalLowSppLighting,
+      transportExperiments: config.transportExperiments,
+      transportExperimentFlags: config.transportExperimentFlags,
       bvhNodeCount: config.bvhNodeCount,
       displayQuality: config.displayQuality,
       accelerationBuildMode: config.accelerationBuildMode,

--- a/src/wavefront-config.js
+++ b/src/wavefront-config.js
@@ -47,6 +47,7 @@ import {
   resolveDeferredPathResolve,
   resolveEnvironmentMap,
   resolveStrictPhysicalLowSppLighting,
+  resolveTransportExperiments,
   scale,
   subtract,
 } from "./wavefront-core.js";
@@ -457,6 +458,7 @@ export function createWavefrontPathTracingComputeConfig(options = {}) {
   );
   const deferredPathResolve = resolveDeferredPathResolve(options);
   const strictPhysicalLowSppLighting = resolveStrictPhysicalLowSppLighting(options);
+  const transportExperiments = resolveTransportExperiments(options, strictPhysicalLowSppLighting);
 
   return Object.freeze({
     mode: rendererWavefrontComputeMode,
@@ -498,6 +500,8 @@ export function createWavefrontPathTracingComputeConfig(options = {}) {
     environmentMap,
     deferredPathResolve,
     strictPhysicalLowSppLighting,
+    transportExperiments,
+    transportExperimentFlags: transportExperiments.bitmask,
     displayQuality: options.displayQuality === true,
     requiresMeshBvhForDisplayQuality: true,
     denoise: options.denoise !== false,

--- a/src/wavefront-core.js
+++ b/src/wavefront-core.js
@@ -295,9 +295,83 @@ export function resolveStrictPhysicalLowSppLighting(options = {}) {
   const value =
     options.strictPhysicalLowSppLighting ??
     options.featureFlags?.["renderer.transport.strictPhysicalLowSppLighting"] ??
+    options.featureFlags?.enabled?.["renderer.transport.strictPhysicalLowSppLighting"] ??
+    options.featureFlags?.flags?.["renderer.transport.strictPhysicalLowSppLighting"] ??
     options.featureFlags?.renderer?.transport?.strictPhysicalLowSppLighting ??
     false;
   return value === true;
+}
+
+function readBooleanFeatureFlag(options, dottedName, nestedReader) {
+  const value =
+    options[dottedName] ??
+    options.featureFlags?.[dottedName] ??
+    options.featureFlags?.enabled?.[dottedName] ??
+    options.featureFlags?.flags?.[dottedName] ??
+    nestedReader?.(options.featureFlags) ??
+    false;
+  return value === true;
+}
+
+export const WAVEFRONT_TRANSPORT_EXPERIMENT_BITS = Object.freeze({
+  stableSampleRouting: 1 << 0,
+  strictZeroOverflow: 1 << 1,
+  deferLowSppRussianRoulette: 1 << 2,
+  deterministicDirectLighting: 1 << 3,
+  productStudioImportance: 1 << 4,
+  productTransportTelemetry: 1 << 5,
+});
+
+export function resolveTransportExperiments(options = {}, strictPhysicalLowSppLighting = false) {
+  const requested = Object.freeze({
+    stableSampleRouting: readBooleanFeatureFlag(
+      options,
+      "renderer.transport.stableSampleRouting.enabled",
+      (flags) => flags?.renderer?.transport?.stableSampleRouting
+    ),
+    strictZeroOverflow: readBooleanFeatureFlag(
+      options,
+      "renderer.transport.strictZeroOverflow.enabled",
+      (flags) => flags?.renderer?.transport?.strictZeroOverflow
+    ),
+    deferLowSppRussianRoulette: readBooleanFeatureFlag(
+      options,
+      "renderer.transport.deferLowSppRussianRoulette.enabled",
+      (flags) => flags?.renderer?.transport?.deferLowSppRussianRoulette
+    ),
+    deterministicDirectLighting: readBooleanFeatureFlag(
+      options,
+      "renderer.transport.deterministicDirectLighting.enabled",
+      (flags) => flags?.renderer?.transport?.deterministicDirectLighting
+    ),
+    productStudioImportance: readBooleanFeatureFlag(
+      options,
+      "renderer.environment.productStudioImportance.enabled",
+      (flags) => flags?.renderer?.environment?.productStudioImportance
+    ),
+    productTransportTelemetry: readBooleanFeatureFlag(
+      options,
+      "renderer.diagnostics.productTransportTelemetry.enabled",
+      (flags) => flags?.renderer?.diagnostics?.productTransportTelemetry
+    ),
+  });
+  const effective = Object.freeze({
+    stableSampleRouting: requested.stableSampleRouting,
+    strictZeroOverflow: requested.strictZeroOverflow && strictPhysicalLowSppLighting,
+    deferLowSppRussianRoulette:
+      requested.deferLowSppRussianRoulette && strictPhysicalLowSppLighting,
+    deterministicDirectLighting:
+      requested.deterministicDirectLighting && strictPhysicalLowSppLighting,
+    productStudioImportance: requested.productStudioImportance,
+    productTransportTelemetry: requested.productTransportTelemetry,
+  });
+  let bitmask = 0;
+  for (const [key, bit] of Object.entries(WAVEFRONT_TRANSPORT_EXPERIMENT_BITS)) {
+    if (effective[key]) {
+      bitmask |= bit;
+    }
+  }
+  return Object.freeze({ requested, effective, bitmask: bitmask >>> 0 });
 }
 
 export function emissionPower(emission) {

--- a/src/wavefront-frame-stats.js
+++ b/src/wavefront-frame-stats.js
@@ -116,6 +116,8 @@ export function createWavefrontFrameStats({
       environmentMap: createEnvironmentMapSnapshot(config.environmentMap),
       deferredPathResolve: config.deferredPathResolve,
       strictPhysicalLowSppLighting: config.strictPhysicalLowSppLighting,
+      transportExperiments: config.transportExperiments,
+      transportExperimentFlags: config.transportExperimentFlags,
       bvhNodeCount: config.bvhNodeCount,
       displayQuality: config.displayQuality,
       accelerationBuildMode: config.accelerationBuildMode,

--- a/src/wavefront-packers.js
+++ b/src/wavefront-packers.js
@@ -201,7 +201,7 @@ export function createConfigPayload(config, tile, frameIndex, buildRange = {}) {
   data.setUint32(256, config.environmentPortalCount ?? 0, true);
   data.setUint32(260, config.environmentPortalMode ?? 0, true);
   data.setUint32(264, config.samplesPerPixel, true);
-  data.setUint32(268, 0, true);
+  data.setUint32(268, config.transportExperimentFlags ?? 0, true);
   writeVec4(floatView, 272, [
     config.environmentMap.enabled ? 1 : 0,
     config.environmentMap.intensity,

--- a/src/wavefront-shader-kernels.js
+++ b/src/wavefront-shader-kernels.js
@@ -746,7 +746,13 @@ fn resolveSurfaceRecords(@builtin(global_invocation_id) globalId: vec3<u32>) {
     atomicAdd(&counters.terminatedCount, 1u);
     return;
   }
-  if (strict_physical_low_spp_lighting_enabled() && ray.bounce >= 2u) {
+  let rouletteStartBounce = select(
+    2u,
+    6u,
+    transport_experiment_enabled(TRANSPORT_EXPERIMENT_DEFER_LOW_SPP_RUSSIAN_ROULETTE) &&
+      config.samplesPerPixel <= 8u
+  );
+  if (strict_physical_low_spp_lighting_enabled() && ray.bounce >= rouletteStartBounce) {
     let survivalProbability = clamp(max_component(continuationThroughput), 0.05, 0.95);
     let roulette = sample_dimension_1d(
       ray.sourcePixelId,
@@ -787,12 +793,18 @@ fn resolveSurfaceRecords(@builtin(global_invocation_id) globalId: vec3<u32>) {
         );
       }
     } else {
-      let overflowEnvironment = terminal_surface_environment_contribution(
-        ray,
-        arrivingThroughput,
-        hit
-      );
-      let rawWeightedContribution = overflowEnvironment * sample_weight();
+      var rawWeightedContribution = vec3<f32>(0.0);
+      if (
+        !strict_physical_low_spp_lighting_enabled() ||
+        !transport_experiment_enabled(TRANSPORT_EXPERIMENT_STRICT_ZERO_OVERFLOW)
+      ) {
+        let overflowEnvironment = terminal_surface_environment_contribution(
+          ray,
+          arrivingThroughput,
+          hit
+        );
+        rawWeightedContribution = overflowEnvironment * sample_weight();
+      }
       record_radiance_diagnostics(rawWeightedContribution);
       let weightedContribution = sanitize_linear_radiance(rawWeightedContribution);
       record_termination_metrics(

--- a/src/wavefront-shader-layout.js
+++ b/src/wavefront-shader-layout.js
@@ -197,7 +197,7 @@ struct FrameConfig {
   environmentPortalCount: u32,
   environmentPortalMode: u32,
   samplesPerPixel: u32,
-  _portalPad1: u32,
+  transportExperimentFlags: u32,
   environmentMapSettings: vec4<f32>,
   pathResolveSettings: vec4<f32>,
   environmentMapMeta: vec4<f32>,
@@ -226,6 +226,12 @@ const TERMINAL_SOURCE_KIND_ABSORPTION_NULL = 5u;
 const TERMINAL_SOURCE_KIND_RUSSIAN_ROULETTE = 6u;
 const TERMINAL_SOURCE_KIND_MAX_DEPTH_STRICT = 7u;
 const TERMINATION_LUMINANCE_SCALE = 1000000.0;
+const TRANSPORT_EXPERIMENT_STABLE_SAMPLE_ROUTING = 1u;
+const TRANSPORT_EXPERIMENT_STRICT_ZERO_OVERFLOW = 2u;
+const TRANSPORT_EXPERIMENT_DEFER_LOW_SPP_RUSSIAN_ROULETTE = 4u;
+const TRANSPORT_EXPERIMENT_DETERMINISTIC_DIRECT_LIGHTING = 8u;
+const TRANSPORT_EXPERIMENT_PRODUCT_STUDIO_IMPORTANCE = 16u;
+const TRANSPORT_EXPERIMENT_PRODUCT_TRANSPORT_TELEMETRY = 32u;
 
 struct Counters {
   activeCount: atomic<u32>,
@@ -326,6 +332,14 @@ fn random01(seed: u32) -> f32 {
   return f32(hash_u32(seed) & 0x00ffffffu) / 16777215.0;
 }
 
+fn transport_experiment_enabled(bit: u32) -> bool {
+  return (config.transportExperimentFlags & bit) != 0u;
+}
+
+fn sample_frame_index(frameIndex: u32) -> u32 {
+  return select(frameIndex, 0u, transport_experiment_enabled(TRANSPORT_EXPERIMENT_STABLE_SAMPLE_ROUTING));
+}
+
 fn radical_inverse_vdc(bits: u32) -> f32 {
   var value = bits;
   value = (value << 16u) | (value >> 16u);
@@ -343,7 +357,7 @@ fn sample_dimension_1d(
   frameIndex: u32,
   dimension: u32
 ) -> f32 {
-  return random01(mix_seed(pixelId, sampleId, bounce, frameIndex, dimension));
+  return random01(mix_seed(pixelId, sampleId, bounce, sample_frame_index(frameIndex), dimension));
 }
 
 fn sample_dimension_2d(
@@ -356,7 +370,7 @@ fn sample_dimension_2d(
 ) -> vec2<f32> {
   let strata = max(strataCount, 1u);
   let jitter = sample_dimension_1d(pixelId, sampleId, bounce, frameIndex, dimension);
-  let scramble = hash_u32(mix_seed(pixelId, sampleId, bounce, frameIndex, dimension));
+  let scramble = hash_u32(mix_seed(pixelId, sampleId, bounce, sample_frame_index(frameIndex), dimension));
   let stratified = fract((f32(sampleId % strata) + jitter) / f32(strata));
   let lowDiscrepancy = fract(radical_inverse_vdc(sampleId ^ scramble) + jitter);
   return vec2<f32>(stratified, lowDiscrepancy);

--- a/src/wavefront-shader-lighting.js
+++ b/src/wavefront-shader-lighting.js
@@ -190,6 +190,10 @@ fn uniform_hemisphere_pdf() -> f32 {
   return 1.0 / (2.0 * 3.14159265359);
 }
 
+fn cosine_hemisphere_pdf(normal: vec3<f32>, direction: vec3<f32>) -> f32 {
+  return saturate(dot(normal, direction)) / 3.14159265359;
+}
+
 fn sample_uniform_sphere_direction(sample: vec2<f32>) -> vec3<f32> {
   let z = 1.0 - 2.0 * sample.y;
   let radial = sqrt(max(1.0 - z * z, 0.0));
@@ -798,58 +802,75 @@ fn sample_emissive_triangle_light(
   return DirectLightSample(vec4<f32>(lightDirection, 0.0), vec4<f32>(radiance, 0.0), lightPdf, traceDistance, 0u, 1u);
 }
 
-fn sample_direct_light(hit: HitRecord, ray: RayRecord, normal: vec3<f32>) -> DirectLightSample {
-  let environmentSelectionProbability = select(1.0, 0.5, config.emissiveTriangleCount > 0u);
-  let selector = sample_dimension_1d(
+fn direct_light_sample_frame_index() -> u32 {
+  return select(
+    config.frameIndex,
+    0u,
+    transport_experiment_enabled(TRANSPORT_EXPERIMENT_DETERMINISTIC_DIRECT_LIGHTING)
+  );
+}
+
+fn sample_environment_direct_light(
+  hit: HitRecord,
+  ray: RayRecord,
+  normal: vec3<f32>,
+  selector: f32,
+  environmentSelectionProbability: f32
+) -> DirectLightSample {
+  let environmentUv = sample_dimension_2d(
     ray.sourcePixelId,
     ray.sampleId,
     ray.bounce,
-    config.frameIndex,
-    SAMPLE_DIM_DIRECT_LIGHT_SELECTOR
+    direct_light_sample_frame_index(),
+    SAMPLE_DIM_DIRECT_ENVIRONMENT,
+    config.samplesPerPixel
   );
-  if (selector < environmentSelectionProbability) {
-    let environmentUv = sample_dimension_2d(
-      ray.sourcePixelId,
-      ray.sampleId,
-      ray.bounce,
-      config.frameIndex,
-      SAMPLE_DIM_DIRECT_ENVIRONMENT,
-      config.samplesPerPixel
-    );
-    var lightDirection = normal;
-    var radiance = vec3<f32>(0.0);
-    var pdf = 0.0;
-    if (strict_physical_low_spp_lighting_enabled() && !environment_importance_sampling_enabled()) {
+  var lightDirection = normal;
+  var radiance = vec3<f32>(0.0);
+  var pdf = 0.0;
+  if (strict_physical_low_spp_lighting_enabled() && !environment_importance_sampling_enabled()) {
+    if (transport_experiment_enabled(TRANSPORT_EXPERIMENT_PRODUCT_STUDIO_IMPORTANCE)) {
+      lightDirection = cosine_sample_hemisphere(environmentUv, normal);
+      radiance = procedural_sky_radiance(lightDirection);
+      pdf = cosine_hemisphere_pdf(normal, lightDirection);
+    } else {
       lightDirection = sample_uniform_hemisphere_direction(environmentUv, normal);
       radiance = procedural_sky_radiance(lightDirection);
       pdf = uniform_hemisphere_pdf();
-    } else {
-      let environmentSample = sample_environment_importance(vec2<f32>(
-        selector / max(environmentSelectionProbability, 0.000001),
-        environmentUv.y
-      ));
-      lightDirection = safe_normalize(environmentSample.direction, normal);
-      radiance = direct_environment_radiance(
-        offset_origin(hit.position.xyz, hit.geometricNormal.xyz, hit.shadingNormal.xyz, lightDirection),
-        lightDirection
-      );
-      pdf = environmentSample.pdf;
     }
-    return DirectLightSample(
-      vec4<f32>(lightDirection, 0.0),
-      vec4<f32>(radiance, 0.0),
-      pdf * environmentSelectionProbability,
-      1000000.0,
-      0u,
-      1u
+  } else {
+    let environmentSample = sample_environment_importance(vec2<f32>(
+      selector / max(environmentSelectionProbability, 0.000001),
+      environmentUv.y
+    ));
+    lightDirection = safe_normalize(environmentSample.direction, normal);
+    radiance = direct_environment_radiance(
+      offset_origin(hit.position.xyz, hit.geometricNormal.xyz, hit.shadingNormal.xyz, lightDirection),
+      lightDirection
     );
+    pdf = environmentSample.pdf;
   }
+  return DirectLightSample(
+    vec4<f32>(lightDirection, 0.0),
+    vec4<f32>(radiance, 0.0),
+    pdf * environmentSelectionProbability,
+    1000000.0,
+    0u,
+    1u
+  );
+}
+
+fn sample_emissive_direct_light(
+  hit: HitRecord,
+  ray: RayRecord,
+  environmentSelectionProbability: f32
+) -> DirectLightSample {
   let emissiveSample = sample_emissive_triangle_light(
     hit,
     ray.sourcePixelId,
     ray.sampleId,
     ray.bounce,
-    config.frameIndex,
+    direct_light_sample_frame_index(),
     SAMPLE_DIM_EMISSIVE_LIGHT_SELECTION,
     SAMPLE_DIM_EMISSIVE_LIGHT_SURFACE
   );
@@ -866,10 +887,24 @@ fn sample_direct_light(hit: HitRecord, ray: RayRecord, normal: vec3<f32>) -> Dir
   );
 }
 
-fn surface_direct_light_contribution(ray: RayRecord, hit: HitRecord) -> vec3<f32> {
+fn sample_direct_light(hit: HitRecord, ray: RayRecord, normal: vec3<f32>) -> DirectLightSample {
+  let environmentSelectionProbability = select(1.0, 0.5, config.emissiveTriangleCount > 0u);
+  let selector = sample_dimension_1d(
+    ray.sourcePixelId,
+    ray.sampleId,
+    ray.bounce,
+    direct_light_sample_frame_index(),
+    SAMPLE_DIM_DIRECT_LIGHT_SELECTOR
+  );
+  if (selector < environmentSelectionProbability) {
+    return sample_environment_direct_light(hit, ray, normal, selector, environmentSelectionProbability);
+  }
+  return sample_emissive_direct_light(hit, ray, environmentSelectionProbability);
+}
+
+fn direct_light_sample_contribution(ray: RayRecord, hit: HitRecord, lightSample: DirectLightSample) -> vec3<f32> {
   let normal = surface_shading_normal(hit);
   let viewDirection = safe_normalize(-ray.direction.xyz, normal);
-  let lightSample = sample_direct_light(hit, ray, normal);
   if (lightSample.valid == 0u) {
     return vec3<f32>(0.0);
   }
@@ -904,6 +939,19 @@ fn surface_direct_light_contribution(ray: RayRecord, hit: HitRecord) -> vec3<f32
     (lightSample.flags & DIRECT_LIGHT_FLAG_DELTA) != 0u
   );
   return sanitize_linear_radiance(contribution);
+}
+
+fn surface_direct_light_contribution(ray: RayRecord, hit: HitRecord) -> vec3<f32> {
+  let normal = surface_shading_normal(hit);
+  if (transport_experiment_enabled(TRANSPORT_EXPERIMENT_DETERMINISTIC_DIRECT_LIGHTING)) {
+    let environmentLight = sample_environment_direct_light(hit, ray, normal, 0.5, 1.0);
+    let emissiveLight = sample_emissive_direct_light(hit, ray, 0.0);
+    return sanitize_linear_radiance(
+      direct_light_sample_contribution(ray, hit, environmentLight) +
+      direct_light_sample_contribution(ray, hit, emissiveLight)
+    );
+  }
+  return direct_light_sample_contribution(ray, hit, sample_direct_light(hit, ray, normal));
 }
 
 fn surface_procedural_sun_contribution(ray: RayRecord, hit: HitRecord) -> vec3<f32> {

--- a/tests/wavefront-compute.test.js
+++ b/tests/wavefront-compute.test.js
@@ -566,6 +566,51 @@ test("wavefront config packs the strict physical low-spp lighting flag", () => {
   assert.equal(payloadView.getFloat32(296, true), 1);
 });
 
+test("wavefront config packs composable transport experiment flags", () => {
+  const baseline = createWavefrontPathTracingComputeConfig({
+    width: 640,
+    height: 360,
+  });
+  const config = createWavefrontPathTracingComputeConfig({
+    width: 640,
+    height: 360,
+    strictPhysicalLowSppLighting: true,
+    featureFlags: {
+      enabled: {
+        "renderer.transport.stableSampleRouting.enabled": true,
+        "renderer.transport.strictZeroOverflow.enabled": true,
+        "renderer.transport.deferLowSppRussianRoulette.enabled": true,
+        "renderer.transport.deterministicDirectLighting.enabled": true,
+        "renderer.environment.productStudioImportance.enabled": true,
+        "renderer.diagnostics.productTransportTelemetry.enabled": true,
+      },
+    },
+  });
+  const strictOffConfig = createWavefrontPathTracingComputeConfig({
+    width: 640,
+    height: 360,
+    featureFlags: {
+      enabled: {
+        "renderer.transport.strictZeroOverflow.enabled": true,
+        "renderer.transport.deferLowSppRussianRoulette.enabled": true,
+        "renderer.transport.deterministicDirectLighting.enabled": true,
+      },
+    },
+  });
+  const payload = createConfigPayload(config, { x: 0, y: 0, width: 64, height: 64 }, 17);
+  const payloadView = new DataView(payload);
+
+  assert.equal(baseline.transportExperimentFlags, 0);
+  assert.equal(config.transportExperiments.requested.strictZeroOverflow, true);
+  assert.equal(config.transportExperiments.effective.strictZeroOverflow, true);
+  assert.equal(config.transportExperiments.effective.productTransportTelemetry, true);
+  assert.equal(config.transportExperimentFlags, 63);
+  assert.equal(payloadView.getUint32(268, true), 63);
+  assert.equal(strictOffConfig.transportExperiments.requested.strictZeroOverflow, true);
+  assert.equal(strictOffConfig.transportExperiments.effective.strictZeroOverflow, false);
+  assert.equal(strictOffConfig.transportExperiments.effective.deterministicDirectLighting, false);
+});
+
 test("wavefront reference helper generates deterministic primary rays from the camera contract", () => {
   const config = createWavefrontPathTracingComputeConfig({
     width: 1,
@@ -848,6 +893,8 @@ test("wavefront sample dimensions stay unique and expose low-discrepancy helpers
     dimensions.every(({ wgslName }) => shaderSource.includes(`const ${wgslName}: u32 =`))
   );
   assert.match(source, /fn radical_inverse_vdc\(bits: u32\) -> f32/);
+  assert.match(source, /fn sample_frame_index\(frameIndex: u32\) -> u32/);
+  assert.match(source, /TRANSPORT_EXPERIMENT_STABLE_SAMPLE_ROUTING/);
   assert.match(source, /fn sample_dimension_1d\(/);
   assert.match(source, /fn sample_dimension_2d\(/);
   assert.notDeepEqual(jitterA, jitterB);
@@ -1012,7 +1059,9 @@ test("wavefront compute uses physical continuation throughput with strict physic
   assert.match(source, /var continuationThroughput = surface_continuation_throughput\(\s+hit,\s+continuationViewDirection,\s+continuationLightDirection,\s+scatter\s+\) \* segmentTransmittance;/);
   assert.match(source, /if \(max_component\(continuationThroughput\) <= 0\.000001\) \{/);
   assert.match(source, /record_deferred_path_throughput\(ray, continuationThroughput\);/);
-  assert.match(source, /strict_physical_low_spp_lighting_enabled\(\) && ray\.bounce >= 2u/);
+  assert.match(source, /TRANSPORT_EXPERIMENT_DEFER_LOW_SPP_RUSSIAN_ROULETTE/);
+  assert.match(source, /let rouletteStartBounce = select\(/);
+  assert.match(source, /strict_physical_low_spp_lighting_enabled\(\) && ray\.bounce >= rouletteStartBounce/);
   assert.match(source, /let survivalProbability = clamp\(max_component\(continuationThroughput\), 0\.05, 0\.95\);/);
   assert.match(source, /SAMPLE_DIM_RUSSIAN_ROULETTE/);
   assert.match(source, /continuationThroughput = continuationThroughput \/ survivalProbability;/);
@@ -1041,13 +1090,11 @@ test("wavefront compute uses physical continuation throughput with strict physic
     source,
     /accumulation\[ray\.rayId\] =\s+accumulation\[ray\.rayId\] \+\s+vec4<f32>\(weightedContribution, 1\.0\);/
   );
+  assert.match(source, /TRANSPORT_EXPERIMENT_STRICT_ZERO_OVERFLOW/);
+  assert.match(source, /var rawWeightedContribution = vec3<f32>\(0\.0\);/);
   assert.match(
     source,
-    /let overflowEnvironment = terminal_surface_environment_contribution\(\s+ray,\s+arrivingThroughput,\s+hit\s+\);/
-  );
-  assert.match(
-    source,
-    /record_deferred_terminal_source\(\s*ray,\s*terminal_surface_environment_source\(ray, hit\),\s*TERMINAL_SOURCE_KIND_AMBIENT_QUEUE_OVERFLOW\s*\);/
+    /record_deferred_terminal_source\(\s*ray,\s*vec3<f32>\(0\.0\),\s*TERMINAL_SOURCE_KIND_AMBIENT_QUEUE_OVERFLOW\s*\);/
   );
 });
 
@@ -1057,14 +1104,20 @@ test("wavefront compute samples all-material direct light with MIS before random
   assert.match(source, /fn direct_environment_radiance/);
   assert.match(source, /fn procedural_sky_radiance/);
   assert.match(source, /fn uniform_hemisphere_pdf\(\) -> f32/);
+  assert.match(source, /fn cosine_hemisphere_pdf\(normal: vec3<f32>, direction: vec3<f32>\) -> f32/);
   assert.match(source, /fn sample_uniform_hemisphere_direction\(sample: vec2<f32>, normal: vec3<f32>\) -> vec3<f32>/);
   assert.match(source, /fn sample_environment_importance/);
   assert.match(source, /struct DirectLightSample/);
   assert.match(source, /fn sample_emissive_triangle_light/);
+  assert.match(source, /fn sample_environment_direct_light/);
+  assert.match(source, /fn sample_emissive_direct_light/);
   assert.match(source, /fn sample_direct_light/);
+  assert.match(source, /fn direct_light_sample_contribution/);
   assert.match(source, /fn surface_procedural_sun_contribution/);
   assert.match(source, /strict_physical_low_spp_lighting_enabled\(\) && !environment_importance_sampling_enabled\(\)/);
   assert.match(source, /radiance = procedural_sky_radiance\(lightDirection\);/);
+  assert.match(source, /TRANSPORT_EXPERIMENT_PRODUCT_STUDIO_IMPORTANCE/);
+  assert.match(source, /pdf = cosine_hemisphere_pdf\(normal, lightDirection\);/);
   assert.match(source, /pdf = uniform_hemisphere_pdf\(\);/);
   assert.match(source, /fn surface_supports_direct_lighting/);
   assert.match(source, /u32\(config\.environmentMapMeta\.x\)/);
@@ -1076,7 +1129,10 @@ test("wavefront compute samples all-material direct light with MIS before random
   assert.match(source, /fn visibility_test_ray/);
   assert.match(source, /fn scene_visibility_blocked/);
   assert.match(source, /fn surface_direct_light_contribution/);
-  assert.match(source, /let lightSample = sample_direct_light\(hit, ray, normal\);/);
+  assert.match(source, /TRANSPORT_EXPERIMENT_DETERMINISTIC_DIRECT_LIGHTING/);
+  assert.match(source, /let environmentLight = sample_environment_direct_light\(hit, ray, normal, 0\.5, 1\.0\);/);
+  assert.match(source, /let emissiveLight = sample_emissive_direct_light\(hit, ray, 0\.0\);/);
+  assert.match(source, /return direct_light_sample_contribution\(ray, hit, sample_direct_light\(hit, ray, normal\)\);/);
   assert.match(source, /if \(scene_visibility_blocked\(origin, lightDirection, lightSample\.maxDistance\)\) \{/);
   assert.match(source, /let incidentRadiance = lightSample\.radiance\.xyz;/);
   assert.match(source, /let bsdf = evaluate_surface_bsdf\(hit, viewDirection, lightDirection\);/);


### PR DESCRIPTION
Adds composable Product Studio strict transport experiment flags for stable sample routing, strict zero overflow, deferred low-SPP Russian roulette, deterministic direct lighting, environment importance, and transport telemetry.\n\nValidation run locally:\n- npm test -- tests/wavefront-compute.test.js\n- npm run typecheck