### PR TITLE
Fix professional Animation Adventure root motion looping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@ All notable changes to this project will be documented in this file.
   - (placeholder)
 
 - **Fixed**
-  - (placeholder)
+  - Fixed professional Animation Adventure travel so repeated locomotion clips
+    advance by accumulated root-motion distance instead of a single unlooped
+    root translation.
 
 - **Security**
   - (placeholder)

--- a/README.md
+++ b/README.md
@@ -153,7 +153,9 @@ and root-authored movement profiles for travel beats. It rejects the legacy
 2D proxy path instead of silently falling back, renders through WebGPU, and
 exposes `renderMode: "webgpu-pbr"`, texture counts, normal-map readiness,
 root-motion policy, character position, camera position, and active clip
-diagnostics for host validation. The current surface establishes the WebGPU
+diagnostics for host validation. Repeated travel beats accumulate root-motion
+distance from the clip duration and loop count, capped by the declared movement
+requirement and route segment. The current surface establishes the WebGPU
 lifecycle and validation boundary for the PBR animation path; shader-level
 textured character and environment drawing builds on this boundary.
 

--- a/src/professional-animated-scene-renderer.js
+++ b/src/professional-animated-scene-renderer.js
@@ -121,6 +121,57 @@ function buildRouteSegments(route) {
   });
 }
 
+function positiveNumber(value) {
+  const numberValue = Number(value);
+  return Number.isFinite(numberValue) && numberValue > 0 ? numberValue : 0;
+}
+
+function movementRequirementDistance(requirement) {
+  return positiveNumber(
+    requirement?.distance
+      ?? requirement?.distanceMeters
+      ?? requirement?.rootTranslationDistance
+      ?? 0,
+  );
+}
+
+function resolveRootMotionTravelDistance({ beat, kind, profile, segment, durationMs, elapsedMs }) {
+  const rootDistance = positiveNumber(profile?.rootTranslationDistance);
+  if (rootDistance <= 0) {
+    return { travelled: 0, movementDistance: 0 };
+  }
+
+  const requestedDistance = movementRequirementDistance(beat.movementRequirement);
+  const segmentDistance = positiveNumber(segment?.distance);
+  const capDistance = positiveNumber(requestedDistance || segmentDistance) || rootDistance;
+  const maxDistance = segmentDistance > 0
+    ? Math.min(capDistance, segmentDistance)
+    : capDistance;
+
+  if (kind === "jump") {
+    const progress = clamp01(elapsedMs / Math.max(1, durationMs));
+    const movementDistance = Math.min(rootDistance, maxDistance);
+    return {
+      travelled: movementDistance * progress,
+      movementDistance,
+    };
+  }
+
+  const profileDurationMs = positiveNumber(profile?.durationMs);
+  const loopedDistance = profileDurationMs > 0 && profile?.loopable !== false
+    ? rootDistance * (elapsedMs / profileDurationMs)
+    : rootDistance * clamp01(elapsedMs / Math.max(1, durationMs));
+  const fullDistance = profileDurationMs > 0 && profile?.loopable !== false
+    ? rootDistance * (durationMs / profileDurationMs)
+    : rootDistance;
+  const movementDistance = Math.min(fullDistance, maxDistance);
+
+  return {
+    travelled: Math.min(loopedDistance, movementDistance),
+    movementDistance,
+  };
+}
+
 function resolveRootMotionPosition({ route, beats, clipAssets, loopTimeMs }) {
   const profiles = clipProfileById(clipAssets);
   const segments = buildRouteSegments(route);
@@ -133,13 +184,19 @@ function resolveRootMotionPosition({ route, beats, clipAssets, loopTimeMs }) {
     const profile = profiles.get(beat.clipId);
     const kind = movementRequirementKind(beat.movementRequirement, beat);
     const moves = kind === "travel" || kind === "jump" || kind === "root-authored";
-    const distance = moves ? Number(profile?.rootTranslationDistance ?? 0) : 0;
     const active = loopTimeMs >= cursorMs && loopTimeMs < cursorMs + durationMs;
-    const progress = active ? clamp01((loopTimeMs - cursorMs) / durationMs) : 1;
-    if (moves && distance > 0) {
+    const elapsedMs = active ? Math.max(0, loopTimeMs - cursorMs) : durationMs;
+    if (moves) {
       const segment = segments[Math.min(segmentIndex, Math.max(0, segments.length - 1))];
       if (segment) {
-        const travelled = Math.min(distance * progress, segment.distance);
+        const { travelled, movementDistance } = resolveRootMotionTravelDistance({
+          beat,
+          kind,
+          profile,
+          segment,
+          durationMs,
+          elapsedMs,
+        });
         const nextPosition = add3(position, scale3(segment.direction, travelled));
         if (active) {
           return {
@@ -148,10 +205,10 @@ function resolveRootMotionPosition({ route, beats, clipAssets, loopTimeMs }) {
             activeBeat: beat,
             activeProfile: profile,
             activeMovementMode: kind,
-            movementDistance: distance,
+            movementDistance,
           };
         }
-        position = add3(position, scale3(segment.direction, Math.min(distance, segment.distance)));
+        position = nextPosition;
         if (length3(sub3(position, segment.end)) < 0.05) {
           segmentIndex += 1;
           position = [...segment.end];

--- a/tests/package.test.js
+++ b/tests/package.test.js
@@ -1019,6 +1019,55 @@ test("createProfessionalAnimatedSceneRenderer uses WebGPU diagnostics and reject
   renderer.destroy();
 });
 
+test("createProfessionalAnimatedSceneRenderer advances travel by repeated root-motion loops", async () => {
+  const device = new FakeDevice();
+  const renderer = await createProfessionalAnimatedSceneRenderer({
+    canvas: createFakeCanvas(),
+    navigator: { gpu: new FakeGpu(new FakeAdapter(device)) },
+    route: [
+      { id: "gate", position: [0, 0, 0], arriveMs: 0 },
+      { id: "crop-row", position: [3, 0, 0], arriveMs: 3000 },
+    ],
+    beats: [
+      {
+        id: "walk-to-crops",
+        order: 0,
+        kind: "locomotion",
+        clipId: "female-basic-locomotion-walking",
+        durationMs: 3000,
+        movementRequirement: { kind: "travel", distanceMeters: 3 },
+      },
+    ],
+    modelAsset: createTexturedSkinnedTriangleGlb(),
+    clipAssets: [
+      {
+        id: "female-basic-locomotion-walking",
+        asset: createTranslationClipGlb(),
+        movementProfile: {
+          motionMode: "root-authored",
+          durationMs: 1000,
+          rootTranslationDistance: 1,
+          expectedSpeed: 1,
+          loopable: true,
+          worldDisplacementAllowed: true,
+          footSlideTolerance: 0.02,
+        },
+      },
+    ],
+  });
+
+  const start = renderer.renderOnce(0);
+  const halfway = renderer.renderOnce(1500);
+  const end = renderer.renderOnce(2999);
+
+  assert.equal(start.characterPosition[0], 0);
+  assert.equal(Number(halfway.characterPosition[0].toFixed(2)), 1.5);
+  assert.equal(Number(end.characterPosition[0].toFixed(2)), 3);
+  assert.equal(end.movementValidation.movementDistance, 3);
+
+  renderer.destroy();
+});
+
 test("createProfessionalAnimatedSceneRenderer fails closed for untextured or calibrated movement assets", async () => {
   const device = new FakeDevice();
   await assert.rejects(


### PR DESCRIPTION
## Summary\n- Accumulate professional Animation Adventure travel distance from repeated root-motion clip loops\n- Cap travel by the declared movement requirement and route segment\n- Add regression coverage for multi-loop root-motion travel\n- Document the renderer behavior in README and CHANGELOG\n\n## Validation\n- npm_config_cache=/tmp/plasius-npm-cache npx -y node@24 /usr/local/lib/node_modules/npm/bin/npm-cli.js test -- --runInBand\n\nCloses #133