### PR TITLE
Fix terminal emissive MIS for source-stable rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,13 @@ All notable changes to this project will be documented in this file.
   - (placeholder)
 
 - **Changed**
-  - (placeholder)
+  - Changed emissive light metadata upload to resolve stable triangle ids back
+    to the BVH-ordered triangle buffer before writing GPU light records.
 
 - **Fixed**
-  - (placeholder)
+  - Fixed multi-bounce source-stable renders so terminal emissive continuation
+    hits are MIS-weighted against direct emissive sampling instead of adding
+    full softbox radiance as sparse stippled pixels.
 
 - **Security**
   - (placeholder)
@@ -71,9 +74,13 @@ All notable changes to this project will be documented in this file.
   - Changed source-stable direct lighting to reuse deterministic direct-light
     evaluation while removing direct-light sample dependence on adjacent pixel
     ids and frame-index shimmer.
+  - Changed emissive light metadata upload to resolve stable triangle ids back
+    to the BVH-ordered triangle buffer before writing GPU light records.
 
 - **Fixed**
-  - (placeholder)
+  - Fixed multi-bounce source-stable renders so terminal emissive continuation
+    hits are MIS-weighted against direct emissive sampling instead of adding
+    full softbox radiance as sparse stippled pixels.
 
 - **Security**
   - (placeholder)

--- a/README.md
+++ b/README.md
@@ -194,7 +194,10 @@ so Product Studio diagnostics can record the exact active set for each render.
 denoise-off Product Studio validation: in strict physical mode it enables the
 deterministic direct-light path and removes direct-light sample dependence on
 adjacent pixel ids and frame index so low-SPP source routing is stable without
-adding ambient fill.
+adding ambient fill. Multi-bounce continuation rays that terminate on emissive
+geometry are MIS-weighted against that direct emissive estimator, so rare
+softbox hits remain physically valid without adding full unbalanced source
+radiance as isolated stippled pixels.
 Set `presentationOutput: "linear"` for linear presented validation captures, or
 omit it to keep the default tone-mapped presentation.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@plasius/gpu-renderer",
-  "version": "0.2.33",
+  "version": "0.2.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@plasius/gpu-renderer",
-      "version": "0.2.33",
+      "version": "0.2.34",
       "funding": [
         {
           "type": "patreon",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plasius/gpu-renderer",
-  "version": "0.2.33",
+  "version": "0.2.34",
   "description": "Framework-agnostic WebGPU renderer runtime for Plasius projects.",
   "type": "module",
   "sideEffects": false,

--- a/src/wavefront-compute.js
+++ b/src/wavefront-compute.js
@@ -167,6 +167,15 @@ function emissiveTriangleWeight(triangle) {
   return triangleAreaForLightSampling(triangle) * Math.max(emissionPower(triangle.emission), 0.000001);
 }
 
+function resolveOrderedEmissiveTriangleIndices(config) {
+  const triangleIndexById = new Map(
+    config.meshAcceleration.triangles.map((triangle, index) => [triangle.triangleId, index])
+  );
+  return config.emissiveTriangleIndices.indices
+    .map((triangleId) => triangleIndexById.get(triangleId))
+    .filter((triangleIndex) => Number.isInteger(triangleIndex));
+}
+
 export async function createWavefrontPathTracingComputeRenderer(options = {}) {
   assertAnalyticDisplayQualityPolicy(options);
   const constants = getGpuUsageConstants();
@@ -339,12 +348,13 @@ export async function createWavefrontPathTracingComputeRenderer(options = {}) {
   );
   const packedBvhNodeUints = new Uint32Array(packedBvhNodes.buffer);
   const packedBvhNodeFloats = new Float32Array(packedBvhNodes.buffer);
-  const emissiveWeights = config.emissiveTriangleIndices.indices.map((triangleIndex) =>
+  const orderedEmissiveTriangleIndices = resolveOrderedEmissiveTriangleIndices(config);
+  const emissiveWeights = orderedEmissiveTriangleIndices.map((triangleIndex) =>
     emissiveTriangleWeight(config.meshAcceleration.triangles[triangleIndex])
   );
   const totalEmissiveWeight = emissiveWeights.reduce((total, weight) => total + weight, 0);
   let cumulativeEmissiveWeight = 0;
-  config.emissiveTriangleIndices.indices.forEach((triangleIndex, index) => {
+  orderedEmissiveTriangleIndices.forEach((triangleIndex, index) => {
     const nodeOffset = (config.bvhNodeCapacity + index) * (BVH_NODE_RECORD_BYTES / 4);
     cumulativeEmissiveWeight += emissiveWeights[index] ?? 0;
     packedBvhNodeFloats[nodeOffset] = cumulativeEmissiveWeight;

--- a/src/wavefront-shader-kernels.js
+++ b/src/wavefront-shader-kernels.js
@@ -592,7 +592,14 @@ fn resolveSurfaceRecords(@builtin(global_invocation_id) globalId: vec3<u32>) {
 
   if (hit.hitType == 1u) {
     let guidedLightWeight = select(1.0, 0.24, (ray.flags & RAY_FLAG_GUIDED_EMISSIVE) != 0u);
-    let sourceRadiance = max(hit.emission.xyz, hit.color.xyz) * guidedLightWeight;
+    var sourceRadiance = max(hit.emission.xyz, hit.color.xyz) * guidedLightWeight;
+    if ((ray.flags & RAY_FLAG_DELTA_SAMPLE) == 0u) {
+      let bsdfPdf = max(ray.throughput.w, 0.000001);
+      let lightPdf = terminal_emissive_light_pdf(ray, hit);
+      if (lightPdf > 0.000001) {
+        sourceRadiance = sourceRadiance * power_heuristic(bsdfPdf, lightPdf);
+      }
+    }
     if (deferred_path_resolve_enabled()) {
       record_deferred_terminal_source(
         ray,

--- a/src/wavefront-shader-lighting.js
+++ b/src/wavefront-shader-lighting.js
@@ -802,6 +802,68 @@ fn sample_emissive_triangle_light(
   return DirectLightSample(vec4<f32>(lightDirection, 0.0), vec4<f32>(radiance, 0.0), lightPdf, traceDistance, 0u, 1u);
 }
 
+fn emissive_direct_class_probability() -> f32 {
+  if (config.emissiveTriangleCount == 0u) {
+    return 0.0;
+  }
+  if (
+    transport_experiment_enabled(TRANSPORT_EXPERIMENT_DETERMINISTIC_DIRECT_LIGHTING) ||
+    transport_experiment_enabled(TRANSPORT_EXPERIMENT_SOURCE_STABLE_DIRECT_LIGHTING)
+  ) {
+    return 1.0;
+  }
+  return select(1.0, 0.5, config.emissiveTriangleCount > 0u);
+}
+
+fn terminal_emissive_light_pdf(ray: RayRecord, hit: HitRecord) -> f32 {
+  if (config.emissiveTriangleCount == 0u) {
+    return 0.0;
+  }
+
+  var lightSlot = 0xffffffffu;
+  var triangleIndex = 0xffffffffu;
+  for (var candidateSlot = 0u; candidateSlot < config.emissiveTriangleCount; candidateSlot = candidateSlot + 1u) {
+    let candidateMetadata = bvhNodes[config.bvhNodeCapacity + candidateSlot];
+    let candidateTriangleIndex = candidateMetadata.childOrFirst;
+    if (candidateTriangleIndex >= config.triangleCount) {
+      continue;
+    }
+    let candidateTriangle = triangles[candidateTriangleIndex];
+    if (candidateTriangle.triangleId == hit.primitiveId) {
+      lightSlot = candidateSlot;
+      triangleIndex = candidateTriangleIndex;
+      break;
+    }
+  }
+
+  if (lightSlot == 0xffffffffu || triangleIndex == 0xffffffffu) {
+    return 0.0;
+  }
+
+  let lightMetadata = bvhNodes[config.bvhNodeCapacity + lightSlot];
+  let lightTriangle = triangles[triangleIndex];
+  let triangleArea = triangle_surface_area(lightTriangle);
+  let lightNormal = triangle_surface_normal(lightTriangle);
+  var selectionProbability =
+    emissive_direct_class_probability() /
+    max(f32(config.emissiveTriangleCount), 1.0);
+  if (strict_physical_low_spp_lighting_enabled()) {
+    let totalWeight = max(lightMetadata.boundsMin.z, 0.0);
+    let triangleWeight = max(lightMetadata.boundsMin.y, 0.0);
+    if (totalWeight > 0.000001 && triangleWeight > 0.000001) {
+      selectionProbability = emissive_direct_class_probability() * triangleWeight / totalWeight;
+    }
+  }
+
+  let areaPdf = selectionProbability / max(triangleArea, 0.000001);
+  return solid_angle_pdf_from_area_pdf(
+    areaPdf,
+    ray.origin.xyz,
+    hit.position.xyz,
+    lightNormal
+  );
+}
+
 fn direct_light_sample_frame_index() -> u32 {
   return select(
     config.frameIndex,
@@ -897,7 +959,8 @@ fn sample_emissive_direct_light(
 }
 
 fn sample_direct_light(hit: HitRecord, ray: RayRecord, normal: vec3<f32>) -> DirectLightSample {
-  let environmentSelectionProbability = select(1.0, 0.5, config.emissiveTriangleCount > 0u);
+  let environmentSelectionProbability =
+    1.0 - emissive_direct_class_probability();
   let selector = sample_dimension_1d(
     direct_light_sample_pixel_id(ray),
     ray.sampleId,

--- a/tests/wavefront-compute.test.js
+++ b/tests/wavefront-compute.test.js
@@ -1211,7 +1211,10 @@ test("wavefront compute converts emissive area PDFs to solid-angle MIS measures"
 
   assert.match(source, /function emissiveTriangleWeight\(triangle\)/);
   assert.match(source, /triangleAreaForLightSampling\(triangle\) \* Math\.max\(emissionPower\(triangle\.emission\), 0\.000001\)/);
-  assert.match(source, /const emissiveWeights = config\.emissiveTriangleIndices\.indices\.map/);
+  assert.match(source, /function resolveOrderedEmissiveTriangleIndices\(config\)/);
+  assert.match(source, /const triangleIndexById = new Map/);
+  assert.match(source, /const orderedEmissiveTriangleIndices = resolveOrderedEmissiveTriangleIndices\(config\);/);
+  assert.match(source, /const emissiveWeights = orderedEmissiveTriangleIndices\.map/);
   assert.match(source, /packedBvhNodeFloats\[nodeOffset\] = cumulativeEmissiveWeight;/);
   assert.match(source, /packedBvhNodeFloats\[nodeOffset \+ 1\] = emissiveWeights\[index\] \?\? 0;/);
   assert.match(source, /packedBvhNodeFloats\[nodeOffset \+ 2\] = totalEmissiveWeight;/);
@@ -1227,8 +1230,23 @@ test("wavefront compute converts emissive area PDFs to solid-angle MIS measures"
     source,
     /let lightPdf = solid_angle_pdf_from_area_pdf\(areaPdf, hit\.position\.xyz, lightPoint, lightNormal\);/
   );
-  assert.match(source, /let environmentSelectionProbability = select\(1\.0, 0\.5, config\.emissiveTriangleCount > 0u\);/);
+  assert.match(source, /fn emissive_direct_class_probability\(\) -> f32/);
+  assert.match(source, /return select\(1\.0, 0\.5, config\.emissiveTriangleCount > 0u\);/);
+  assert.match(source, /let environmentSelectionProbability =\s+1\.0 - emissive_direct_class_probability\(\);/);
   assert.match(source, /return DirectLightSample\(vec4<f32>\(lightDirection, 0\.0\), vec4<f32>\(radiance, 0\.0\), lightPdf, traceDistance, 0u, 1u\);/);
+});
+
+test("wavefront compute MIS-weights terminal emissive continuation hits", () => {
+  const source = readRendererSource();
+
+  assert.match(source, /fn terminal_emissive_light_pdf\(ray: RayRecord, hit: HitRecord\) -> f32/);
+  assert.match(source, /candidateTriangle\.triangleId == hit\.primitiveId/);
+  assert.match(source, /selectionProbability = emissive_direct_class_probability\(\) \* triangleWeight \/ totalWeight;/);
+  assert.match(source, /ray\.origin\.xyz,\s+hit\.position\.xyz,\s+lightNormal/);
+  assert.match(
+    source,
+    /let lightPdf = terminal_emissive_light_pdf\(ray, hit\);\s+if \(lightPdf > 0\.000001\) \{\s+sourceRadiance = sourceRadiance \* power_heuristic\(bsdfPdf, lightPdf\);/s
+  );
 });
 
 test("wavefront BSDF numeric helpers flag PDF mismatches and invalid MIS measures", () => {


### PR DESCRIPTION
## Summary
- MIS-weight terminal emissive continuation hits against direct emissive sampling to reduce multi-bounce softbox stipple without denoise or fake fill.
- Resolve stable emissive triangle ids back to the BVH-ordered triangle buffer before writing GPU light metadata.
- Bump @plasius/gpu-renderer to 0.2.34 and document the source-stable multi-bounce fix.

## Validation
- npm test -- --test-name-pattern="emissive area|terminal emissive|transport experiment|source-stable|direct light|deferred visible"
- npm run typecheck
- npm run build
- npm run pack:check